### PR TITLE
Add ability for `form.create` to create a hidden input with the value of `options.nonce`

### DIFF
--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/create-nonce.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/create-nonce.html
@@ -1,0 +1,2 @@
+<form method="POST" enctype="application/x-www-form-urlencoded" class="form">
+<input type="hidden" name="nonce" value="D2A619A309DCE1BEF50F01F08EB764B42D9B36BF8128A8D303FD6DCF91E5FDD6" />

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/create-nonce.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/create-nonce.html
@@ -1,2 +1,2 @@
 <form method="POST" enctype="application/x-www-form-urlencoded" class="form">
-<input type="hidden" name="nonce" value="D2A619A309DCE1BEF50F01F08EB764B42D9B36BF8128A8D303FD6DCF91E5FDD6" />
+<input name="nonce" value="D2A619A309DCE1BEF50F01F08EB764B42D9B36BF8128A8D303FD6DCF91E5FDD6" type="hidden" />

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/create-nonce.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/create-nonce.html.twig
@@ -2,7 +2,9 @@
     Test basic create method with nonce
 #}
 {% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
-{% set nonce = 'D2A619A309DCE1BEF50F01F08EB764B42D9B36BF8128A8D303FD6DCF91E5FDD6' %}
+
 {{
-    form.create()
+    form.create({
+        'nonce': 'D2A619A309DCE1BEF50F01F08EB764B42D9B36BF8128A8D303FD6DCF91E5FDD6'
+    })
 }}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/create-nonce.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/create-nonce.html.twig
@@ -1,0 +1,8 @@
+{#
+    Test basic create method with nonce
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{% set nonce = 'D2A619A309DCE1BEF50F01F08EB764B42D9B36BF8128A8D303FD6DCF91E5FDD6' %}
+{{
+    form.create()
+}}

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -432,7 +432,7 @@ Option  | Type   | Description
 ------- | ------ | -------------------------------------------------------------
 action  | string | URL to post to, will submit to self if empty
 class   | string | A space separated list of class names
-nonce   | string | Random string used to prevent CSRF, adds a hidden `nonce` input after <form>
+nonce   | string | Random string used to prevent CSRF, adds a hidden `nonce` input after `<form>`
 enctype | string | How the form-data should be encoded (requires method = POST)
 id      | string | A unique identifier, if required
 name    | string | The name of the form

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -432,6 +432,7 @@ Option  | Type   | Description
 ------- | ------ | -------------------------------------------------------------
 action  | string | URL to post to, will submit to self if empty
 class   | string | A space separated list of class names
+nonce   | string | CSRF token, will look for a template `nonce` value by default
 enctype | string | How the form-data should be encoded (requires method = POST)
 id      | string | A unique identifier, if required
 name    | string | The name of the form

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -432,7 +432,7 @@ Option  | Type   | Description
 ------- | ------ | -------------------------------------------------------------
 action  | string | URL to post to, will submit to self if empty
 class   | string | A space separated list of class names
-nonce   | string | CSRF token, will look for a template `nonce` value by default
+nonce   | string | Random string used to prevent CSRF, adds a hidden `nonce` input after <form>
 enctype | string | How the form-data should be encoded (requires method = POST)
 id      | string | A unique identifier, if required
 name    | string | The name of the form
@@ -494,7 +494,11 @@ attribute on the `form` element will be set to `POST`.
         {% set options = options|merge({'enctype': options.enctype|default('application/x-www-form-urlencoded')}) %}
     {% endif %}
 
-    <form{{ attributes(options|defaults(defaults)) }}>
+    <form{{ attributes(options|defaults(defaults)|exclude('nonce')) }}>
+
+    {% if options.nonce is defined and options.nonce is not empty %}
+        {{ form.hidden({'name': 'nonce', 'value': options.nonce}) }}
+    {% endif %}
 
     {{ methodInput|default }}
 


### PR DESCRIPTION
Option  | Type   | Description
------- | ------ | -------------------------------------------------------------
nonce   | string | Random string used to prevent CSRF, adds a hidden `nonce` input after `<form>`

Closes #209 