### PR TITLE
Add z-index: -1; to prevent table-selection TH from hiding TD border.

### DIFF
--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -120,6 +120,7 @@
     max-width: 60px;
     position: relative;
     width: 60px;
+    z-index: -1;
 }
 
 .table-link {


### PR DESCRIPTION
Resolves #152 