### PR TITLE
Add new status indicator component, helper and tests

### DIFF
--- a/stylesheets/_component.status.scss
+++ b/stylesheets/_component.status.scss
@@ -3,7 +3,6 @@
     height: 12px;
     width: 12px;
     position: relative;
-    text-indent: -999px;
     top: 1px;
     vertical-align: baseline;
 }

--- a/stylesheets/_component.status.scss
+++ b/stylesheets/_component.status.scss
@@ -1,0 +1,28 @@
+.status {
+    display: inline-block;
+    height: 12px;
+    width: 12px;
+    position: relative;
+    text-indent: -999px;
+    top: 1px;
+    vertical-align: baseline;
+}
+
+.status {
+    &.is-active,
+    &.is-online {
+        background-color: #297c46;
+        border-radius: 6px;
+    }
+
+    &.is-offline {
+        background-color: #c84d40;
+        border-radius: 2px;
+    }
+
+    &.is-inactive {
+        background-color: #fff;
+        border: 2px solid #ccc;
+        border-radius: 6px;
+    }
+}

--- a/stylesheets/pulsar.scss
+++ b/stylesheets/pulsar.scss
@@ -119,6 +119,7 @@ $FontAwesomePath: '../libs/font-awesome/font/';
 @import '_component.select2';
 @import '_component.settings';
 @import '_component.signin';
+@import '_component.status';
 @import '_component.summary';
 @import '_component.tab-help';
 @import '_component.tab-panel';

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-title.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-title.html
@@ -1,0 +1,1 @@
+<span title="foo" class="status is-online"></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-title.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-title.html.twig
@@ -1,0 +1,9 @@
+{#
+    Test basic status method
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.status('online', {
+        'title': 'foo'
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-options.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-options.html
@@ -1,0 +1,1 @@
+<span data-foo="bar" id="baz" title="online" class="status is-online foo"></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-options.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-options.html.twig
@@ -1,0 +1,11 @@
+{#
+    Test status with options
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.status('online', {
+        'class': 'foo',
+        'data-foo': 'bar',
+        'id': 'baz'
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-state.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-state.html
@@ -1,0 +1,1 @@
+<span title="online" class="status is-online"></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-state.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-state.html.twig
@@ -1,0 +1,7 @@
+{#
+    Test status method with state
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.status('online')
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status.html
@@ -1,0 +1,1 @@
+<span title="active" class="status is-active"></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status.html.twig
@@ -1,0 +1,7 @@
+{#
+    Test basic status method
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.status()
+}}

--- a/views/lexicon/tabs/buttons_labels.html.twig
+++ b/views/lexicon/tabs/buttons_labels.html.twig
@@ -393,6 +393,12 @@
         }}
     </p>
 
+    <h2 class="heading">Status indicators</h2>
+    <p>I am online <span class="status is-online" title="online"></span></p>
+    <p>I am offline <span class="status is-offline" title="offline"></span></p>
+    <p>I am active <span class="status is-active" title="active"></span></p>
+    <p>I am inactive <span class="status is-inactive" title="inactive"></span></p>
+
     <h2 class="heading">Dropdown/Dropup buttons</h2>
     <p>
         <div class="btn__toolbar">

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -963,3 +963,62 @@ data-*    | string | Data attributes, eg: `'data-foo': 'bar'`
 
 {% endspaceless %}
 {% endmacro %}
+
+
+{# -----------------------------------------------------------------------------
+
+# Status
+
+Displays a small visual indication of state, helpful when used within table
+cells or piano list keys to avoid the need for a user to check many items
+individually to determine their state.
+
+## Example usage
+
+```twig
+{{ html.status('online') }}
+```
+
+The 'state' will be used for both the title attribute, and for the stateful
+class name, eg:
+
+```html
+<span class="status is-online" title="online"></span>
+```
+
+### States
+
+ * online
+ * offline
+ * active
+ * inactive
+
+Some states are simply synonyms of each other, the choice of verb will be
+defined by the context in which it is to be used.
+
+## Options
+
+Option | Type   | Description
+------ | ------ | --------------------------------------------------------------
+class  | string | CSS classes, space separated
+id     | string | A unique identifier, if required
+data-* | string | Data attributes, eg: `'data-foo': 'bar'`
+
+#}
+{% macro status(state, options) %}
+{% spaceless %}
+
+    <span{{
+        attributes(options
+            |exclude('state')
+            |defaults({
+                'class': 'status is-' ~ state|default('active')
+            })
+            |merge({
+                'title': state|default('active')
+            })
+        )
+    }}></span>
+
+{% endspaceless %}
+{% endmacro %}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -988,7 +988,7 @@ class name, eg:
 
 ### States
 
- * online
+ * online (default)
  * offline
  * active
  * inactive
@@ -1002,20 +1002,22 @@ Option | Type   | Description
 ------ | ------ | --------------------------------------------------------------
 class  | string | CSS classes, space separated
 id     | string | A unique identifier, if required
+title  | string | Title attribute, defaults to 'state' if not supplied
 data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro status(state, options) %}
 {% spaceless %}
 
+{% if options.title is not defined %}
+    {% set options = options|default({})|merge({ 'title': state|default('active') }) %}
+{% endif %}
+
     <span{{
         attributes(options
             |exclude('state')
             |defaults({
                 'class': 'status is-' ~ state|default('active')
-            })
-            |merge({
-                'title': state|default('active')
             })
         )
     }}></span>


### PR DESCRIPTION
Closes #109 

Documentation for gitbook:
----

# Status

Displays a small visual indication of state; helpful when used within table
cells or piano list keys to avoid the need for a user to check many items
individually to determine their state.

Status indicators should ideally have some text which indicates their context. For example, they could be sat next to a text label called 'Active', or within a table column entitled 'Online'. Try not to rely on this indicator alone.

<p data-height="200" data-theme-id="21222" data-slug-hash="mPrvqZ" data-default-tab="result" data-user="pulsar" class="codepen">See the Pen <a href="http://codepen.io/pulsar/pen/mPrvqZ/">docs - status indicators</a> by Pulsar (<a href="http://codepen.io/pulsar">@pulsar</a>) on <a href="http://codepen.io">CodePen</a>.</p>
<script async src="//assets.codepen.io/assets/embed/ei.js"></script>

### Accessibility

You may notice 'offline' uses a square instead of a circle, this is to visually distinguish it from the green 'online' status for red/green colourblind users as colour alone isn't a reliable indicator of status. The title attribute is also added which is displayed on hover and for screen readers.

![Showing how status labels are viewed for Deuternopia sufferers](./status-colourblind.png)

_Example of how status indicators are seen by deuternopia sufferers_

## Example usage

```twig
{{ html.status('online') }}
```

The 'state' will be used for both the title attribute, and for the stateful
class name, eg:

```html
<span class="status is-online" title="online"></span>
```

### States

 * online
 * offline
 * active
 * inactive

Some states are simply synonyms of each other, the choice of verb will be
defined by the context in which it is to be used.

## Options

Option | Type   | Description
------ | ------ | --------------------------------------------------------------
class  | string | CSS classes, space separated
id     | string | A unique identifier, if required
data-* | string | Data attributes, eg: `'data-foo': 'bar'`

