### PR TITLE
Update breadcrumb styles

### DIFF
--- a/stylesheets/_component.breadcrumb.scss
+++ b/stylesheets/_component.breadcrumb.scss
@@ -1,68 +1,12 @@
 .breadcrumb {
-  background-color: color(white);
-  border-bottom: 1px solid color(gray);
+    color: color(gray, light);
+    font-size: $font-size-small;
 
-  ul {
-    list-style-type: none;
-    margin: $padding-small-vertical 0 $padding-small-vertical $gutter-width;
+    a {
+        color: color(gray, light);
 
-    @include respond-min($screen-phone) {
-      margin: 0 0 0 $gutter-width;
+        &:hover {
+            color: color(gray);
+        }
     }
-  }
-
-  li {
-    @include inline-block;
-    margin: 0;
-    padding: 0 ($gutter-width / 4) 0 0;
-
-    &:before {
-      color: color(gray, light);
-      content: " / ";
-      @include inline-block;
-      font-size: 1.25em;
-      margin-left: $gutter-width / 8;
-      padding-right: $gutter-width / 2 - 3;
-      position: relative;
-      top: 1px;
-
-      @include respond-min($screen-phone) {
-        font-size: 1.5em;
-        margin-left: $gutter-width / 4;
-        padding-right: $gutter-width - 6;
-        top: 3px;
-      }
-    }
-
-    @include respond-min($screen-phone) {
-      padding: 0 ($gutter-width / 2) 0 0;
-    }
-
-    &:first-child {
-      padding-left: 0;
-    }
-
-    &:first-child:before {
-      display: none;
-    }
-  }
-
-  li > a,
-  li > span {
-    @include inline-block;
-    line-height: $line-height-base - 1;
-
-    @include respond-min($screen-phone) {
-      line-height: ($line-height-base * 2) - 1;
-    }
-  }
-
-  a {
-    color: color(gray, dark);
-    text-decoration: none;
-  }
-
-  &:hover a {
-    color: color(link);
-  }
 }

--- a/stylesheets/_layout.tabs.scss
+++ b/stylesheets/_layout.tabs.scss
@@ -11,8 +11,8 @@
 
 .main-title {
     font-size: 1.75em;
-    line-height: 47px;
-    margin-bottom: 1px;
+    line-height: 42px;
+    margin-bottom: 6px;
 }
 
 .sub-title {

--- a/stylesheets/_override.shame.scss
+++ b/stylesheets/_override.shame.scss
@@ -38,14 +38,6 @@
     max-width: 100%;
 }
 
-
-
-.main-title {
-    font-size: 1.75em;
-    line-height: 47px;
-    margin-bottom: 1px;
-}
-
 .tab__title {
   border-bottom: 1px solid #ccc;
   line-height: 47px;

--- a/views/pulsar/layouts/base.html.twig
+++ b/views/pulsar/layouts/base.html.twig
@@ -36,7 +36,7 @@
     <link rel="stylesheet" type="text/css" href="{{ libsPath ~ 'font-awesome/css/font-awesome-ie7.min.css' }}" />
     <![endif]-->
 
-    <!-- <link rel="stylesheet" href="http://basehold.it/24"> -->
+    <link rel="stylesheet" href="http://basehold.it/24">
 
     <script
         src="{{ base_path ~ 'dist/js/bundle.js' }}"
@@ -95,6 +95,9 @@
 
             <div class="content-main">
                 <div class="tabs__content">
+                    <nav class="breadcrumb">
+                        <a href="#">Bread</a> / <a href="#">Crumb</a> / Trail
+                    </nav>
                     <h1 class="main-title">{{ heading|default('MISSING HEADING') }}</h1>
                     {% block tabs_list %}{% endblock %}
                     {% block tabs_content %}{% endblock %}


### PR DESCRIPTION
Driven by the need for Continuum CMS and XFP to have breadcrumbs restored, especially in legacy UIs.

The breadcrumb styles being removed in this commit are the Pulsar 3's clone of CMS 1.10 styles and are good to be removed rather than deprecated.

`main-title` position has been tweaked to maintain a neat baseline, and also cope with the absence of `.breadcrumb` if it's not there.

<img width="508" alt="screen shot 2016-03-10 at 15 41 52" src="https://cloud.githubusercontent.com/assets/18653/13675065/cde2cd04-e6d7-11e5-9bc3-0e93197d06ea.png">

Closes #101