### PR TITLE
Stop toggle switch labels from inheriting state modified text colour

### DIFF
--- a/stylesheets/_component.toggle-switch.scss
+++ b/stylesheets/_component.toggle-switch.scss
@@ -95,3 +95,21 @@
         }
     }
 }
+
+// State class overrides to make sure internal 'icon' doesn't inherit the state
+// colour styling as they look terrible and don't meet AA
+.has-changed,
+.has-success,
+.has-warning,
+.has-info,
+.has-error,
+.has-danger {
+    .toggle-switch-label.control__label {
+        color: color(white);
+    }
+}
+
+.toggle-switch.is-disabled + .toggle-switch-label {
+    opacity: .5;
+}
+


### PR DESCRIPTION
<img width="805" alt="screen shot 2016-05-03 at 20 28 56" src="https://cloud.githubusercontent.com/assets/18653/15011831/e50536ea-11eb-11e6-88ff-87771e6d17c1.png">

Closes #181 