### PR TITLE
Block list helper

### DIFF
--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-class.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-class.html
@@ -1,0 +1,5 @@
+<ul class="block-list foo">
+    <li class="block-list__item">foo</li>
+    <li class="block-list__item">bar</li>
+    <li class="block-list__item">baz</li>
+</ul>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-class.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-class.html.twig
@@ -1,0 +1,14 @@
+{#
+    Test basic block list method
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.block_list({
+        'class': 'foo',
+        'items': [
+            {'value': 'foo'},
+            {'value': 'bar'},
+            {'value': 'baz'}
+        ]
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-div-header-footer.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-div-header-footer.html
@@ -1,0 +1,7 @@
+<div class="block-list">
+    <div class="block-list__header">header</div>
+    <div class="block-list__item">foo</div>
+    <div class="block-list__item">bar</div>
+    <div class="block-list__item">baz</div>
+    <div class="block-list__footer">footer</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-div-header-footer.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-div-header-footer.html.twig
@@ -1,0 +1,16 @@
+{#
+    Test basic block list method
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.block_list({
+        'type': 'div',
+        'footer': 'footer',
+        'header': 'header',
+        'items': [
+            {'value': 'foo'},
+            {'value': 'bar'},
+            {'value': 'baz'}
+        ]
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-div.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-div.html
@@ -1,0 +1,5 @@
+<div class="block-list">
+    <div class="block-list__item">foo</div>
+    <div class="block-list__item">bar</div>
+    <div class="block-list__item">baz</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-div.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-div.html.twig
@@ -1,0 +1,14 @@
+{#
+    Test basic block list method
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.block_list({
+        'type': 'div',
+        'items': [
+            {'value': 'foo'},
+            {'value': 'bar'},
+            {'value': 'baz'}
+        ]
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-footer.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-footer.html
@@ -1,0 +1,6 @@
+<ul class="block-list">
+    <li class="block-list__item">foo</li>
+    <li class="block-list__item">bar</li>
+    <li class="block-list__item">baz</li>
+    <li class="block-list__footer">footer</li>
+</ul>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-footer.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-footer.html.twig
@@ -1,0 +1,14 @@
+{#
+    Test basic block list method
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.block_list({
+        'footer': 'footer',
+        'items': [
+            {'value': 'foo'},
+            {'value': 'bar'},
+            {'value': 'baz'}
+        ]
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-header.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-header.html
@@ -1,0 +1,6 @@
+<ul class="block-list">
+    <li class="block-list__header">header</li>
+    <li class="block-list__item">foo</li>
+    <li class="block-list__item">bar</li>
+    <li class="block-list__item">baz</li>
+</ul>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-header.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-header.html.twig
@@ -1,0 +1,14 @@
+{#
+    Test basic block list method
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.block_list({
+        'header': 'header',
+        'items': [
+            {'value': 'foo'},
+            {'value': 'bar'},
+            {'value': 'baz'}
+        ]
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-link-header-footer.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-link-header-footer.html
@@ -1,0 +1,7 @@
+<div class="block-list">
+    <div class="block-list__header">header</div>
+    <a href="#foo" class="block-list__item">foo</a>
+    <a href="#bar" class="block-list__item">bar</a>
+    <a href="#baz" class="block-list__item">baz</a>
+    <div class="block-list__footer">footer</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-link-header-footer.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-link-header-footer.html.twig
@@ -1,0 +1,16 @@
+{#
+    Test basic block list method
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.block_list({
+        'type': 'link',
+        'footer': 'footer',
+        'header': 'header',
+        'items': [
+            {'label': 'foo', 'href': '#foo'},
+            {'label': 'bar', 'href': '#bar'},
+            {'label': 'baz', 'href': '#baz'}
+        ]
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-link.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-link.html
@@ -1,0 +1,5 @@
+<div class="block-list">
+    <a href="#foo" class="block-list__item">foo</a>
+    <a href="#bar" class="block-list__item">bar</a>
+    <a href="#baz" class="block-list__item">baz</a>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-link.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-link.html.twig
@@ -1,0 +1,14 @@
+{#
+    Test basic block list method
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.block_list({
+        'type': 'link',
+        'items': [
+            {'label': 'foo', 'href': '#foo'},
+            {'label': 'bar', 'href': '#bar'},
+            {'label': 'baz', 'href': '#baz'}
+        ]
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-ol.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-ol.html
@@ -1,0 +1,5 @@
+<ol class="block-list">
+    <li class="block-list__item">foo</li>
+    <li class="block-list__item">bar</li>
+    <li class="block-list__item">baz</li>
+</ol>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-ol.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list-ol.html.twig
@@ -1,0 +1,14 @@
+{#
+    Test basic block list method
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.block_list({
+        'type': 'ol',
+        'items': [
+            {'value': 'foo'},
+            {'value': 'bar'},
+            {'value': 'baz'}
+        ]
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list.html
@@ -1,0 +1,5 @@
+<ul class="block-list">
+    <li class="block-list__item">foo</li>
+    <li class="block-list__item">bar</li>
+    <li class="block-list__item">baz</li>
+</ul>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/block_list.html.twig
@@ -1,0 +1,13 @@
+{#
+    Test basic block list method
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.block_list({
+        'items': [
+            {'value': 'foo'},
+            {'value': 'bar'},
+            {'value': 'baz'}
+        ]
+    })
+}}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -190,19 +190,38 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
     {% endif %}
 
     <{{ mainTag }} class="block-list">
-    {% for item in options.items %}
 
+    {% if options.header is defined and options.header is not empty %}
+        {% set header = {'value': options.header, 'class': 'block-list__header'} %}
+
+        {% if options.type is defined and (options.type == 'div' or options.type == 'link') %}
+            {{ html.div(header) }}
+        {% else %}
+            {{ html.li(header) }}
+        {% endif %}
+    {% endif %}
+
+    {% for item in options.items %}
         {% set item = item|merge({'class': 'block-list__item'}) %}
 
         {% if options.type is defined and options.type == 'div' %}
             {{ html.div(item) }}
-        {% elseif  options.type is defined and options.type == 'link' %}
+        {% elseif options.type is defined and options.type == 'link' %}
             {{ html.link(item) }}
         {% else %}
             {{ html.li(item) }}
         {% endif %}
-
     {% endfor %}
+
+    {% if options.footer is defined and options.footer is not empty %}
+        {% set footer = {'value': options.footer, 'class': 'block-list__footer'} %}
+
+        {% if options.type is defined and (options.type == 'div' or options.type == 'link') %}
+            {{ html.div(footer) }}
+        {% else %}
+            {{ html.li(footer) }}
+        {% endif %}
+    {% endif %}
     </{{ mainTag }}>
 
 {% endspaceless %}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -133,6 +133,84 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 {# -----------------------------------------------------------------------------
 
+# Block list
+
+## Example usage
+
+```twig
+{{
+    html.block_list({
+        'items': [
+            {'value': 'foo'},
+            {'value': 'bar'},
+            {'value': 'baz'}
+        ]
+    })
+}}
+```
+
+## Example using `link` markup scheme
+
+```twig
+{{
+    html.block_list({
+        'type': 'link',
+        'items': [
+            {'label': 'foo', 'href': '#foo'},
+            {'label': 'bar', 'href': '#bar'},
+            {'label': 'baz', 'href': '#baz'}
+        ]
+    })
+}}
+```
+
+## Options
+
+Option | Type   | Description
+------ | ------ | --------------------------------------------------------------
+class  | string | CSS classes, space separated
+footer | string | String/Markup to display in the footer row
+header | string | String/Markup to display in the header row
+id     | string | A unique identifier, if required
+items  | array  | An `options` hash which will added as attributes to the `div`, `li` or `a` element (defined by `type`)
+type   | string | Markup scheme to use: `ul` (default), `ol`, `div` or `link`
+data-* | string | Data attributes, eg: `'data-foo': 'bar'`
+
+#}
+{% macro block_list(options) %}
+{% spaceless %}
+    {% import _self as html %}
+
+    {% set mainTag = 'ul' %}
+
+    {% if options.type is defined and options.type == 'link' %}
+        {% set mainTag = 'div' %}
+    {% elseif options.type is defined and options.type != 'ul' %}
+        {% set mainTag = options.type %}
+    {% endif %}
+
+    <{{ mainTag }} class="block-list">
+    {% for item in options.items %}
+
+        {% set item = item|merge({'class': 'block-list__item'}) %}
+
+            {% if options.type is defined and options.type == 'div' %}
+                {{ html.div(item) }}
+            {% elseif  options.type is defined and options.type == 'link' %}
+                {{ html.link(item) }}
+            {% else %}
+                {{ html.li(item) }}
+            {% endif %}
+
+    {% endfor %}
+    </{{ mainTag }}>
+
+{% endspaceless %}
+{% endmacro %}
+
+
+{# -----------------------------------------------------------------------------
+
 # Button
 
 ## Example usage
@@ -341,6 +419,42 @@ placement    | string | the alignment of the dropdown menu, `left` (default) or 
                 'items': options.items|default
             })
         }}
+    </div>
+
+{% endspaceless %}
+{% endmacro %}
+
+{# -----------------------------------------------------------------------------
+
+# Div
+
+Simple wrapper to create `<div>` elements, mainly used from within other helpers..
+
+## Example usage
+
+```twig
+{{
+    html.div({
+        value: 'foo'
+    })
+}}
+```
+
+## Options
+
+Option | Type   | Description
+------ | ------ | --------------------------------------------------------------
+class  | string | CSS classes, space separated
+id     | string | A unique identifier, if required
+value  | string | The value to display
+data-* | string | Data attributes, eg: `'data-foo': 'bar'`
+
+#}
+{% macro div(options) %}
+{% spaceless %}
+
+    <div{{ attributes(options|exclude('value')) }}>
+        {{- options.value|raw -}}
     </div>
 
 {% endspaceless %}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -194,13 +194,13 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
         {% set item = item|merge({'class': 'block-list__item'}) %}
 
-            {% if options.type is defined and options.type == 'div' %}
-                {{ html.div(item) }}
-            {% elseif  options.type is defined and options.type == 'link' %}
-                {{ html.link(item) }}
-            {% else %}
-                {{ html.li(item) }}
-            {% endif %}
+        {% if options.type is defined and options.type == 'div' %}
+            {{ html.div(item) }}
+        {% elseif  options.type is defined and options.type == 'link' %}
+            {{ html.link(item) }}
+        {% else %}
+            {{ html.li(item) }}
+        {% endif %}
 
     {% endfor %}
     </{{ mainTag }}>

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -189,7 +189,10 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
         {% set mainTag = options.type %}
     {% endif %}
 
-    <{{ mainTag }} class="block-list">
+    <{{ mainTag }}{{ attributes(options
+        |exclude('footer header items type')
+        |defaults({'class': 'block-list'})
+    )}}>
 
     {% if options.header is defined and options.header is not empty %}
         {% set header = {'value': options.header, 'class': 'block-list__header'} %}


### PR DESCRIPTION
## Example usage

```twig
{{
    html.block_list({
        'items': [
            {'value': 'foo'},
            {'value': 'bar'},
            {'value': 'baz'}
        ]
    })
}}
```

## Example using `link` markup scheme

```twig
{{
    html.block_list({
        'type': 'link',
        'items': [
            {'label': 'foo', 'href': '#foo'},
            {'label': 'bar', 'href': '#bar'},
            {'label': 'baz', 'href': '#baz'}
        ]
    })
}}
```

## Options

Option | Type   | Description
------ | ------ | --------------------------------------------------------------
class  | string | CSS classes, space separated
footer | string | String/Markup to display in the footer row
header | string | String/Markup to display in the header row
id     | string | A unique identifier, if required
items  | array  | An `options` hash which will added as attributes to the `div`, `li` or `a` element (defined by `type`)
type   | string | Markup scheme to use: `ul` (default), `ol`, `div` or `link`
data-* | string | Data attributes, eg: `'data-foo': 'bar'`

Closes #172