### PR TITLE
Lock to a known working version of node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "mocha-phantomjs": "^4.0.2",
     "mochify": "~2.15.0",
     "mochify-istanbul": "^2.4.1",
+    "node-sass": "3.4.2",
     "phantomjs": "^1.9.19",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",


### PR DESCRIPTION
node-sass `3.5.2` (a dependency of grunt-sass) causes "segmentation fault 11" locally and on Jenkins/Travis.

Locking to `3.4.2` for now to prevent this error.

Closes #166 