### PR TITLE
Only use `inline-block` on button groups that aren't being used as form controls.

### DIFF
--- a/stylesheets/_component.button-groups.scss
+++ b/stylesheets/_component.button-groups.scss
@@ -8,7 +8,9 @@
 .btn__group,
 .btn__group-vertical {
   position: relative;
-  @include inline-block;
+  &:not(.controls) {
+    @include inline-block;
+  }
   vertical-align: middle; // match .btn alignment given font-size hack above
 
   > .btn:not(.btn--naked),


### PR DESCRIPTION
Resolves #54 