### PR TITLE
Add new get_constant extension to simplify constant checking within views

### DIFF
--- a/src/Jadu/Pulsar/Twig/Extension/GetConstantExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/GetConstantExtension.php
@@ -7,6 +7,12 @@ use Twig_SimpleFunction;
 
 class GetConstantExtension extends Twig_Extension
 {
+
+    /**
+     * Register the `get_constant` function with Twig
+     *
+     * @return array The Twig function
+     */
     public function getFunctions()
     {
         return array(
@@ -28,12 +34,14 @@ class GetConstantExtension extends Twig_Extension
      * Get constant value if defined, null if not
      *
      * @param  string $name The name of the constant
-     * @return string       The value of the constant, null if not defined
+     * @param  string $fallback A fallback value, or type
+     *
+     * @return string The value of the constant, null if not defined
      */
-    public function getConstant($name = '')
+    public function getConstant($name = '', $fallback = null)
     {
         if (empty($name) || !defined($name)) {
-            return null;
+            return $fallback;
         }
 
         return constant($name);

--- a/src/Jadu/Pulsar/Twig/Extension/GetConstantExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/GetConstantExtension.php
@@ -2,9 +2,6 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
-use Twig_Extension;
-use Twig_SimpleFunction;
-
 class GetConstantExtension extends \Twig_Extension
 {
     public function getFunctions()
@@ -25,9 +22,7 @@ class GetConstantExtension extends \Twig_Extension
     }
 
     /**
-     * Get constant
-     *
-     * Returns constant value if defined, null if not
+     * Get constant value if defined, null if not
      *
      * @param  string $name The name of the constant
      * @return string       The value of the constant, null if not defined

--- a/src/Jadu/Pulsar/Twig/Extension/GetConstantExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/GetConstantExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Jadu\Pulsar\Twig\Extension;
+
+use Twig_Extension;
+use Twig_SimpleFunction;
+
+class GetConstantExtension extends \Twig_Extension
+{
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('get_constant', array($this, 'getConstant')),
+        );
+    }
+
+    /**
+     * Name of this extension
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'get_constant_extension';
+    }
+
+    /**
+     * Get constant
+     *
+     * Returns constant value if defined, null if not
+     *
+     * @param  string $name The name of the constant
+     * @return string       The value of the constant, null if not defined
+     */
+    public function getConstant($name = '')
+    {
+        if (empty($name) || !defined($name)) {
+            return null;
+        }
+
+        return constant($name);
+    }
+}

--- a/src/Jadu/Pulsar/Twig/Extension/GetConstantExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/GetConstantExtension.php
@@ -5,12 +5,12 @@ namespace Jadu\Pulsar\Twig\Extension;
 use Twig_Extension;
 use Twig_SimpleFunction;
 
-class GetConstantExtension extends \Twig_Extension
+class GetConstantExtension extends Twig_Extension
 {
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('get_constant', array($this, 'getConstant')),
+            new Twig_SimpleFunction('get_constant', array($this, 'getConstant')),
         );
     }
 

--- a/src/Jadu/Pulsar/Twig/Extension/GetConstantExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/GetConstantExtension.php
@@ -2,6 +2,9 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
+use Twig_Extension;
+use Twig_SimpleFunction;
+
 class GetConstantExtension extends \Twig_Extension
 {
     public function getFunctions()

--- a/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
+++ b/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
@@ -7,10 +7,10 @@ class GetConstantExtensionTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->ext = new GetConstantExtension(array());
-        define('STRING', 'foo');
-        define('BOOL', true);
-        define('INT', 42);
-        define('NULL', null);
+        defined('STRING') or define('STRING', 'foo');
+        defined('BOOL') or define('BOOL', true);
+        defined('INT') or define('INT', 42);
+        defined('NULL') or define('NULL', null);
     }
 
     public function testGetName()

--- a/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
+++ b/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
@@ -7,6 +7,7 @@ class GetConstantExtensionTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->ext = new GetConstantExtension(array());
+
         defined('STRING') or define('STRING', 'foo');
         defined('BOOL') or define('BOOL', true);
         defined('INT') or define('INT', 42);

--- a/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
+++ b/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
@@ -34,7 +34,7 @@ class GetConstantExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $twig->render('index.html'));
     }
 
-    public function testGetConstantReturnsNullByDefault()
+    public function testGetConstantReturnsNullFallbackByDefault()
     {
         $this->assertEquals(null, $this->ext->getConstant());
     }
@@ -62,5 +62,10 @@ class GetConstantExtensionTest extends \PHPUnit_Framework_TestCase
     public function testGetNullConstantReturnsNull()
     {
         $this->assertEquals(null, $this->ext->getConstant('NULL'));
+    }
+
+    public function testGetConstantReturnsFallback()
+    {
+        $this->assertEquals('bar', $this->ext->getConstant(null, 'bar'));
     }
 }

--- a/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
+++ b/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
@@ -2,6 +2,9 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
+use Twig_Environment;
+use Twig_Loader_Array;
+
 class GetConstantExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
@@ -17,6 +20,18 @@ class GetConstantExtensionTest extends \PHPUnit_Framework_TestCase
     public function testGetName()
     {
         $this->assertEquals('get_constant_extension', $this->ext->getName());
+    }
+
+    public function testGetConstantFunction()
+    {
+        $loader = new Twig_Loader_Array(array(
+            'index.html' => '{{ get_constant("STRING") }}',
+        ));
+
+        $twig = new Twig_Environment($loader);
+        $twig->addExtension(new GetConstantExtension());
+
+        $this->assertEquals('foo', $twig->render('index.html'));
     }
 
     public function testGetConstantReturnsNullByDefault()

--- a/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
+++ b/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
@@ -6,7 +6,7 @@ class GetConstantExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->ext = new GetConstantExtension(array());
+        $this->ext = new GetConstantExtension();
 
         defined('STRING') or define('STRING', 'foo');
         defined('BOOL') or define('BOOL', true);

--- a/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
+++ b/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jadu\Pulsar\Twig\Extension;
+
+class GetConstantExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->ext = new GetConstantExtension(array());
+        define('STRING', 'foo');
+        define('BOOL', true);
+        define('INT', 42);
+        define('NULL', null);
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals('get_constant_extension', $this->ext->getName());
+    }
+
+    public function testGetConstantReturnsNullByDefault()
+    {
+        $this->assertEquals(null, $this->ext->getConstant());
+    }
+
+    public function testGetUndefinedConstantReturnsNull()
+    {
+        $this->assertEquals(null, $this->ext->getConstant('WAT'));
+    }
+
+    public function testGetStringConstantReturnsString()
+    {
+        $this->assertEquals('foo', $this->ext->getConstant('STRING'));
+    }
+
+    public function testGetBoolConstantReturnsBool()
+    {
+        $this->assertEquals(true, $this->ext->getConstant('BOOL'));
+    }
+
+    public function testGetIntConstantReturnsInt()
+    {
+        $this->assertEquals(42, $this->ext->getConstant('INT'));
+    }
+
+    public function testGetNullConstantReturnsNull()
+    {
+        $this->assertEquals(null, $this->ext->getConstant('NULL'));
+    }
+}


### PR DESCRIPTION
Checks whether a constant is defined and returns the value, or null if it doesn't exist.

Addresses #6 