### PR TITLE
Fix vertical alignment of text for single-line form controls in IE8.

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -22,6 +22,7 @@ fieldset {
 .form__control {
     border-radius: $input-border-radius;
     height: $input-height-base;
+    line-height: $input-height-base;
 
     &.checkbox,
     &.radio {
@@ -46,6 +47,7 @@ fieldset {
 
     &.textarea {
         height: auto;
+        line-height: $line-height-base;
         min-height: 68px;
         padding-top: 11px;
         padding-bottom: 11px;


### PR DESCRIPTION
Resolves #33 