### PR TITLE
Allow full and partial URLs to be used as inline tab links

### DIFF
--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-fragment.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-fragment.html
@@ -1,0 +1,7 @@
+<div class="nav-inline">
+    <ul class="nav-inline__list">
+        <li class="nav-inline__item">
+            <a href="#baz" data-toggle="tab" class="nav-inline__link">bar</a>
+        </li>
+    </ul>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-fragment.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-fragment.html.twig
@@ -1,0 +1,12 @@
+{% import '@pulsar/pulsar/v2/helpers/tabs.html.twig' as tabs %}
+{%
+    set nav = [
+        {
+          "id"    : "foo",
+          "label" : "bar",
+          "src"   : '#baz'
+        }
+    ]
+%}
+{{ tabs.list(nav) }}
+{{ tabs.content(nav) }}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-full-url.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-full-url.html
@@ -1,0 +1,7 @@
+<div class="nav-inline">
+    <ul class="nav-inline__list">
+        <li class="nav-inline__item">
+            <a href="http://www.foo.com" data-toggle="tab" class="nav-inline__link">bar</a>
+        </li>
+    </ul>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-full-url.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-full-url.html.twig
@@ -1,0 +1,12 @@
+{% import '@pulsar/pulsar/v2/helpers/tabs.html.twig' as tabs %}
+{%
+    set nav = [
+        {
+          "id"    : "foo",
+          "label" : "bar",
+          "src"   : 'http://www.foo.com'
+        }
+    ]
+%}
+{{ tabs.list(nav) }}
+{{ tabs.content(nav) }}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-relative-url.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-relative-url.html
@@ -1,0 +1,7 @@
+<div class="nav-inline">
+    <ul class="nav-inline__list">
+        <li class="nav-inline__item">
+            <a href="/baz" data-toggle="tab" class="nav-inline__link">bar</a>
+        </li>
+    </ul>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-relative-url.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-relative-url.html.twig
@@ -1,0 +1,12 @@
+{% import '@pulsar/pulsar/v2/helpers/tabs.html.twig' as tabs %}
+{%
+    set nav = [
+        {
+          "id"    : "foo",
+          "label" : "bar",
+          "src"   : "/baz"
+        }
+    ]
+%}
+{{ tabs.list(nav) }}
+{{ tabs.content(nav) }}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-string.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-string.html
@@ -1,0 +1,10 @@
+<div class="nav-inline">
+    <ul class="nav-inline__list">
+        <li class="nav-inline__item">
+            <a href="#foo" data-toggle="tab" class="nav-inline__link">bar</a>
+        </li>
+    </ul>
+</div>
+<div class="tab__pane" id="foo">
+    baz
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-string.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-string.html.twig
@@ -1,0 +1,12 @@
+{% import '@pulsar/pulsar/v2/helpers/tabs.html.twig' as tabs %}
+{%
+    set nav = [
+        {
+          "id"    : "foo",
+          "label" : "bar",
+          "src"   : 'baz'
+        }
+    ]
+%}
+{{ tabs.list(nav) }}
+{{ tabs.content(nav) }}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-template.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-template.html
@@ -1,0 +1,14 @@
+<div class="nav-inline">
+    <ul class="nav-inline__list">
+        <li class="nav-inline__item">
+            <a href="#foo" data-toggle="tab" class="nav-inline__link">bar</a>
+        </li>
+    </ul>
+</div>
+<div class="tab__pane" id="foo">
+    <div class="tab__container">
+        <div class="tab__inner">
+            <div class="tab__content"></div>
+        </div>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-template.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-template.html.twig
@@ -1,0 +1,13 @@
+{% import '@pulsar/pulsar/v2/helpers/tabs.html.twig' as tabs %}
+{% set template %}{% include '@tests/tabs/template.twig' %}{% endset %}
+{%
+    set nav = [
+        {
+          "id"    : "foo",
+          "label" : "bar",
+          "src"   : template
+        }
+    ]
+%}
+{{ tabs.list(nav) }}
+{{ tabs.content(nav) }}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/template.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/template.twig
@@ -1,0 +1,2 @@
+{% extends '@pulsar/pulsar/components/tab.html.twig' %}
+{% block foo %}test template{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/MacroTest.php
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/MacroTest.php
@@ -26,6 +26,7 @@ class MacroTest extends \PHPUnit_Framework_TestCase
 
         $loader = new Twig_Loader_Filesystem($this->getFixturesPath());
         $loader->addPath($baseDir . 'views', 'pulsar');
+        $loader->addPath($baseDir . 'tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures', 'tests');
 
         $this->twig = new Twig_Environment($loader, array(
             'cache' => false,

--- a/views/pulsar/v2/helpers/tabs.html.twig
+++ b/views/pulsar/v2/helpers/tabs.html.twig
@@ -7,7 +7,15 @@
             <li class="nav-inline__item{% if tab.active is defined and tab.active == tab.id %} nav-inline__item--is-active is-active{% endif %}{% if tab.hidden is defined and tab.hidden == true %} hide{% endif %}">
                 {% set href = '#' ~ tab.id %}
                 {% set toggle = 'tab' %}
-                {% if tab.src is defined and tab.src != null and tab.src|json_encode|slice(1, 1) == '#' %}
+                {%
+                    if tab.src is defined
+                    and tab.src != null
+                    and (
+                           tab.src|slice(0, 1) == '/'
+                        or tab.src|json_encode|slice(1, 1) == '#'
+                        or tab.src|json_encode|slice(1, 4) == 'http'
+                    )
+                %}
                     {% set href = tab.src %}
                 {% elseif tab.href is defined and tab.href != null %}
                     {% set href = tab.href %}
@@ -38,7 +46,13 @@
     {%- endfor -%}
 
     {%- for tab in tabs -%}
-        {%- if tab.src is defined and tab.src != null and tab.src|json_encode|slice(1, 1) != '#' -%}
+        {%-
+            if tab.src is defined
+            and tab.src != null
+            and tab.src|slice(0, 1) != '/'
+            and tab.src|json_encode|slice(1, 1) != '#'
+            and tab.src|json_encode|slice(1, 4) != 'http'
+        -%}
             <div class="tab__pane{% if (tab.active is defined and tab.active == tab.id) or (active_tab == '#' ~ tab.id) %} is-active{% endif %}" id="{{ tab.id }}"{% if tab.attr is defined and tab.attr != null %} {{ tab.attr|raw }}{% endif %}>
                 {{ tab.src|raw }}
             </div>


### PR DESCRIPTION
Resolves #13 

Matches against the following criteria:

If `src` starts with `#`, `/` or `http` then it will be treated as a link, no content pane will be created by the `tabs.content()` helper.

Otherwise, `src` templates will be a parsed as usual.