### PR TITLE
Stop inline choice block layout breaking when a label wraps onto multiple lines

### DIFF
--- a/stylesheets/_component.choice.scss
+++ b/stylesheets/_component.choice.scss
@@ -59,5 +59,9 @@
     }
     > .controls > .control__label {
         clear: none;
+
+        &:last-child {
+            margin: 0 5px 5px 0;
+        }
     }
 }

--- a/stylesheets/_component.choice.scss
+++ b/stylesheets/_component.choice.scss
@@ -52,6 +52,11 @@
 }
 
 .choice--block-inline {
+    .controls {
+        display: flex;
+        flex-wrap: wrap;
+        width: 100% !important;
+    }
     > .controls > .control__label {
         clear: none;
     }

--- a/views/lexicon/forms.html.twig
+++ b/views/lexicon/forms.html.twig
@@ -9,9 +9,8 @@
 
 {% set heading = 'Form Helpers' %}
 
-{% set tab_text %}
-    {% include 'lexicon/forms/text.html.twig' %}
-{% endset %}
+{% set tab_text %}{% include 'lexicon/forms/text.html.twig' %}{% endset %}
+{% set tab_choice %}{% include 'lexicon/forms/choice.html.twig' %}{% endset %}
 
 {%
     set nav_data = {
@@ -56,10 +55,15 @@
 {%
     set tabs_content = [
         {
+          "id"    : "choice",
+          "label" : "Choice",
+          "src"   : tab_choice,
+          "active": true
+        },
+        {
           "id"    : "text",
           "label" : "Text",
-          "src"   : tab_text,
-          "active": true
+          "src"   : tab_text
         }
     ]
 %}

--- a/views/lexicon/forms/choice.html.twig
+++ b/views/lexicon/forms/choice.html.twig
@@ -1,0 +1,109 @@
+{% extends '@pulsar/pulsar/components/tab.html.twig' %}
+
+{% block tab_content %}
+
+    {{
+        form.create()
+    }}
+
+
+    {{
+        form.choice({
+            'class': 'choice--block form__group--medium',
+            'label': 'Choice block radios',
+            'options': [
+                {
+                    'label': html.icon('bold') ~ ' Bold',
+                    'value': 'bold',
+                    'name': 'foo'
+                },
+                {
+                    'label': html.icon('italic') ~ ' Italic',
+                    'value': 'italic',
+                    'name': 'foo'
+                },
+                {
+                    'label': html.icon('underline') ~ ' Underline',
+                    'value': 'underline',
+                    'name': 'foo'
+                },
+            ]
+        })
+    }}
+
+    {{
+        form.choice({
+            'class': 'choice--block choice--block-inline form__group--medium',
+            'optimize': 'few',
+            'label': 'Choice block radios',
+            'options': [
+                {
+                    'label': html.icon('bold') ~ ' rah rah rah rah rah rah rah rah rah rah rah rah rah ',
+                    'value': 'bold',
+                    'name': 'foo'
+                },
+                {
+                    'label': html.icon('italic') ~ ' Italic',
+                    'value': 'italic',
+                    'name': 'foo'
+                },
+                {
+                    'label': html.icon('italic') ~ ' Italic',
+                    'value': 'italic',
+                    'name': 'foo'
+                },
+                {
+                    'label': html.icon('italic') ~ ' Italic',
+                    'value': 'italic',
+                    'name': 'foo'
+                }
+            ]
+        })
+    }}
+
+    {{
+        form.choice({
+            'class': 'choice--block choice--block-inline form__group--medium',
+            'label': 'Choice block checkboxes (& inline)',
+            'multiple': true,
+            'options': [
+                {
+                    'label': html.icon('bold') ~ ' Bold',
+                    'value': 'bold',
+                    'name': 'foo'
+                },
+                {
+                    'label': html.icon('italic') ~ ' Italic',
+                    'value': 'italic',
+                    'name': 'foo'
+                },
+                {
+                    'label': html.icon('underline') ~ ' Underline',
+                    'value': 'underline',
+                    'name': 'foo'
+                },
+            ]
+        })
+    }}
+
+
+
+    {{
+        form.end()
+    }}
+
+{% endblock tab_content %}
+
+{% block tab_sidebar %}
+    <a href="https://jadu.gitbooks.io/pulsar/content/text.html">
+        <img src="../../../images/cover.png" alt="Pulsar documentation front cover" width="157px" />
+    </a>
+    {{
+        html.button({
+            'label': 'View Documentation',
+            'type': 'link',
+            'href': 'https://jadu.gitbooks.io/pulsar/content/choice.html'
+        })
+    }}
+
+{% endblock tab_sidebar %}

--- a/views/lexicon/forms/text.html.twig
+++ b/views/lexicon/forms/text.html.twig
@@ -191,7 +191,7 @@
         form.text({
             'label': 'Prepended &amp; Appended',
             'append': '.00',
-
+            'prepend': '£'
         })
     }}
 


### PR DESCRIPTION
Added some flex box goodness for modern browsers top stop choice block layouts looking too screwy when labels wrap to separate lines.

<img width="865" alt="screen shot 2016-04-24 at 13 28 19" src="https://cloud.githubusercontent.com/assets/18653/14767546/7378c9ec-0a20-11e6-9621-36da07bbf595.png">

This PR addresses a single real-world issue we're resolving for Continuum CMS, a couple of other tickets have been created for related enhancements that will need more time to investigate.

* #176 has been added to test https://github.com/10up/flexibility as a suitable IE8 polyfill.
* #175 has been created to add the ability for choice blocks to hide their inputs

Closes #171