### PR TITLE
Fix odd datatables row highlight in chrome and restore functionality in firefox

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -61,8 +61,8 @@
             bAutoWidth: false,
             columnDefs: [
                 { className: 'control', orderable: false, targets: 0 },
-                { "searchable": false, "targets": 0 },
-                { "orderable": false, "targets": 0 }
+                { "searchable": false, "targets": [0, 1] },
+                { "orderable": false, "targets": [0, 1] }
             ],
             oLanguage: {
              sSearch: "Filter:"
@@ -73,8 +73,9 @@
                 }
             },
             select: {
-                style:    'multi',
-                selector: 'td.table-selection'
+                className: 'dt-row-selected',
+                style:     'multi',
+                selector:  'td.table-selection'
             },
             stateSave: false,
             tableTools: {

--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -1,3 +1,33 @@
+.table-responsive,
+.table-selection {
+    text-align: center;
+    min-width: 25px;
+    max-width: 25px;
+    padding-left: 5px;
+    padding-right: 5px;
+    position: relative;
+    user-select: none;
+    width: 25px;
+    z-index: 1;
+}
+
+.dt-row-selected > td {
+    background-color: color(background, selected);
+
+    a,
+    a:link {
+        border-bottom-color: color(link, dark);
+        color: color(link, dark);
+    }
+
+    .table-row-select::before {
+        content: '\f14a';
+    }
+}
+
+
+
+
 
 .datatable {
     border-top: 1px solid color(border);
@@ -29,16 +59,6 @@
 .table__tr {
     vertical-align: top;
 
-    &.selected .table__td {
-        background-color: color(background, selected);
-
-        a,
-        a:link {
-            border-bottom-color: color(link, dark);
-            color: color(link, dark);
-        }
-    }
-
     &.is-disabled .table__td {
         &,
         & > * {
@@ -58,10 +78,6 @@
     font-size: 14px;
     position: relative;
     top: 1px;
-}
-
-.table__tr.selected .table-row-select::before {
-    content: '\f14a';
 }
 
 .table__th,
@@ -106,7 +122,7 @@
 
 // scss-lint:disable SelectorFormat
 .table__th.sorting_disabled:hover {
-    border: 0;
+    // border: 0;
     text-decoration: none;
 
     > .table-link {
@@ -122,16 +138,7 @@
     width: 1%;
 }
 
-.table-responsive,
-.table-selection {
-    text-align: center;
-    min-width: 30px;
-    max-width: 30px;
-    position: relative;
-    user-select: none;
-    width: 30px;
-    z-index: -1;
-}
+
 
 .table-link {
     border-bottom: 1px dotted color(gray, light);

--- a/stylesheets/_component.tables.scss
+++ b/stylesheets/_component.tables.scss
@@ -1,6 +1,6 @@
 table {
     background-color: $table-bg;
-    border-collapse: collapse;
+    border-collapse: separate;
 }
 
 th {


### PR DESCRIPTION
Mostly caused by a `-1` z-index