### PR TITLE
Disabled links in pagination should now be visually distinct

### DIFF
--- a/stylesheets/_component.pagination.scss
+++ b/stylesheets/_component.pagination.scss
@@ -18,7 +18,7 @@
   }
 
   a, span {
-    color: color(gray, dark);
+    color: color(text);
     font-family: $font-family-regular;
     @include inline-block;
     line-height: $line-height-base * 1.75;
@@ -31,20 +31,20 @@
     & > a,
     & > span {
       background-color: darken(color(white), 10%);
-      color: color(black);
+      color: color(text);
     }
   }
 
   li.is-disabled {
     a, span {
-      color: color(gray);
+      color: color(text, disabled);
       cursor: not-allowed;
     }
   }
 
   li:not(.is-disabled) > a:hover {
     background-color: darken(color(white), 5%);
-    color: color(black);
+    color: color(text);
   }
 
   form {

--- a/stylesheets/_palette.base.scss
+++ b/stylesheets/_palette.base.scss
@@ -67,7 +67,8 @@ $palette-monochromes: (
 $palette-alias: (
     text: (
         base:  map-get(map-get($palette-monochromes, gray), darker),
-        light: map-get(map-get($palette-monochromes, gray), lighter)
+        light: map-get(map-get($palette-monochromes, gray), lighter),
+        disabled: map-get(map-get($palette-monochromes, gray), lighter)
     ),
     link: (
         base:  map-get(map-get($palette-branding, jadu-blue), dark),

--- a/views/lexicon/index.html.twig
+++ b/views/lexicon/index.html.twig
@@ -37,6 +37,7 @@
 {% set tab_loading %}{% include   'lexicon/tabs/loading.html.twig' %}{% endset %}
 {% set tab_message %}{% include   'lexicon/tabs/message.html.twig' %}{% endset %}
 {% set tab_modals %}{% include    'lexicon/tabs/modals.html.twig' %}{% endset %}
+{% set tab_pagination %}{% include 'lexicon/tabs/pagination.html.twig' %}{% endset %}
 {% set tab_panels %}{% include    'lexicon/tabs/panels.html.twig' %}{% endset %}
 {% set tab_progress_bars %}{% include 'lexicon/tabs/progress_bars.html.twig' %}{% endset %}
 {% set tab_tooltips %}{% include  'lexicon/tabs/tooltips.html.twig' %}{% endset %}
@@ -54,7 +55,7 @@
                 "1.1": {
                     "1.1.1": {
                         "label": "Components",
-                        "href": "/app/app.php/lexicon/main",
+                        "href": "/app/app.php/lexicon",
                         "class": "is-active"
                     },
                     "1.1.2": {
@@ -107,13 +108,18 @@
         },
         {
           "id"    : "messages",
-          "label" : html.icon("envelope") ~ " Messages",
+          "label" : "Messages",
           "src"   : tab_message
         },
         {
           "id"    : "metadata",
           "label" : "Metadata",
           "src"   : tab_metadata
+        },
+        {
+          "id"    : "pagination",
+          "label" : "Pagination",
+          "src"   : tab_pagination
         },
         {
           "id"    : "panels",

--- a/views/lexicon/index.html.twig
+++ b/views/lexicon/index.html.twig
@@ -29,20 +29,48 @@
     ]
 %}
 
-{% set tab_buttons %}{% include   'lexicon/tabs/buttons_labels.html.twig' %}{% endset %}
-{% set tab_colours %}{% include   'lexicon/tabs/colours.html.twig' %}{% endset %}
-{% set tab_decks %}{% include     'lexicon/tabs/decks.html.twig' %}{% endset %}
-{% set tab_flash %}{% include     'lexicon/tabs/flash.html.twig' %}{% endset %}
-{% set tab_forms %}{% include     'lexicon/tabs/forms.html.twig' %}{% endset %}
-{% set tab_loading %}{% include   'lexicon/tabs/loading.html.twig' %}{% endset %}
-{% set tab_message %}{% include   'lexicon/tabs/message.html.twig' %}{% endset %}
-{% set tab_modals %}{% include    'lexicon/tabs/modals.html.twig' %}{% endset %}
-{% set tab_pagination %}{% include 'lexicon/tabs/pagination.html.twig' %}{% endset %}
-{% set tab_panels %}{% include    'lexicon/tabs/panels.html.twig' %}{% endset %}
-{% set tab_progress_bars %}{% include 'lexicon/tabs/progress_bars.html.twig' %}{% endset %}
-{% set tab_tooltips %}{% include  'lexicon/tabs/tooltips.html.twig' %}{% endset %}
-{% set tab_data_grid %}{% include 'lexicon/tabs/datagrid.html.twig' %}{% endset %}
-{% set tab_metadata %}{% include  'lexicon/tabs/metadata.html.twig' %}{% endset %}
+{% set tab_buttons %}
+    {% include 'lexicon/tabs/buttons_labels.html.twig' %}
+{% endset %}
+{% set tab_colours %}
+    {% include 'lexicon/tabs/colours.html.twig' %}
+{% endset %}
+{% set tab_decks %}
+    {% include 'lexicon/tabs/decks.html.twig' %}
+{% endset %}
+{% set tab_flash %}
+    {% include 'lexicon/tabs/flash.html.twig' %}
+{% endset %}
+{% set tab_forms %}
+    {% include 'lexicon/tabs/forms.html.twig' %}
+{% endset %}
+{% set tab_loading %}
+    {% include 'lexicon/tabs/loading.html.twig' %}
+{% endset %}
+{% set tab_message %}
+    {% include 'lexicon/tabs/message.html.twig' %}
+{% endset %}
+{% set tab_modals %}
+    {% include 'lexicon/tabs/modals.html.twig' %}
+{% endset %}
+{% set tab_pagination %}
+    {% include 'lexicon/tabs/pagination.html.twig' %}
+{% endset %}
+{% set tab_panels %}
+    {% include 'lexicon/tabs/panels.html.twig' %}
+{% endset %}
+{% set tab_progress_bars %}
+    {% include 'lexicon/tabs/progress_bars.html.twig' %}
+{% endset %}
+{% set tab_tooltips %}
+    {% include 'lexicon/tabs/tooltips.html.twig' %}
+{% endset %}
+{% set tab_data_grid %}
+    {% include 'lexicon/tabs/datagrid.html.twig' %}
+{% endset %}
+{% set tab_metadata %}
+    {% include 'lexicon/tabs/metadata.html.twig' %}
+{% endset %}
 
 {%
     set nav_data = {

--- a/views/lexicon/modules.html.twig
+++ b/views/lexicon/modules.html.twig
@@ -43,7 +43,7 @@
                 "1.1": {
                     "1.1.1": {
                         "label": "Components",
-                        "href": "/app/app.php/lexicon/main"
+                        "href": "/app/app.php/lexicon"
                     },
                     "1.1.2": {
                         "label": "Modules",

--- a/views/lexicon/modules.html.twig
+++ b/views/lexicon/modules.html.twig
@@ -29,8 +29,12 @@
     ]
 %}
 
-{% set tab_modals %}{% include   'lexicon/tabs/modals.html.twig' %}{% endset %}
-{% set tab_popovers %}{% include 'lexicon/tabs/popovers.html.twig' %}{% endset %}
+{% set tab_modals %}
+    {% include 'lexicon/tabs/modals.html.twig' %}
+{% endset %}
+{% set tab_popovers %}
+    {% include 'lexicon/tabs/popovers.html.twig' %}
+{% endset %}
 
 {%
     set nav_data = {

--- a/views/lexicon/patterns.html.twig
+++ b/views/lexicon/patterns.html.twig
@@ -29,8 +29,12 @@
     ]
 %}
 
-{% set pattern_masterswitch %}{% include 'lexicon/patterns/masterswitch.html.twig' %}{% endset %}
-{% set pattern_piano %}{% include 'lexicon/patterns/piano.html.twig' %}{% endset %}
+{% set pattern_masterswitch %}
+    {% include 'lexicon/patterns/masterswitch.html.twig' %}
+{% endset %}
+{% set pattern_piano %}
+    {% include 'lexicon/patterns/piano.html.twig' %}
+{% endset %}
 
 {%
     set tabs_content = [

--- a/views/lexicon/patterns.html.twig
+++ b/views/lexicon/patterns.html.twig
@@ -59,7 +59,7 @@
                 "1.1": {
                     "1.1.1": {
                         "label": "Components",
-                        "href": "/app/app.php/lexicon/main"
+                        "href": "/app/app.php/lexicon"
                     },
                     "1.1.2": {
                         "label": "Modules",

--- a/views/lexicon/tabs/pagination.html.twig
+++ b/views/lexicon/tabs/pagination.html.twig
@@ -1,0 +1,15 @@
+{% extends "@pulsar/pulsar/components/tab.html.twig" %}
+
+{% block tab_content %}
+<div class="pagination">
+    <ul class="pull-left"><!--
+        --><li class="is-disabled"><a href="#"><i class="icon-double-angle-left"></i> Previous</a></li><!--
+        --><li><a href="#">1</a></li><!--
+        --><li class="selected"><a href="#">2</a></li><!--
+        --><li><a href="#">3</a></li><!--
+        --><li><a href="#">4</a></li><!--
+        --><li><a href="#">5</a></li><!--
+        --><li><a href="#">Next <i class="icon-double-angle-right"></i></a></li><!--
+    --></ul>
+</div>
+{% endblock tab_content %}


### PR DESCRIPTION
Fixes #45 by adding a new alias to the base colour palette, so disabled text can use `colour(text, disabled)` and be styled consistently.

Added a codepen example to the docs: https://jadu.gitbooks.io/pulsar/content/pagination.html

This PR also fixes an issue with the Lexicon's 'Components' links not working correctly.