### PR TITLE
139 choice block

### DIFF
--- a/js/PulsarFormComponent.js
+++ b/js/PulsarFormComponent.js
@@ -33,6 +33,28 @@ PulsarFormComponent.prototype.init = function () {
         }
     });
 
+    // Block styled checkboxes and radios
+    var choiceBlock = component.$html.find(".choice--block");
+    choiceBlock.on('change', '.controls input[type="checkbox"], .controls input[type="radio"]', component.selectionButtons);
+
+};
+
+PulsarFormComponent.prototype.selectionButtons = function() {
+
+    var $target = $(this);
+
+    var $controls = $target.closest('.controls');
+
+    $controls.find('input[type="checkbox"]:not(:checked), input[type="radio"]:not(:checked)')
+        .closest('.control__label')
+        .removeClass('is-selected');
+
+    if ($target.is(':checked')) {
+        $target.closest('.control__label').addClass('is-selected');
+    } else {
+        $target.closest('.control__label').removeClass('is-selected');
+    }
+
 };
 
 module.exports = PulsarFormComponent;

--- a/stylesheets/_component.choice.scss
+++ b/stylesheets/_component.choice.scss
@@ -1,0 +1,56 @@
+
+// align inputs with the text labels properly
+.form-choice.choice--block .form__control {
+    &.checkbox,
+    &.radio {
+        vertical-align: baseline;
+    }
+}
+
+.choice--block > .controls {
+
+    // width modifiers are used on the control__labels
+    max-width: 100%;
+    width: 100%;
+
+    .control__label {
+        box-shadow: inset 0 0 0 1px color(border); // nicer border effects
+        border-radius: $border-radius;
+        margin: 0 5px 5px 0;
+        max-width: 100%;
+        padding: 10px;
+        user-select: none; // stop nasty blue text selection when clicking
+        width: 100%; // mobile-first width
+
+        &:last-child {
+            margin: 0;
+        }
+
+        @include ie-lte(8) {
+            border: 1px solid color(border);
+        }
+    }
+
+    .control__label.is-selected {
+        background-color: color(background, light);
+        box-shadow: inset 0 0 0 2px color(black);
+
+        @include ie-lte(8) {
+            border: 1px solid color(black);
+        }
+    }
+}
+
+@include respond-min($screen-tablet) {
+    @each $variant, $width in $inputs {
+        .form-choice.form__group--#{$variant} > .controls > .control__label {
+            width: #{$width};
+        }
+    }
+}
+
+.choice--block-inline {
+    > .controls > .control__label {
+        clear: none;
+    }
+}

--- a/stylesheets/_component.choice.scss
+++ b/stylesheets/_component.choice.scss
@@ -11,7 +11,7 @@
 
     // width modifiers are used on the control__labels
     max-width: 100%;
