### PR TITLE
Add state-specific border colours to button groups

### DIFF
--- a/stylesheets/_component.button-groups.scss
+++ b/stylesheets/_component.button-groups.scss
@@ -3,120 +3,137 @@
  * check _component.forms.scss
  */
 
-
 // Make the div behave like a button
 .btn__group,
 .btn__group-vertical {
-  position: relative;
-  &:not(.controls) {
-    @include inline-block;
-  }
-  vertical-align: middle; // match .btn alignment given font-size hack above
-
-  > .btn:not(.btn--naked),
-  > .btn__group {
-    border-left: 1px solid #ccc;
-    border-right: 1px solid #ccc;
     position: relative;
-    vertical-align: bottom;
-    // Bring the "active" button to the front
-    &:hover,
-    &:focus,
-    &:active,
-    &.active {
-      z-index: 2;
+    vertical-align: middle; // match .btn alignment given font-size hack above
+
+    &:not(.controls) {
+        @include inline-block;
     }
-  }
+
+    > .btn:not(.btn--naked),
+    > .btn__group {
+        position: relative;
+        vertical-align: bottom;
+
+        // Bring the "active" button to the front
+        &:hover,
+        &:focus,
+        &:active,
+        &.active {
+            z-index: 2;
+        }
+    }
+
+    > .btn:not(:first-of-type):not(.btn--naked) {
+        border-left: 1px solid #ccc;
+        border-right: 1px solid #ccc;
+    }
+
+    @each $state, $state-color, $state-color-alt in $state-colors {
+        > .btn--#{$state}:not(:first-of-type):not(.btn--naked) {
+            border-left-color: darken(color($state), 10);
+            border-right-color: darken(color($state), 10);
+        }
+    }
 }
 
 .btn__group > .btn + .btn,
 .btn__group > .btn__group + .btn__group {
-  margin-left: -1px;
+    margin-left: -1px;
 }
 
 .btn__group > .btn:not(.btn--naked):first-of-type,
 .btn__group > .btn__group:first-of-type {
-  border-left-width: 0;
-  border-left-width: 0;
-  border-top-left-radius: 3px;
-  border-bottom-left-radius: 3px;
+    border-left-width: 0;
+    border-left-width: 0;
+    border-top-left-radius: 3px;
+    border-bottom-left-radius: 3px;
 }
 
 .btn__group > .btn:last-of-type,
 .btn__group > .btn__group:last-of-type {
-  border-right-width: 0;
-  border-top-right-radius: 3px;
-  border-bottom-right-radius: 3px;
+    border-right-width: 0;
+    border-top-right-radius: 3px;
+    border-bottom-right-radius: 3px;
 }
 
 .btn__group > .btn:not(:first-of-type):not(:last-of-type):not(.dropdown__toggle),
 .btn__group > .btn__group:not(:first-of-type):not(:last-of-type) {
-  border-radius: 0;
+    border-radius: 0;
 }
 
 // Prevent double borders when buttons are next to each other
 .btn__group .btn + .btn,
 .btn__group .btn__group + .btn__group {
-  margin-left: -1px;
+    margin-left: -1px;
 }
 
 // Optional: Group multiple button groups together for a toolbar
 .btn__toolbar {
-  @include clear-fix;
+    @include clear-fix;
 
-  .btn__group {
-    float: left;
-  }
-  // Space out series of button groups
-  > .btn,
-  > .btn__group {
-    + .btn,
-    + .btn__group {
-      margin-left: 4px; // match the default display: inline-block; spacing for consistency
+    .btn__group {
+        float: left;
     }
-    + .btn {
-      + .btn {
-        margin-left: 0; // for fixing the white-space between rows of display: inline-block; buttons
-      }
+
+    // Space out series of button groups
+    > .btn,
+    > .btn__group {
+        + .btn,
+        + .btn__group {
+            margin-left: 4px; // match the default display: inline-block; spacing for consistency
+        }
+
+        + .btn {
+            + .btn {
+                margin-left: 0; // for fixing the white-space between rows of display: inline-block; buttons
+            }
+        }
     }
-  }
 }
 
 // Set corners individual because sometimes a single button can be in a .btn__group and we need :first-of-type and :last-of-type to both match
 .btn__group > .btn:first-of-type,
 .btn__group > .btn__group:first-of-type {
-  margin-left: 0;
-  &:not(:last-of-type):not(.dropdown__toggle) {
-    @include border-right-radius(0);
-  }
+    margin-left: 0;
+    &:not(:last-of-type):not(.dropdown__toggle) {
+        @include border-right-radius(0);
+    }
 }
+
 // Need .dropdown__toggle since :last-of-type doesn't apply given a .dropdown-menu immediately after it
 .btn__group > .btn:last-of-type:not(:first-of-type),
 .btn__group > .dropdown__toggle:not(:first-of-type) {
-  @include border-left-radius(0);
+    @include border-left-radius(0);
 }
 
 // Custom edits for including btn__groups within btn__groups (useful for including dropdown buttons within a btn__group)
 .btn__group > .btn__group {
-  margin-left: -1px;
+    margin-left: -1px;
 }
+
 .btn__group > .btn__group:not(:first-of-type):not(:last-of-type) > .btn {
-  border-radius: 0;
+    border-radius: 0;
 }
+
 .btn__group > .btn__group:first-of-type {
-  > .btn:last-of-type,
-  > .dropdown__toggle {
-    @include border-right-radius(0);
-  }
+    > .btn:last-of-type,
+    > .dropdown__toggle {
+        @include border-right-radius(0);
+    }
 }
+
 .btn__group > .btn__group:last-of-type > .btn:first-of-type {
-  @include border-left-radius(0);
+    @include border-left-radius(0);
 }
 
 // On active and open, don't show outline
 .btn__group .dropdown__toggle:active,
 .btn__group.open .dropdown__toggle {
-  outline: 0;
+    outline: 0;
 }
 
 
@@ -126,49 +143,48 @@
 
 // Remove the box-shadow and borders from btns
 .btn__group > .btn__group > .btn {
-  box-shadow: none;
-  border-right: none;
-  border-left: none;
+    box-shadow: none;
+    border-right: none;
+    border-left: none;
 }
 
 // Add the box-shadow to the nested .btn__group rather than the .btn
 .btn__group > .btn__group {
-  box-shadow: 0 2px 0 #ccc;
+    box-shadow: 0 2px 0 #ccc;
 }
 
 // Give the line between buttons some depth
 .btn__group > .btn + .dropdown__toggle {
-  padding-left: 8px;
-  padding-right: 8px;
+    padding-left: 8px;
+    padding-right: 8px;
 }
+
 .btn__group > .btn-lg + .dropdown__toggle {
-  padding-left: 12px;
-  padding-right: 12px;
+    padding-left: 12px;
+    padding-right: 12px;
 }
 
 // The clickable button for toggling the menu
 // Remove the gradient and set the same inset shadow as the :active state
 .btn__group.open .dropdown__toggle {
-  box-shadow: inset 0 3px 5px rgba(0,0,0,.125);
+    box-shadow: inset 0 3px 5px rgba(0,0,0,.125);
 }
-
 
 // Reposition the caret
 .btn .caret {
-  margin-left: 0;
+    margin-left: 0;
 }
 // Carets in other button sizes
 .btn-lg .caret {
-  border-width: 5px;
+    border-width: 5px;
 }
 // Upside down carets for .dropup
 .dropup .btn-lg .caret {
-  border-bottom-width: 5px;
+    border-bottom-width: 5px;
 }
-
 
 // Checkbox and radio options
 .btn__group[data-toggle="buttons"] > .btn > input[type="radio"],
 .btn__group[data-toggle="buttons"] > .btn > input[type="checkbox"] {
-  display: none;
+    display: none;
 }

--- a/views/lexicon/tabs/buttons_labels.html.twig
+++ b/views/lexicon/tabs/buttons_labels.html.twig
@@ -273,9 +273,19 @@
         {{
             html.button_group({
                 buttons: [
-                    html.button({ label: 'Left' }),
-                    html.button({ label: 'Middle' }),
-                    html.button({ label: 'Right' })
+                    html.button({ label: 'Left', 'class': 'btn--primary' }),
+                    html.button({ label: 'Middle', 'class': 'btn--primary' }),
+                    html.button({ label: 'Right', 'class': 'btn--primary' })
+                ]
+            })
+        }}
+
+        {{
+            html.button_group({
+                buttons: [
+                    html.button({ label: 'Left', 'class': 'btn--danger' }),
+                    html.button({ label: 'Middle', 'class': 'btn--danger' }),
+                    html.button({ label: 'Right', 'class': 'btn--danger' })
                 ]
             })
         }}

--- a/views/pulsar/layouts/base.html.twig
+++ b/views/pulsar/layouts/base.html.twig
@@ -36,7 +36,7 @@
     <link rel="stylesheet" type="text/css" href="{{ libsPath ~ 'font-awesome/css/font-awesome-ie7.min.css' }}" />
     <![endif]-->
 
-    <link rel="stylesheet" href="http://basehold.it/24">
+    <!-- <link rel="stylesheet" href="http://basehold.it/24"> -->
 
     <script
         src="{{ base_path ~ 'dist/js/bundle.js' }}"


### PR DESCRIPTION
Main change is addition of this on L:35

```
@each $state, $state-color, $state-color-alt in $state-colors {
    > .btn--#{$state}:not(:first-of-type):not(.btn--naked) {
        border-left-color: darken(color($state), 10);
        border-right-color: darken(color($state), 10);
    }
}
```

<img width="585" alt="screen shot 2016-03-21 at 20 56 46" src="https://cloud.githubusercontent.com/assets/18653/13934023/da4a3392-efa7-11e5-9169-3621f9982cd7.png">

Fixes #126