### PR TITLE
Update no-wrap table class to support new .u- utility format

### DIFF
--- a/stylesheets/_component.tables.scss
+++ b/stylesheets/_component.tables.scss
@@ -60,7 +60,7 @@
 
         &.no-wrap,
         &.u-no-wrap {
-            @extend .u-no-wrap;
+            @extend %u-no-wrap;
             overflow: hidden;
             text-overflow: ellipsis;
         }

--- a/stylesheets/_component.tables.scss
+++ b/stylesheets/_component.tables.scss
@@ -58,8 +58,9 @@
             }
         }
 
-        &.no-wrap {
-            white-space: nowrap;
+        &.no-wrap,
+        &.u-no-wrap {
+            @extend .u-no-wrap;
             overflow: hidden;
             text-overflow: ellipsis;
         }

--- a/stylesheets/_utility.utilities.scss
+++ b/stylesheets/_utility.utilities.scss
@@ -129,10 +129,12 @@ div.no-results {
     margin: 10px 0;
 }
 
-.u-no-wrap {
+.u-no-wrap,
+%u-no-wrap {
     white-space: nowrap !important;
 }
 
-.u-word-break {
+.u-word-break,
+%u-word-break {
     word-break: break-all !important;
 }

--- a/stylesheets/_utility.utilities.scss
+++ b/stylesheets/_utility.utilities.scss
@@ -129,6 +129,10 @@ div.no-results {
     margin: 10px 0;
 }
 
+.u-no-wrap {
+    white-space: nowrap !important;
+}
+
 .u-word-break {
     word-break: break-all !important;
 }


### PR DESCRIPTION
Keep supporting `.no-wrap`, no plans to deprecate that just yet