### PR TITLE
Stop flash messages appearing on top of navigation

### DIFF
--- a/stylesheets/_component.flash.scss
+++ b/stylesheets/_component.flash.scss
@@ -3,26 +3,26 @@
     padding: (($line-height-base / $line-height-small) / 2) $gutter-width;
     width: 100%;
 
-@include respond-min($screen-phone) {
-    padding: ($line-height-base / 2) $gutter-width;
-}
-
-@include respond-min($screen-desktop) {
-    top: auto;
-    z-index: $zindex-flash;
-}
-
-    &.is-sticky {
-    display: none; // Flashes should be hidden on page load, then animated in so the user sees them.
-}
-
-i {
-    margin: 0 ($gutter-width / 4) 0 0;
-
     @include respond-min($screen-phone) {
-        margin-right: $gutter-width / 2;
+        padding: ($line-height-base / 2) $gutter-width;
     }
-}
+
+    @include respond-min($screen-desktop) {
+        top: auto;
+        z-index: $zindex-flash;
+    }
+
+        &.is-sticky {
+        display: none; // Flashes should be hidden on page load, then animated in so the user sees them.
+    }
+
+    i {
+        margin: 0 ($gutter-width / 4) 0 0;
+
+        @include respond-min($screen-phone) {
+            margin-right: $gutter-width / 2;
+        }
+    }
 }
 
 // Make sure sticky flashes appear over the breadcrumb
@@ -95,7 +95,9 @@ i {
 .flash-container {
     clear: both;
     top: -5px;
+    left: 0;
     margin-bottom: 0;
     position: relative;
+    width: auto;
     z-index: $zindex-flash;
 }

--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -13,7 +13,7 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
     transform: translate3d(-100%, 0, 0);
     vertical-align: top;
     width: 75px;
-    z-index: 3;
+    z-index: $zindex-nav;
 
     @include respond-min($screen-desktop) {
         left: auto;


### PR DESCRIPTION
Fixed through use of existing ` $zindex-nav;` variable on the main navigation container.

![flash](https://cloud.githubusercontent.com/assets/18653/16193693/99b090f0-36e8-11e6-8b35-c73de77d2754.gif)

Closes #234 