### PR TITLE
Add `removable` option to `html.label` helper

### DIFF
--- a/stylesheets/_component.labels.scss
+++ b/stylesheets/_component.labels.scss
@@ -1,72 +1,84 @@
 .label {
-  @include inline-block;
-  @include content-box;
-  @include label-variant(color(base), color(base, alt));
-  border-radius: $border-radius;
-  font-size: 75%;
-  font-weight: 500;
-  line-height: 1;
-  padding: .25em .6em;
-  text-align: center;
-  text-transform: lowercase;
-  vertical-align: baseline;
-  white-space: nowrap;
+    @include inline-block;
+    @include content-box;
+    @include label-variant(color(base), color(base, alt));
+    border-radius: $border-radius;
+    font-size: 75%;
+    font-weight: 500;
+    line-height: 1;
+    padding: .25em .6em;
+    text-align: center;
+    text-transform: lowercase;
+    vertical-align: baseline;
+    white-space: nowrap;
 
-  // Add hover effects, but only for links
-  &[href] {
-    &:hover,
-    &:focus {
-      text-decoration: none;
-      cursor: pointer;
-      background-color: color(gray, lighter);
+    // Add hover effects, but only for links
+    &[href] {
+        &:hover,
+        &:focus {
+            text-decoration: none;
+            cursor: pointer;
+            background-color: color(gray, lighter);
+        }
     }
-  }
 
-    // Addable/Removable labels
-    .remove-button,
-    .remove-button [class^="icon-"],
-    .remove-button [class*=" icon-"] {
+    // Removable labels
+    .btn.remove-button,
+    .btn.remove-button [class^="icon-"],
+    .btn.remove-button [class*=" icon-"] {
         &,
         &:hover {
             box-shadow: none;
             color: inherit;
             font-size: 1em;
-            line-height: 1;
+            line-height: inherit;
             margin-left: 2px;
             text-decoration: none;
             top: 0;
         }
+    }
+
+    // Override default button styling
+    .btn.remove-button:active {
+        background-color: inherit;
     }
 }
 
 // Colors
 // Contextual variations (linked labels get darker on :hover)
 .label--primary {
-  @include label-variant(color(primary), color(primary, alt));
+    @include label-variant(color(primary), color(primary, alt));
 }
 
 .label--success {
-  @include label-variant(color(success), color(success, alt));
+    @include label-variant(color(success), color(success, alt));
 }
 
 .label--warning {
-  @include label-variant(color(warning), color(warning, alt));
+    @include label-variant(color(warning), color(warning, alt));
 }
 
 .label--danger {
-  @include label-variant(color(danger), color(danger, alt));
-  $badge-primary-bg: darken($badge-primary-bg, 10%);
+    @include label-variant(color(danger), color(danger, alt));
+    $badge-primary-bg: darken($badge-primary-bg, 10%);
 }
 
 .label--info {
-  @include label-variant(color(info), color(info, alt));
+    @include label-variant(color(info), color(info, alt));
 }
 
 .label--inverse {
-  @include label-variant(color(inverse), color(inverse, alt));
+    @include label-variant(color(inverse), color(inverse, alt));
 
-  i {
-    color: color(white);
-  }
+    i {
+        color: color(white);
+    }
 }
 
+.label--large {
+    line-height: 2;
+
+    .remove-button {
+        line-height: inherit;
+    }
+}

--- a/stylesheets/_component.labels.scss
+++ b/stylesheets/_component.labels.scss
@@ -22,23 +22,21 @@
     }
   }
 
