### PR TITLE
Update node-sass dependency and fix sass issue with block-list extends

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mocha-phantomjs": "^4.0.2",
     "mochify": "~2.15.0",
     "mochify-istanbul": "^2.4.1",
-    "node-sass": "3.4.2",
+    "node-sass": "^3.7.0",
     "phantomjs": "^1.9.19",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",

--- a/stylesheets/_component.block-list.scss
+++ b/stylesheets/_component.block-list.scss
@@ -146,7 +146,6 @@ a.block-list__item:hover {
 }
 
 .block-list--bordered {
-    @extend .block-list--padded;
     border: 1px solid color(border);
     border-radius: $border-radius;
 


### PR DESCRIPTION
`.block-list--padded` doesn't exist, node-sass has been updated and now reports this (rightly) as an error condition

Fixes #187 