### PR TITLE
Add breadcrumb helper

### DIFF
--- a/stylesheets/_component.breadcrumb.scss
+++ b/stylesheets/_component.breadcrumb.scss
@@ -1,5 +1,6 @@
 .breadcrumb {
     color: color(gray, light);
+    margin-bottom: 11px;
     font-size: $font-size-small;
 
     a,

--- a/stylesheets/_component.toolbar.scss
+++ b/stylesheets/_component.toolbar.scss
@@ -7,8 +7,8 @@
 
     @include respond-min($screen-desktop) {
         background-color: color(white);
-        height: 72px;
-        margin-bottom: 11px;
+        height: 60px;
+        margin-bottom: 0;
         padding: 14px 20px;
     }
 }

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/nav/breadcrumb-items.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/nav/breadcrumb-items.html
@@ -1,0 +1,5 @@
+<nav class="breadcrumb">
+    <a href="#foo">foo</a> /
+    <a href="#bar">bar</a> /
+    <a href="#baz">baz</a>
+</nav>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/nav/breadcrumb-items.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/nav/breadcrumb-items.html.twig
@@ -1,0 +1,9 @@
+{% import '@pulsar/pulsar/v2/helpers/nav.html.twig' as nav %}
+{%
+    set breadcrumbs = [
+        {'label': 'foo', 'href': '#foo'},
+        {'label': 'bar', 'href': '#bar'},
+        {'label': 'baz', 'href': '#baz'}
+    ]
+%}
+{{ nav.breadcrumbs(breadcrumbs) }}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/nav/breadcrumb.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/nav/breadcrumb.html
@@ -1,0 +1,1 @@
+<nav class="breadcrumb"></nav>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/nav/breadcrumb.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/nav/breadcrumb.html.twig
@@ -1,0 +1,2 @@
+{% import '@pulsar/pulsar/v2/helpers/nav.html.twig' as nav %}
+{{ nav.breadcrumbs() }}

--- a/views/lexicon/index.html.twig
+++ b/views/lexicon/index.html.twig
@@ -10,6 +10,14 @@
 {% set heading = 'Components' %}
 
 {%
+    set breadcrumbs = [
+        {'label': 'Bread', 'href': '#'},
+        {'label': 'Crumb', 'href': '#'},
+        {'label': 'Trail', 'href': '#'}
+    ]
+%}
+
+{%
     set actions_menu = [
         html.link({
           'label': html.icon('save') ~ ' Save',

--- a/views/pulsar/layouts/base.html.twig
+++ b/views/pulsar/layouts/base.html.twig
@@ -37,7 +37,7 @@
     <link rel="stylesheet" type="text/css" href="{{ libsPath ~ 'font-awesome/css/font-awesome-ie7.min.css' }}" />
     <![endif]-->
 
-    <!-- <link rel="stylesheet" href="http://basehold.it/24"> -->
+    <!-- <link rel="stylesheet" href="http://basehold.it/12"> -->
 
     <script
         src="{{ base_path ~ 'dist/js/bundle.js' }}"
@@ -102,11 +102,7 @@
 
             <div class="content-main">
                 <div class="tabs__content">
-                    <nav class="breadcrumb">
-                    {% block breadcrumb %}
-                        <a href="#">Bread</a> / <a href="#">Crumb</a> / Trail
-                    {% endblock %}
-                    </nav>
+                    {{ nav.breadcrumbs(breadcrumbs|default) }}
                     <h1 class="main-title">{{ heading|default('MISSING HEADING') }}</h1>
                     {% block tabs_list %}{% endblock %}
                     {% block tabs_content %}{% endblock %}

--- a/views/pulsar/v2/helpers/nav.html.twig
+++ b/views/pulsar/v2/helpers/nav.html.twig
@@ -102,3 +102,17 @@
         </ul>
     </div>
 {%- endmacro -%}
+
+
+{%- macro breadcrumbs(items) -%}
+    {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+
+    <nav class="breadcrumb">
+    {%- for item in items -%}
+        {{ html.link(item) }}
+        {% if not loop.last %}
+            /
+        {% endif %}
+    {%- endfor -%}
+    </nav>
+{%- endmacro -%}


### PR DESCRIPTION
- [x] Improve breadcrumb positioning against baseline
- [x] helper
- [x] tests
- [x] documentation

# Breadcrumb

A basic helper to render a list of breadcrumb links. A view should set the `breadcrumbs` object which will then be rendered by the base template.

```twig
{%
    set breadcrumbs = [
        {'label': 'foo', 'href': '#foo'},
        {'label': 'bar', 'href': '#bar'},
        {'label': 'baz', 'href': '#baz'}
    ]
%}
```

###### Example output in base template
```html
<nav class="breadcrumb">
    <a href="#foo">foo</a> /
    <a href="#bar">bar</a> /
    <a href="#baz">baz</a>
</nav>
```