-  // Addable/Removable labels
-  [data-filter-action="add"],
-  [data-filter-action="remove"] {
-    border-left: 1px dotted;
-    border-color: white;
-    color: inherit;
-    margin-left: 5px;
-    text-decoration: none;
-
-    i {
-        margin-left: 7px;
+    // Addable/Removable labels
+    .remove-button,
+    .remove-button [class^="icon-"],
+    .remove-button [class*=" icon-"] {
+        &,
+        &:hover {
+            box-shadow: none;
+            color: inherit;
+            font-size: 1em;
+            line-height: 1;
+            margin-left: 2px;
+            text-decoration: none;
+            top: 0;
+        }
     }
-
-    &:hover {
-      margin-top: 1px;
-    }
-  }
 }
 
 // Colors

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/label-removable.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/label-removable.html
@@ -1,0 +1,1 @@
+<span class="label">foo<a type="link" data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"></i></a></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/label-removable.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/label-removable.html.twig
@@ -1,0 +1,10 @@
+{#
+    Test label
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.label({
+        'label': 'foo',
+        'removable': true
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-input.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-input.html
@@ -1,9 +1,8 @@
 <input
-    data-action="remove"
     data-placement="right"
     data-toggle="tooltips"
     data-title="Remove this item"
+    data-action="remove"
     type="button"
     value="&lt;i class=&quot;icon-remove-sign&quot;&gt;&lt;/i&gt;"
-    class="btn remove-button"
-/>
+    class="btn remove-button" />

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-link.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-link.html
@@ -1,1 +1,8 @@
-<a type="link" data-action="remove" data-placement="right" data-toggle="tooltips" data-title="Remove this item" class="btn remove-button"><i class="icon-remove-sign"></i></a>
+<a
+    type="link"
+    data-placement="right"
+    data-toggle="tooltips"
+    data-title="Remove this item"
+    data-action="remove"
+    class="btn remove-button">
+<i class="icon-remove-sign"></i></a>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-placements.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-placements.html
@@ -1,7 +1,35 @@
-<button type="button" data-action="remove" data-placement="top" data-toggle="tooltips" data-title="Remove this item" class="btn remove-button"><i class="icon-remove-sign"></i></button>
+<button
+    data-placement="top"
+    data-toggle="tooltips"
+    data-title="Remove this item"
+    type="button"
+    data-action="remove"
+    class="btn remove-button">
+<i class="icon-remove-sign"></i></button>
 
-<button type="button" data-action="remove" data-placement="right" data-toggle="tooltips" data-title="Remove this item" class="btn remove-button"><i class="icon-remove-sign"></i></button>
+<button
+    data-placement="right"
+    data-toggle="tooltips"
+    data-title="Remove this item"
+    type="button"
+    data-action="remove"
+    class="btn remove-button">
+<i class="icon-remove-sign"></i></button>
 
-<button type="button" data-action="remove" data-placement="bottom" data-toggle="tooltips" data-title="Remove this item" class="btn remove-button"><i class="icon-remove-sign"></i></button>
+<button
+    data-placement="bottom"
+    data-toggle="tooltips"
+    data-title="Remove this item"
+    type="button"
+    data-action="remove"
+    class="btn remove-button">
+<i class="icon-remove-sign"></i></button>
 
-<button type="button" data-action="remove" data-placement="left" data-toggle="tooltips" data-title="Remove this item" class="btn remove-button"><i class="icon-remove-sign"></i></button>
+<button
+    data-placement="left"
+    data-toggle="tooltips"
+    data-title="Remove this item"
+    type="button"
+    data-action="remove"
+    class="btn remove-button">
+<i class="icon-remove-sign"></i></button>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-submit.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-submit.html
@@ -1,9 +1,8 @@
 <button
     type="submit"
-    data-action="remove"
     data-placement="right"
     data-toggle="tooltips"
     data-title="Remove this item"
+    data-action="remove"
     class="btn remove-button">
-    <i class="icon-remove-sign"></i>
-</button>
+<i class="icon-remove-sign"></i></button>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-target.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-target.html
@@ -1,3 +1,10 @@
-<button type="button" data-action="remove" data-action-target="foo" data-placement="right" data-toggle="tooltips" data-title="Remove this item" class="btn remove-button">
+<button
+    data-placement="right"
+    data-toggle="tooltips"
+    data-title="Remove this item"
+    type="button"
+    data-action="remove"
+    data-action-target="foo"
+    class="btn remove-button">
     <i class="icon-remove-sign"></i>
 </button>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button.html
@@ -1,3 +1,9 @@
-<button type="button" data-action="remove" data-placement="right" data-toggle="tooltips" data-title="Remove this item" class="btn remove-button">
+<button
+    data-placement="right"
+    data-toggle="tooltips"
+    data-title="Remove this item"
+    type="button"
+    data-action="remove"
+    class="btn remove-button">
     <i class="icon-remove-sign"></i>
 </button>

--- a/views/lexicon/index.html.twig
+++ b/views/lexicon/index.html.twig
@@ -109,12 +109,18 @@
             }
         },
         "2": {
+            "label": "Elements",
+            "class": "",
+            "href": "/app/app.php/lexicon",
+            "icon": "th"
+        },
+        "3": {
             "label": "Forms",
             "class": "",
             "href": "/app/app.php/lexicon/forms.html.twig",
             "icon": "check"
         },
-        "3": {
+        "4": {
             "label": "Docs",
             "class": "",
             "href": "http://jadu.gitbooks.io/pulsar/",
@@ -126,15 +132,10 @@
 {%
     set tabs_content = [
         {
-          "id"    : "checkgrid",
-          "label" : "Checkgrid",
-          "src"   : tab_checkgrid,
-          "active": true
-        },
-        {
           "id"    : "colours",
           "label" : "Colours",
-          "src"   : tab_colours
+          "src"   : tab_colours,
+          "active": true
         },
         {
           "id"    : "buttons",

--- a/views/lexicon/tabs/buttons_labels.html.twig
+++ b/views/lexicon/tabs/buttons_labels.html.twig
@@ -356,12 +356,73 @@
 
     <h2 class="heading">Removable labels</h2>
     <p>
-        <span class="label label--inverse">
-            <strong>Created:</strong> Last 30 days <a href="#" data-filter-action="remove"><i class="icon-remove"></i></a>
-        </span>
-        <span class="label label--primary">
-            UX <a href="#" data-filter-action="remove"><i class="icon-remove"></i></a>
-        </span>
+        {{
+            html.label({
+                label: 'default',
+                removable: true
+            })
+        }}
+        {{
+            html.label({
+                label: 'primary',
+                class: 'label--primary',
+                removable: true
+            })
+        }}
+        {{
+            html.label({
+                label: 'success',
+                class: 'label--success',
+                removable: true
+            })
+        }}
+        {{
+            html.label({
+                label: 'warning',
+                class: 'label--warning',
+                removable: true
+            })
+        }}
+        {{
+            html.label({
+                label: 'danger',
+                class: 'label--danger',
+                removable: true
+            })
+        }}
+        {{
+            html.label({
+                label: 'info',
+                class: 'label--info',
+                removable: true
+            })
+        }}
+        {{
+            html.label({
+                label: 'inverse',
+                class: 'label--inverse',
+                removable: true
+            })
+        }}
+        {{
+            html.label({
+                'label': 'label with tooltip',
+                'class': 'label--inverse',
+                'data-toggle': 'tooltips',
+                'data-title': 'Hello!',
+                removable: true
+            })
+        }}
+        {{
+            html.label({
+                'label': 'label with right-aligned tooltip',
+                'class': 'label--inverse',
+                'data-toggle': 'tooltips',
+                'data-title': 'You look nice',
+                'data-placement': 'right',
+                removable: true
+            })
+        }}
     </p>
 
     <h2 class="heading">Badges</h2>

--- a/views/lexicon/tabs/buttons_labels.html.twig
+++ b/views/lexicon/tabs/buttons_labels.html.twig
@@ -352,6 +352,12 @@
                 'data-placement': 'right'
             })
         }}
+        {{
+            html.label({
+                label: 'large label',
+                class: 'label--large'
+            })
+        }}
     </p>
 
     <h2 class="heading">Removable labels</h2>
@@ -420,6 +426,13 @@
                 'data-toggle': 'tooltips',
                 'data-title': 'You look nice',
                 'data-placement': 'right',
+                removable: true
+            })
+        }}
+        {{
+            html.label({
+                class: 'label--large',
+                label: 'label large',
                 removable: true
             })
         }}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -619,27 +619,39 @@ Provide extra contextual meaning to things.
 
 ## Options
 
