### PR TITLE
Remove remaining query-toggles references

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -22,7 +22,6 @@ var $                     = require('jquery'),
     clickover  = require('../libs/bootstrapx-clickover/js/bootstrapx-clickover'),
     svgeezy    = require('../libs/svgeezy/svgeezy.min'),
     select2    = require('../libs/select2/dist/js/select2.min'),
-    toggles    = require('../libs/jquery-toggles/toggles.min'),
 
     dt            = require('datatables.net')(window, $),
     dt_responsive = require('datatables.net-responsive')(window, $),

--- a/stylesheets/pulsar.scss
+++ b/stylesheets/pulsar.scss
@@ -16,7 +16,6 @@ $ie-version: 12 !default;
 
 // Third party plugins
 @import '../libs/normalize-css/normalize.css';
-@import '../libs/jquery-toggles/css/toggles-full.css';
 @import '../libs/select2/dist/css/select2.css';
 
 // Font awesome


### PR DESCRIPTION
This dependency has been removed from Pulsar, these includes need to be removed to prevent the build breaking, or 404s in the browser.

Closes #121