### PR TITLE
Add `word-wrap: break-word;` to prevent long form labels from overlapping their controls.

### DIFF
--- a/stylesheets/_structure.forms.scss
+++ b/stylesheets/_structure.forms.scss
@@ -19,6 +19,7 @@ $control-column-width: 75%;
     // the main label, usually placed in the left hand column
     > .control__label {
         width: $label-column-width;
+        word-wrap: break-word;
     }
 
     .help-block {


### PR DESCRIPTION
Resolves #57 