### PR TITLE
Use cursor pointer when mousing over toggle-switch

### DIFF
--- a/stylesheets/_component.toggle-switch.scss
+++ b/stylesheets/_component.toggle-switch.scss
@@ -48,6 +48,7 @@
     border-color: transparent;
     border-radius: 1.5em;
     color: color(white);
+    cursor: pointer;
     display: inline-block;
     font-size: 2em;
     height: 1em;


### PR DESCRIPTION
Adds expected affordance that this element can be clicked on.

![cursor](https://cloud.githubusercontent.com/assets/18653/13684978/33872a50-e706-11e5-8096-1764078fb72f.gif)

Closes #103 