### PR TITLE
Remove default argument values from helpers

### DIFF
--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -45,7 +45,7 @@ Option        | Type   | Description
 items         | array  | An array of items to put in the dropdown list (usually radios)
 
 #}
-{% macro button_group(options = {}) %}
+{% macro button_group(options) %}
 {% spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
@@ -105,7 +105,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
 *Any other options not listed here will be applied to the input.
 
 #}
-{% macro checkbox(options = {}) %}
+{% macro checkbox(options) %}
 {% spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
@@ -179,7 +179,7 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
 *Any other options not listed here will be applied to the input.
 
 #}
-{% macro checkbox_inline(options = {}) %}
+{% macro checkbox_inline(options) %}
 {% spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
@@ -270,7 +270,7 @@ required | bool   | Visually indicates that the field must be completed, will no
 multiple | bool   | If `true`, uses checkboxes instead of radios, or passes the `multiple` attribute to the select2 element
 
 #}
-{% macro choice(options = {}) %}
+{% macro choice(options) %}
 {% spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
@@ -285,7 +285,7 @@ multiple | bool   | If `true`, uses checkboxes instead of radios, or passes the 
 
     {% if options.optimize == 'many' or (options.options|length > 5 and options.optimize == 'auto') %}
 
-        {% set select_options = {} %}
+        {% set select_options %}
         {% for select_option in options.options %}
             {%
                 set select_options = select_options|merge({
@@ -371,7 +371,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 *Any other options not listed here will be applied to the paragraph.
 
 #}
-{% macro content(options = {}) %}
+{% macro content(options) %}
 {% spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
@@ -442,7 +442,7 @@ to be created automatically after the `<form>` element, and the `method`
 attribute on the `form` element will be set to `POST`.
 
 #}
-{% macro create(options = {}) %}
+{% macro create(options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
@@ -521,7 +521,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 *Any other options not listed here will be applied to the input.
 
 #}
-{% macro date(options = {}) %}
+{% macro date(options) %}
 {% spaceless %}
     {% import _self as form %}
 
@@ -572,7 +572,7 @@ actions | array  | Helpers to display as the actions, usually `form.submit()` bu
 class   | string | A space separated list of class names
 
 #}
-{% macro end(options = {}) %}
+{% macro end(options) %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     {% if options.actions is defined %}
@@ -621,7 +621,7 @@ name   | string | The name of this control
 data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro fieldset_start(options = {}) %}
+{% macro fieldset_start(options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -701,7 +701,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 *Any other options not listed here will be applied to the input.
 *
 #}
-{% macro file(options = {}) %}
+{% macro file(options) %}
 {% spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
@@ -806,7 +806,7 @@ Option           | Type   | Description
 controls.class   | string | A space separated list of class names
 
 #}
-{% macro group(options = {}) %}
+{% macro group(options) %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
@@ -910,7 +910,7 @@ Option | Type   | Description
 value  | string | The string or html markup to render inside the help block
 
 #}
-{% macro help(options = {}) %}
+{% macro help(options) %}
 {% spaceless %}
 
     {% if options.value is defined and options.value is not empty %}
@@ -954,7 +954,7 @@ value       | string | Specifies the value of the input
 data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro hidden(options = {}) %}
+{% macro hidden(options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -1017,7 +1017,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 *Any other options not listed here will be applied to the input.
 
 #}
-{% macro password(options = {}) %}
+{% macro password(options) %}
 {% spaceless %}
     {% import _self as form %}
 
@@ -1068,7 +1068,7 @@ data-*   | string | Data attributes, eg: `'data-foo': 'bar'`
 *Any other options not listed here will be applied to the input.
 
 #}
-{% macro radio(options = {}) %}
+{% macro radio(options) %}
 {% spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
@@ -1139,7 +1139,7 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
 *Any other options not listed here will be applied to the input
 
 #}
-{% macro radio_inline(options = {}) %}
+{% macro radio_inline(options) %}
 {% spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
@@ -1233,7 +1233,7 @@ required | bool   | Visually indicates that the field must be completed
 *Any other options not listed here will be applied to the input
 
 #}
-{% macro radio_simple(options = {}) %}
+{% macro radio_simple(options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -1305,7 +1305,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 *Any other options not listed here will be applied to the input.
 
 #}
-{% macro select(options = {}) %}
+{% macro select(options) %}
 {% spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
@@ -1377,7 +1377,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 *Any other options not listed here will be applied to the input.
 
 #}
-{% macro select2(options = {}) %}
+{% macro select2(options) %}
 {% spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
@@ -1430,7 +1430,7 @@ data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
 *Any other options not listed here will be applied to the input.
 
 #}
-{% macro submit(options = {}) %}
+{% macro submit(options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 
@@ -1488,7 +1488,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 *Any other options not listed here will be applied to the input.
 
 #}
-{% macro text(options = {}) %}
+{% macro text(options) %}
 {% spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
@@ -1553,7 +1553,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 *Any other options not listed here will be applied to the input.
 
 #}
-{% macro textarea(options = {}) %}
+{% macro textarea(options) %}
 {% spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -46,7 +46,7 @@ label  | string | The link text label
 data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro actions_menu(items = {}) %}
+{% macro actions_menu(items) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 
@@ -112,7 +112,7 @@ label  | string | The value to display, usually an integer
 data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro badge(options = {}) %}
+{% macro badge(options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -159,7 +159,7 @@ type    | string | Can be `button` (default), `link`, `input`, `submit`
 data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro button(options = {}) %}
+{% macro button(options) %}
 {% spaceless %}
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
@@ -248,7 +248,7 @@ id      | string | A unique identifier, if required
 data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro button_group(options = {}) %}
+{% macro button_group(options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -303,7 +303,7 @@ placement | string | the alignment of the dropdown menu, `left` (default) or `ri
 data-*    | string | Data attributes, eg: `'data-foo': 'bar'` (applied to the button)
 
 #}
-{% macro button_dropdown(options = {}) %}
+{% macro button_dropdown(options) %}
 {% spaceless %}
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
@@ -381,7 +381,7 @@ Option | Type   | Description
 class  | string | CSS classes, space separated
 
 #}
-{% macro icon(icon_name, options = {}) %}
+{% macro icon(icon_name, options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -417,7 +417,7 @@ label  | string | The value to display
 data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro label(options = {}) %}
+{% macro label(options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -466,7 +466,7 @@ labels | array  | The labels to group
 data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro label_group(options = {}) %}
+{% macro label_group(options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -514,7 +514,7 @@ label  | string | The link text label
 data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro link(options = {}) %}
+{% macro link(options) %}
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -561,7 +561,7 @@ type        | string | `ul` (default), `ol`
 data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro list(options = {}) %}
+{% macro list(options) %}
 {% spaceless %}
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
@@ -624,7 +624,7 @@ type        | string | ul (default) | ol
 data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro link_list(options = {}) %}
+{% macro link_list(options) %}
 {% spaceless %}
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
@@ -682,7 +682,7 @@ value  | string | The value to display
 data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro li(options = {}) %}
+{% macro li(options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -719,7 +719,7 @@ id     | string | A unique identifier, if required
 data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro loading(options = {}) %}
+{% macro loading(options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -768,7 +768,7 @@ items  | hash   | A hash of data where key: value = title: description
 data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro metadata(options = {}) %}
+{% macro metadata(options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -821,7 +821,7 @@ title  | string | The title of the panel
 data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro panel(options = {}) %}
+{% macro panel(options) %}
 {% spaceless %}
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
@@ -876,7 +876,7 @@ value_visible | bool   | Whether to visually display the value inside the bar (d
 data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro progress(options = {}) %}
+{% macro progress(options) %}
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -940,7 +940,7 @@ type      | string | Can be `button` (default), `link`, `input`, `submit`
 data-*    | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
-{% macro remove_button(options = {}) %}
+{% macro remove_button(options) %}
 {% spaceless %}
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}


### PR DESCRIPTION
Requested by @dave-irvine, they're no longer required and break twig.js.

Closes #80