-    width: 100%;
+    width: 75%;
 
     .control__label {
         box-shadow: inset 0 0 0 1px color(border); // nicer border effects

--- a/stylesheets/_config.variables.scss
+++ b/stylesheets/_config.variables.scss
@@ -120,6 +120,16 @@ $input-height-base:                   $line-height-base * 2 !default;
 $input-height-large:                  (floor($font-size-large * 2) + ($padding-large-vertical * 2) + 2) !default;
 $input-height-small:                  (floor($font-size-small * $line-height-small) + ($padding-small-vertical * 2) + 2) !default;
 
+$inputs: (
+    mini:    50px,
+    small:   100px,
+    medium:  200px,
+    regular: 300px,
+    large:   400px,
+    xlarge:  500px,
+    full:    100%
+);
+
 // -----------------------------------------------------------------------------
 //  Modals
 // -----------------------------------------------------------------------------

--- a/stylesheets/pulsar.scss
+++ b/stylesheets/pulsar.scss
@@ -92,6 +92,7 @@ $FontAwesomePath: '../libs/font-awesome/font/';
 @import '_component.flash';
 @import '_component.footer';
 @import '_component.forms';
+@import '_component.choice';
 @import '_component.greeter';
 @import '_component.icons';
 @import '_component.input-groups';

--- a/tests/js/PulsarFormComponentTest.js
+++ b/tests/js/PulsarFormComponentTest.js
@@ -91,12 +91,12 @@ describe('Pulsar Form Component - Select2 elements', function() {
             this.pulsarForm.init();
         });
 
-        it('Should add the is-selected class to the label', function() {
+        it('Should add the is-selected class to the label when input clicked', function() {
             this.$radioFoo.click();
             expect(this.$radioLabelFoo.hasClass('is-selected')).to.be.true;
         });
 
-        it('Should remove the is-selected class to the label if another option selected', function() {
+        it('Should remove the is-selected class to the label if another option selected on click', function() {
             this.$radioFoo.click();
             this.$radioBar.click();
             expect(this.$radioLabelFoo.hasClass('is-selected')).to.be.false;
@@ -110,15 +110,21 @@ describe('Pulsar Form Component - Select2 elements', function() {
             this.pulsarForm.init();
         });
 
-        it('Should add the is-selected class to the label', function() {
+        it('Should add the is-selected class to the label on click', function() {
             this.$checkFoo.click();
             expect(this.$checkLabelFoo.hasClass('is-selected')).to.be.true;
         });
 
-        it('Should not remove the is-selected class if another option selected', function() {
+        it('Should not remove the is-selected class if another option selected on click', function() {
             this.$checkFoo.click();
             this.$checkBar.click();
             expect(this.$checkLabelFoo.hasClass('is-selected')).to.be.true;
+        });
+
+        it('Should remove the is-selected class from the label if unchecked on click', function() {
+            this.$checkFoo.click();
+            this.$checkFoo.click();
+            expect(this.$checkLabelFoo.hasClass('is-selected')).to.be.false;
         });
 
     });

--- a/tests/js/PulsarFormComponentTest.js
+++ b/tests/js/PulsarFormComponentTest.js
@@ -1,55 +1,127 @@
 'use strict';
 
 var $ = require('jquery'),
-	PulsarFormComponent = require('../../js/PulsarFormComponent');
+    PulsarFormComponent = require('../../js/PulsarFormComponent');
 
-describe('Pulsar Form Component', function() {
+describe('Pulsar Form Component - Select2 elements', function() {
 
-	beforeEach(function() {
-		this.$html = $('<html></html>');
-		this.$body = $('<body></body>').appendTo(this.$html);
-		this.$markup = $('\
+    beforeEach(function() {
+        this.$html = $('<div id="html"></div>').appendTo('html');
+        this.$body = $('<div id="body"></div>').appendTo(this.$html);
+        this.$markup = $('\
 <form class="form">\
-	<select class="js-select2">\
-		<option>foo</option>\
-		<option>bar</option>\
-		<option>baz</option>\
-	</select>\
-	<select class="js-select2" data-html="true">\
-		<option>foo</option>\
-		<option>bar</option>\
-		<option>baz</option>\
-	</select>\
+    <select class="js-select2">\
+        <option>foo</option>\
+        <option>bar</option>\
+        <option>baz</option>\
+    </select>\
+    <select class="js-select2" data-html="true">\
+        <option>foo</option>\
+        <option>bar</option>\
+        <option>baz</option>\
+    </select>\
+\
+    <div class="form__group form-choice choice--block">\
+        <label class="control__label">Radio Test</label>\
+        <div class="controls">\
+            <label class="control__label">\
+                <input value="foo" name="foo" type="radio" class="form__control qa-foo radio">Foo</label>\
+            <label class="control__label">\
+                <input value="bar" name="foo" type="radio"class="form__control radio">Bar</label>\
+        </div>\
+    </div>\
+\
+    <div class="form__group form-choice choice--block">\
+        <label class="control__label">Checkbox Test</label>\
+        <div class="controls">\
+            <label class="control__label">\
+                <input value="foo" name="foo" type="checkbox" class="form__control qa-foo checkbox">Foo</label>\
+            <label class="control__label">\
+                <input value="bar" name="foo" type="checkbox"class="form__control checkbox">Bar</label>\
+        </div>\
+    </div>\
 </form>\
-').appendTo(this.$html);
+').appendTo(this.$body);
 
-		this.pulsarForm = new PulsarFormComponent(this.$html);
+        this.$radioFoo = this.$html.find('.radio[value="foo"]');
+        this.$radioBar = this.$html.find('.radio[value="bar"]');
+        this.$radioLabelFoo = this.$radioFoo.closest('.control__label');
 
-	});
+        this.$checkFoo = this.$html.find('.checkbox[value="foo"]');
+        this.$checkBar = this.$html.find('.checkbox[value="bar"]');
+        this.$checkLabelFoo = this.$checkFoo.closest('.control__label');
+        this.$checkLabelBar = this.$checkBar.closest('.control__label');
 
-	describe('Basic select2 elements', function() {
+        this.pulsarForm = new PulsarFormComponent(this.$html);
 
-		beforeEach(function() {
-			sinon.spy($.fn, 'select2');
-			this.pulsarForm.init();
-		});
+    });
 
-		it('should call the select2 plugin', function() {
-			expect($.fn.select2).to.have.been.called;
-		});
+    afterEach(function() {
+        this.$html.remove();
+    });
 
-	});
+    describe('Basic select2 elements', function() {
 
-	describe('Select2 elements with HTML', function() {
+        beforeEach(function() {
+            sinon.spy($.fn, 'select2');
+            this.pulsarForm.init();
+        });
 
-		beforeEach(function() {
-			this.pulsarForm.init();
-		});
+        it('should call the select2 plugin', function() {
+            expect($.fn.select2).to.have.been.called;
+        });
 
-		it('should call the select2 plugin', function() {
-			expect($.fn.select2).to.have.been.called;
-		});
+    });
 
-	});
+    describe('Select2 elements with HTML', function() {
+
+        beforeEach(function() {
+            this.pulsarForm.init();
+        });
+
+        it('should call the select2 plugin', function() {
+            expect($.fn.select2).to.have.been.called;
+        });
+
+    });
+
+    describe('Clicking a choice block radio input', function() {
+
+        beforeEach(function() {
+            this.pulsarForm.init();
+        });
+
+        it('Should add the is-selected class to the label', function() {
+            this.$radioFoo.click();
+            expect(this.$radioLabelFoo.hasClass('is-selected')).to.be.true;
+        });
+
+        it('Should remove the is-selected class to the label if another option selected', function() {
+            this.$radioFoo.click();
+            this.$radioBar.click();
+            expect(this.$radioLabelFoo.hasClass('is-selected')).to.be.false;
+        });
+
+    });
+
+    describe('Clicking a choice block checkbox input', function() {
+
+        beforeEach(function() {
+            this.pulsarForm.init();
+        });
+
+        it('Should add the is-selected class to the label', function() {
+            this.$checkFoo.click();
+            expect(this.$checkLabelFoo.hasClass('is-selected')).to.be.true;
+        });
+
+        it('Should not remove the is-selected class if another option selected', function() {
+            this.$checkFoo.click();
+            this.$checkBar.click();
+            expect(this.$checkLabelFoo.hasClass('is-selected')).to.be.true;
+        });
+
+    });
+
 
 });

--- a/views/lexicon/tabs/forms.html.twig
+++ b/views/lexicon/tabs/forms.html.twig
@@ -259,6 +259,55 @@
         }}
 
         {{
+            form.choice({
+                'class': 'choice--block form__group--medium',
+                'label': 'Choice block radios',
+                'options': [
+                    {
+                        'label': html.icon('bold') ~ ' Bold',
+                        'value': 'bold',
+                        'name': 'foo'
+                    },
+                    {
+                        'label': html.icon('italic') ~ ' Italic',
+                        'value': 'italic',
+                        'name': 'foo'
+                    },
+                    {
+                        'label': html.icon('underline') ~ ' Underline',
+                        'value': 'underline',
+                        'name': 'foo'
+                    },
+                ]
+            })
+        }}
+
+        {{
+            form.choice({
+                'class': 'choice--block choice--block-inline form__group--medium',
+                'label': 'Choice block checkboxes (& inline)',
+                'multiple': true,
+                'options': [
+                    {
+                        'label': html.icon('bold') ~ ' Bold',
+                        'value': 'bold',
+                        'name': 'foo'
+                    },
+                    {
+                        'label': html.icon('italic') ~ ' Italic',
+                        'value': 'italic',
+                        'name': 'foo'
+                    },
+                    {
+                        'label': html.icon('underline') ~ ' Underline',
+                        'value': 'underline',
+                        'name': 'foo'
+                    },
+                ]
+            })
+        }}
+
+        {{
             form.toggle_switch({
                 'checked': false,
                 'label': 'Toggle',


### PR DESCRIPTION
## Choice Block

Block styling is available for the choice helper, add the `choice--block` modifier class. Pass a standard [form width modifier](styleguide-forms.md) to the choice helper's `class` option to control the width of all options.

```
{{
    form.choice({
        'label': 'Blocky options',
        'class': 'choice--block form__group--medium',
        'options': [ ... ]
    })
}}
```

<p data-height="180" data-theme-id="21222" data-slug-hash="XdzwME" data-default-tab="result" data-user="pulsar" class="codepen">See the Pen <a href="http://codepen.io/pulsar/pen/XdzwME/">XdzwME</a> by Pulsar (<a href="http://codepen.io/pulsar">@pulsar</a>) on <a href="http://codepen.io">CodePen</a>.</p>
<script async src="//assets.codepen.io/assets/embed/ei.js"></script>

Add `choice--block choice--block-inline` to lay the options out horizontally.

<p data-height="80" data-theme-id="21222" data-slug-hash="pydmrr" data-default-tab="result" data-user="pulsar" class="codepen">See the Pen <a href="http://codepen.io/pulsar/pen/pydmrr/">pydmrr</a> by Pulsar (<a href="http://codepen.io/pulsar">@pulsar</a>) on <a href="http://codepen.io">CodePen</a>.</p>
<script async src="//assets.codepen.io/assets/embed/ei.js"></script>

![choice-box](https://cloud.githubusercontent.com/assets/18653/14345777/d12cd452-fca6-11e5-96ed-9a3a6b5f3db8.gif)

![choice-box-responsive](https://cloud.githubusercontent.com/assets/18653/14345778/d4e0f2c2-fca6-11e5-9fa1-08862743c3dd.gif)


Closes #139