### PR TITLE
Improve styling of file input state variations

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -64,7 +64,7 @@ fieldset {
         padding: 0;
 
         @include respond-min($screen-tablet) {
-            padding: 11px 0 0;
+            padding: 14px 0 0;
         }
 
         @include ie-lte(9) {
@@ -83,7 +83,7 @@ fieldset {
         .has-success &.file,
         .has-warning &.file,
         .has-error &.file {
-            padding: 11px 10px;
+            padding: 14px 10px 13px;
         }
     }
 

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -71,6 +71,20 @@ fieldset {
             border: 1px solid $input-border;
             border-radius: 0;
         }
+
+        &.is-disabled {
+            background-color: color(white);
+            color: color(text, disabled);
+        }
+    }
+
+    @include respond-min($screen-tablet) {
+        .has-changed &.file,
+        .has-success &.file,
+        .has-warning &.file,
+        .has-error &.file {
+            padding: 11px 10px;
+        }
     }
 
     // IE8 - position text in the middle of inputs

--- a/views/lexicon/forms.html.twig
+++ b/views/lexicon/forms.html.twig
@@ -67,7 +67,8 @@
         {
           "id"    : "buttongroup",
           "label" : "Button Group",
-          "src"   : tab_buttongroup
+          "src"   : tab_buttongroup,
+          "active": true
         },
         {
           "id"    : "checkbox",
@@ -82,8 +83,7 @@
         {
           "id"    : "date",
           "label" : "Date",
-          "src"   : tab_date,
-          "active": true
+          "src"   : tab_date
         },
         {
           "id"    : "file",


### PR DESCRIPTION
Add extra padding around element only when it's using a state variation so that the default help blocks don't get pushed down too far.

![screen shot 2016-05-04 at 09 52 56](https://cloud.githubusercontent.com/assets/18653/15011816/ccd053b6-11eb-11e6-9ba2-2d3e3c4faa91.png)

Closes #182 