### PR TITLE
Choice block inputs with `selected` should have `is-selected` class applied on page load

### DIFF
--- a/js/PulsarFormComponent.js
+++ b/js/PulsarFormComponent.js
@@ -35,7 +35,22 @@ PulsarFormComponent.prototype.init = function () {
 
     // Block styled checkboxes and radios
     var choiceBlock = component.$html.find(".choice--block");
+
+    // set up choice block states on load
+    $.each(choiceBlock, function() {
+        component.initSelectionButtons($(this));
+    });
+
+    // choice block click behaviour
     choiceBlock.on('change', '.controls input[type="checkbox"], .controls input[type="radio"]', component.selectionButtons);
+
+};
+
+PulsarFormComponent.prototype.initSelectionButtons = function(e) {
+
+    e.find('input[type="checkbox"]:checked, input[type="radio"]:checked')
+        .closest('.control__label')
+        .addClass('is-selected');
 
 };
 

--- a/tests/js/PulsarFormComponentTest.js
+++ b/tests/js/PulsarFormComponentTest.js
@@ -27,7 +27,9 @@ describe('Pulsar Form Component - Select2 elements', function() {
             <label class="control__label">\
                 <input value="foo" name="foo" type="radio" class="form__control qa-foo radio">Foo</label>\
             <label class="control__label">\
-                <input value="bar" name="foo" type="radio"class="form__control radio">Bar</label>\
+                <input value="bar" name="foo" type="radio" class="form__control radio">Bar</label>\
+            <label class="control__label">\
+                <input value="baz" name="foo" type="radio" class="form__control radio" checked>Baz</label>\
         </div>\
     </div>\
 \
@@ -37,7 +39,9 @@ describe('Pulsar Form Component - Select2 elements', function() {
             <label class="control__label">\
                 <input value="foo" name="foo" type="checkbox" class="form__control qa-foo checkbox">Foo</label>\
             <label class="control__label">\
-                <input value="bar" name="foo" type="checkbox"class="form__control checkbox">Bar</label>\
+                <input value="bar" name="foo" type="checkbox" class="form__control checkbox">Bar</label>\
+            <label class="control__label">\
+                <input value="baz" name="foo" type="checkbox" class="form__control checkbox" checked>Baz</label>\
         </div>\
     </div>\
 </form>\
@@ -45,12 +49,16 @@ describe('Pulsar Form Component - Select2 elements', function() {
 
         this.$radioFoo = this.$html.find('.radio[value="foo"]');
         this.$radioBar = this.$html.find('.radio[value="bar"]');
+        this.$radioBaz = this.$html.find('.radio[value="baz"]');
         this.$radioLabelFoo = this.$radioFoo.closest('.control__label');
+        this.$radioLabelBaz = this.$radioBaz.closest('.control__label');
 
         this.$checkFoo = this.$html.find('.checkbox[value="foo"]');
         this.$checkBar = this.$html.find('.checkbox[value="bar"]');
+        this.$checkBaz = this.$html.find('.checkbox[value="baz"]');
         this.$checkLabelFoo = this.$checkFoo.closest('.control__label');
         this.$checkLabelBar = this.$checkBar.closest('.control__label');
+        this.$checkLabelBaz = this.$checkBaz.closest('.control__label');
 
         this.pulsarForm = new PulsarFormComponent(this.$html);
 
@@ -125,6 +133,22 @@ describe('Pulsar Form Component - Select2 elements', function() {
             this.$checkFoo.click();
             this.$checkFoo.click();
             expect(this.$checkLabelFoo.hasClass('is-selected')).to.be.false;
+        });
+
+    });
+
+    describe('Pre-checked choice block inputs', function() {
+
+        beforeEach(function() {
+            this.pulsarForm.init();
+        });
+
+        it('Should have the is-selected class applied (radio)', function() {
+            expect(this.$radioLabelBaz.hasClass('is-selected')).to.be.true;
+        });
+
+        it('Should have the is-selected class applied (checkbox)', function() {
+            expect(this.$checkLabelBaz.hasClass('is-selected')).to.be.true;
         });
 
     });

--- a/views/lexicon/forms/choice.html.twig
+++ b/views/lexicon/forms/choice.html.twig
@@ -149,7 +149,8 @@
                 {
                     'label': html.icon('italic') ~ ' Italic',
                     'value': 'italic',
-                    'name': 'foo'
+                    'name': 'foo',
+                    'checked': true
                 },
                 {
                     'label': html.icon('underline') ~ ' Underline',
@@ -204,12 +205,14 @@
                 {
                     'label': html.icon('italic') ~ ' Italic',
                     'value': 'italic',
-                    'name': 'foo'
+                    'name': 'foo',
+                    'checked': true
                 },
                 {
                     'label': html.icon('underline') ~ ' Underline',
                     'value': 'underline',
-                    'name': 'foo'
+                    'name': 'foo',
+                    'checked': true
                 },
             ]
         })


### PR DESCRIPTION
Observe new behaviour when page refreshed:

![choice-refresh](https://cloud.githubusercontent.com/assets/18653/15027915/fe61f734-123d-11e6-8aa3-93f0fd7b6465.gif)

Closes #192