### PR TITLE
Tabs using links as the `src` should no longer throw a javascript error

### DIFF
--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-fragment.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-fragment.html
@@ -1,7 +1,7 @@
 <div class="nav-inline">
     <ul class="nav-inline__list">
         <li class="nav-inline__item">
-            <a href="#baz" data-toggle="tab" class="nav-inline__link">bar</a>
+            <a href="#baz" data-toggle="link" class="nav-inline__link">bar</a>
         </li>
     </ul>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-full-url.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-full-url.html
@@ -1,7 +1,7 @@
 <div class="nav-inline">
     <ul class="nav-inline__list">
         <li class="nav-inline__item">
-            <a href="http://www.foo.com" data-toggle="tab" class="nav-inline__link">bar</a>
+            <a href="http://www.foo.com" data-toggle="link" class="nav-inline__link">bar</a>
         </li>
     </ul>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-relative-url.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-relative-url.html
@@ -1,7 +1,7 @@
 <div class="nav-inline">
     <ul class="nav-inline__list">
         <li class="nav-inline__item">
-            <a href="/baz" data-toggle="tab" class="nav-inline__link">bar</a>
+            <a href="/baz" data-toggle="link" class="nav-inline__link">bar</a>
         </li>
     </ul>
 </div>

--- a/views/pulsar/v2/helpers/tabs.html.twig
+++ b/views/pulsar/v2/helpers/tabs.html.twig
@@ -6,7 +6,7 @@
     {%- for tab in tabs -%}
             <li class="nav-inline__item{% if tab.active is defined and tab.active == tab.id %} nav-inline__item--is-active is-active{% endif %}{% if tab.hidden is defined and tab.hidden == true %} hide{% endif %}">
                 {% set href = '#' ~ tab.id %}
-                {% set toggle = 'tab' %}
+                {% set type = 'tab' %}
                 {%
                     if tab.src is defined
                     and tab.src != null
@@ -16,10 +16,10 @@
                         or tab.src|json_encode|slice(1, 4) == 'http'
                     )
                 %}
+                    {% set type = 'link' %}
                     {% set href = tab.src %}
                 {% elseif tab.href is defined and tab.href != null %}
                     {% set href = tab.href %}
-                    {% set toggle = 'link' %}
                 {% endif %}
 
                 {%
@@ -27,7 +27,7 @@
                         'class': 'nav-inline__link',
                         'label': tab.label,
                         'href': href,
-                        'data-toggle': toggle
+                        'data-toggle': type
                     }
                 %}
                 {{ html.link(options|merge(tab.data|default({}))) }}


### PR DESCRIPTION
Modified tabs helper to no longer pass `data-toggle="tab"` when using full or partial URLs