-Option | Type   | Description
------- | ------ | --------------------------------------------------------------
-class  | string | CSS classes, space separated
-id     | string | A unique identifier, if required
-label  | string | The value to display
-data-* | string | Data attributes, eg: `'data-foo': 'bar'`
+Option        | Type   | Description
+------------- | ------ | --------------------------------------------------------------
+class         | string | CSS classes, space separated
+id            | string | A unique identifier, if required
+label         | string | The value to display
+removable     | bool   | Displays a remove sign at the end of the label
+remove-target | string | Selector of the item to be removed, will be turned into the `data-action-target` attribute
+data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro label(options) %}
 {% spaceless %}
+    {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     <span{{
         attributes(options
-            |exclude('label')
+            |exclude('label removable')
             |defaults({
                 'class': 'label'
             })
         )
     }}>
         {{- options.label|default|raw -}}
+        {% if options.removable is defined and options.removable %}
+        {{
+            html.remove_button({
+                'tooltip': false,
+                'target': options.target|default,
+                'type': 'link'
+            })
+        }}
+        {% endif %}
     </span>
 
 {% endspaceless %}
@@ -1155,6 +1167,16 @@ data-*    | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
+    {% if options.tooltip is defined and options.tooltip != false %}
+    {%
+        set options = options|default({})|merge({
+            'data-placement': options.placement|default('right'),
+            'data-toggle': 'tooltips',
+            'data-title': options.tooltip|default('Remove this item')
+        })
+    %}
+    {% endif %}
+
     {{
         html.button(options
             |exclude('target placement')
@@ -1163,9 +1185,6 @@ data-*    | string | Data attributes, eg: `'data-foo': 'bar'`
                 'type': options.type|default('button'),
                 'data-action': 'remove',
                 'data-action-target': options.target|default,
-                'data-placement': options.placement|default('right'),
-                'data-toggle': 'tooltips',
-                'data-title': options.tooltip|default('Remove this item'),
                 'label': html.icon('remove-sign')
             })
         )

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -625,7 +625,6 @@ class         | string | CSS classes, space separated
 id            | string | A unique identifier, if required
 label         | string | The value to display
 removable     | bool   | Displays a remove sign at the end of the label
-remove-target | string | Selector of the item to be removed, will be turned into the `data-action-target` attribute
 data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
@@ -636,18 +635,18 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
 
     <span{{
         attributes(options
-            |exclude('label removable')
+            |exclude('label removable remove_target')
             |defaults({
                 'class': 'label'
             })
         )
     }}>
         {{- options.label|default|raw -}}
-        {% if options.removable is defined and options.removable %}
+        {% if options.removable is defined and options.removable == true %}
         {{
             html.remove_button({
                 'tooltip': false,
-                'target': options.target|default,
+                'target': 'this',
                 'type': 'link'
             })
         }}
@@ -1167,7 +1166,7 @@ data-*    | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
-    {% if options.tooltip is defined and options.tooltip != false %}
+    {% if options.tooltip is not defined or options.tooltip != false %}
     {%
         set options = options|default({})|merge({
             'data-placement': options.placement|default('right'),


### PR DESCRIPTION
- [x] Add option to `html.label` helper
- [x] Icon should inherit label's choice of text colour to maintain AA

```
{{
    html.label({
        label: 'default',
        removable: true
   })
}}
```

<img width="871" alt="screen shot 2016-05-27 at 10 44 51" src="https://cloud.githubusercontent.com/assets/18653/15606392/d632f79a-2403-11e6-9bac-6a9772446611.png">

Normal remove buttons have a `target` attribute, for these we will assume—at this point—that whatever JS is wired up by the developer will simply reference the element being clicked. (the helper still outputs `data-action-target="this"`)