### PR TITLE
Add ability to add an icon to a piano list item

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -22,7 +22,6 @@ var $                     = require('jquery'),
     clickover  = require('../libs/bootstrapx-clickover/js/bootstrapx-clickover'),
     svgeezy    = require('../libs/svgeezy/svgeezy.min'),
     select2    = require('../libs/select2/dist/js/select2.min'),
-    toggles    = require('../libs/jquery-toggles/toggles.min'),
 
     dt            = require('datatables.net')(window, $),
     dt_responsive = require('datatables.net-responsive')(window, $),

--- a/stylesheets/_component.piano.scss
+++ b/stylesheets/_component.piano.scss
@@ -194,6 +194,23 @@
     width: 25px;
 }
 
+.piano__icon {
+    border-radius: 50%;
+    float: left;
+    height: 48px;
+    margin-bottom: 5px;
+    margin-right: 10px;
+    width: 48px;
+
+    .is-inactive & {
+        -webkit-filter: grayscale(100%); // Webkit
+        -webkit-filter: grayscale(1); // Webkit
+        filter: grayscale(1); // W3C
+        filter: gray; // IE 6-9
+        opacity: 0.25;
+    }
+}
+
 .piano__user {
     color: #000;
     font-size: 14px;
@@ -215,6 +232,10 @@
     background: none;
     margin-bottom: 10px;
     padding: 0;
+}
+
+.piano__service + .piano__title {
+    clear: none;
 }
 
 .piano__item-toggle {

--- a/stylesheets/_palette.base.scss
+++ b/stylesheets/_palette.base.scss
@@ -78,7 +78,7 @@ $palette-alias: (
         disabled: map-get(map-get($palette-monochromes, gray), lighter)
     ),
     border: (
-        base: map-get(map-get($palette-monochromes, gray), light)
+        base: map-get(map-get($palette-monochromes, gray), lighter)
     )
 );
 

--- a/stylesheets/pulsar.scss
+++ b/stylesheets/pulsar.scss
@@ -16,7 +16,6 @@ $ie-version: 12 !default;
 
 // Third party plugins
 @import '../libs/normalize-css/normalize.css';
-@import '../libs/jquery-toggles/css/toggles-full.css';
 @import '../libs/select2/dist/css/select2.css';
 
 // Font awesome


### PR DESCRIPTION
![screen shot 2016-03-15 at 10 46 27](https://cloud.githubusercontent.com/assets/18653/13776513/74e78414-eaa2-11e5-87ea-981617cd415a.png)

Example markup:

```
<li class="piano__item">
    <a href="/piano_item_link">
        <div class="piano__item-header">

            {{ html.status('active', {'class': 'pull-right'}) }}

            <strong class="piano__service">
                <img src="https://upload.wikimedia.org/wikipedia/en/7/76/Slack_Icon.png" class="piano__icon">
                Slack
            </strong>

            <p class="piano__title">Send CMS notifications to Slack channels</p>
        </div>
    </a>
</li>
```

Closes #111 