### PR TITLE
New countdown helper for jQuery.countdown plugin

### DIFF
--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/countdown-format.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/countdown-format.html
@@ -1,0 +1,1 @@
+<span data-final-date="2020/01/02 12:34:56" data-format="%d" class="js-countdown">foo</span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/countdown-format.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/countdown-format.html.twig
@@ -1,0 +1,11 @@
+{#
+    Test basic countdown method
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.countdown({
+        'label': 'foo',
+        'final-date': '2020/01/02 12:34:56',
+        'format': '%d'
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/countdown.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/countdown.html
@@ -1,0 +1,1 @@
+<span data-final-date="2020/01/02 12:34:56" class="js-countdown">foo</span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/countdown.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/countdown.html.twig
@@ -1,0 +1,10 @@
+{#
+    Test basic countdown method
+#}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{{
+    html.countdown({
+        'label': 'foo',
+        'final-date': '2020/01/02 12:34:56'
+    })
+}}

--- a/views/playground/countdown.html.twig
+++ b/views/playground/countdown.html.twig
@@ -1,0 +1,6 @@
+{% extends '@pulsar/pulsar/layouts/base.html.twig' %}
+
+{% block tabs_content %}
+    <span class="js-countdown" data-final-date="1665243907399" data-format="%Hh %Mm %Ss">Expires in 6 hours</span>
+{% endblock %}
+

--- a/views/pulsar/layouts/base.html.twig
+++ b/views/pulsar/layouts/base.html.twig
@@ -5,7 +5,7 @@
 {% set cssPath  = base_path ~ 'css/' %}
 {% set jsPath   = base_path ~ 'js/' %}
 {% set libsPath = base_path ~ 'libs/' %}
-{% set themeFile = cssPath ~ 'themes/slate.css' %}
+{# set themeFile = cssPath ~ 'themes/slate.css' #}
 <!DOCTYPE html>
 <!--[if IE 7]>         <html class="no-js ie7 lt-ie10 lt-ie8"><![endif]-->
 <!--[if IE 8]>         <html class="no-js ie8 lt-ie10 lt-ie9"><![endif]-->

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -446,6 +446,64 @@ placement    | string | the alignment of the dropdown menu, `left` (default) or 
 {% endspaceless %}
 {% endmacro %}
 
+
+{# -----------------------------------------------------------------------------
+
+# Countdown
+
+Helper which wires up jquery.countdown functionality for live countdowns. This
+is a basic implementation for the time being, speak to Pulsar team if you need
+extra functionality as per http://hilios.github.io/jQuery.countdown/documentation.html
+
+## Example usage
+
+```twig
+{{
+    html.countdown({
+        'final-date': '2020/01/01 12:34:00',
+        'format': '%ww %dd %Hh %Mm %S',
+        'label': 'Expires 01/01/2010 at 12:34pm'
+    })
+}}
+```
+
+## Options
+
+Option     | Type   | Description
+---------- | ------ | --------------------------------------------------------------
+class      | string | CSS classes, space separated
+final-date | string | A native date() object, epoch timestamp (milliseconds) or date string
+format     | string | A `strftime` string to format the countdown output (default: `%ww %dd %Hh %Mm %S`)
+id         | string | A unique identifier, if required
+label      | string | A fallback string to display if no js available
+data-*     | string | Data attributes, eg: `'data-foo': 'bar'`
+
+#}
+{% macro countdown(options) %}
+{% spaceless %}
+
+    {%
+        set options = options|default({})|merge({
+            'data-final-date': options['final-date']|default,
+            'data-format': options.format|default
+        })
+    %}
+
+    <span{{
+        attributes(options
+            |exclude('final-date format label')
+            |defaults({
+                'class': 'js-countdown'
+            })
+        )
+    }}>
+        {{- options.label|default|raw -}}
+    </span>
+
+{% endspaceless %}
+{% endmacro %}
+
+
 {# -----------------------------------------------------------------------------
 
 # Div


### PR DESCRIPTION
# Countdown

Add a live countdown to a specific date/time. This is a basic implementation for the time being, speak to Pulsar team if you need extra functionality as per [http://hilios.github.io/jQuery.countdown/documentation.html](http://hilios.github.io/jQuery.countdown/documentation.html)

## Example usage

```twig
{{
    html.countdown({
        'final-date': '2020/01/01 12:34:00',
        'format': '%ww %dd %Hh %Mm %S',
        'label': 'Expires 01/01/2010 at 12:34pm'
    })
}}
```

This will render a simple string which will start counting down. You can style this as you wish. You can provide your own `format` string to provide the most appropriate countdown (ie: there's no point having a countdown using weeks if the final date is only based a few hours away).

## Options

Option     | Type   | Description
---------- | ------ | --------------------------------------------------------------
class      | string | CSS classes, space separated
final-date | string | A native date() object, epoch timestamp (milliseconds) or date string
format     | string | A `strftime` string to format the countdown output (default: `%ww %dd %Hh %Mm %S`)
id         | string | A unique identifier, if required
label      | string | A fallback string to display if no js available
data-*     | string | Data attributes, eg: `'data-foo': 'bar'`
