### PR TITLE
Turn html.status title attributes into a tooltip

### DIFF
--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-placement.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-placement.html
@@ -1,0 +1,1 @@
+<span data-placement="right" title="online" data-toggle="tooltips" class="status is-online"></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-placement.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-placement.html.twig
@@ -1,0 +1,9 @@
+{#
+    Test status method with tooltip positioning
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.status('online', {
+        'data-placement': 'right'
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-title.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-title.html
@@ -1,1 +1,1 @@
-<span title="foo" class="status is-online"></span>
+<span title="foo" data-placement="top" data-toggle="tooltips" class="status is-online"></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-options.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-options.html
@@ -1,1 +1,1 @@
-<span data-foo="bar" id="baz" title="online" class="status is-online foo"></span>
+<span data-foo="bar" id="baz" title="online" data-placement="top" data-toggle="tooltips" class="status is-online foo"></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-state.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-state.html
@@ -1,1 +1,1 @@
-<span title="online" class="status is-online"></span>
+<span title="online" data-placement="top" data-toggle="tooltips" class="status is-online"></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status.html
@@ -1,1 +1,1 @@
-<span title="active" class="status is-active"></span>
+<span title="active" data-placement="top" data-toggle="tooltips" class="status is-active"></span>

--- a/views/lexicon/tabs/buttons_labels.html.twig
+++ b/views/lexicon/tabs/buttons_labels.html.twig
@@ -394,10 +394,10 @@
     </p>
 
     <h2 class="heading">Status indicators</h2>
-    <p>I am online <span class="status is-online" title="online"></span></p>
-    <p>I am offline <span class="status is-offline" title="offline"></span></p>
-    <p>I am active <span class="status is-active" title="active"></span></p>
-    <p>I am inactive <span class="status is-inactive" title="inactive"></span></p>
+    <p>I am online {{ html.status('online') }}</p>
+    <p>I am offline {{ html.status('offline') }}</p>
+    <p>I am active {{ html.status('active') }}</p>
+    <p>I am inactive {{ html.status('inactive') }}</p>
 
     <h2 class="heading">Dropdown/Dropup buttons</h2>
     <p>

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1013,8 +1013,12 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
     <span{{
         attributes(options
             |exclude('state')
+            |merge({
+                'data-placement': options['data-placement']|default('top')
+            })
             |defaults({
-                'class': 'status is-' ~ state|default('active')
+                'class': 'status is-' ~ state|default('active'),
+                'data-toggle': 'tooltips'
             })
         )
     }}></span>


### PR DESCRIPTION
Defaults to top, but can be overridden.

![status](https://cloud.githubusercontent.com/assets/18653/13793254/eb46d9d4-eaed-11e5-8853-263cec9d8e13.gif)

Closes #112