### PR TITLE
Help blocks for form.select2 should have same spacing as regular selects

### DIFF
--- a/stylesheets/_structure.forms.scss
+++ b/stylesheets/_structure.forms.scss
@@ -23,11 +23,11 @@ $control-column-width: 75%;
     }
 
     .help-block {
-        margin: 0;
+        margin-top: .675em;
+    }
 
-        &:nth-of-type(1) {
-            margin-top: .675em;
-        }
+    .help-block ~ .help-block {
+        margin-top: 0;
     }
 }
 


### PR DESCRIPTION
<img width="736" alt="screen shot 2016-05-27 at 20 43 11" src="https://cloud.githubusercontent.com/assets/18653/15619347/a95c519c-244b-11e6-9311-91f50090cfa5.png">

Closes #219 