### PR TITLE
Pagination component should be correctly aligned with its table

### DIFF
--- a/stylesheets/_component.tables.scss
+++ b/stylesheets/_component.tables.scss
@@ -167,6 +167,10 @@ td.table__form {
     }
 }
 
+.table-container + .pagination {
+    margin-top: -24px; // negate default bottom border of .table
+}
+
 // Map depracated table styles to this one -------------------------------------
 
 .table--datagrid {

--- a/views/lexicon/tabs/datagrid.html.twig
+++ b/views/lexicon/tabs/datagrid.html.twig
@@ -158,6 +158,17 @@
             </tr>
         </tbody>
     </table>
+    <div class="pagination">
+        <ul class="pull-left"><!--
+            --><li class="is-disabled"><a href="#"><i class="icon-double-angle-left"></i> Previous</a></li><!--
+            --><li><a href="#">1</a></li><!--
+            --><li class="selected"><a href="#">2</a></li><!--
+            --><li><a href="#">3</a></li><!--
+            --><li><a href="#">4</a></li><!--
+            --><li><a href="#">5</a></li><!--
+            --><li><a href="#">Next <i class="icon-double-angle-right"></i></a></li><!--
+        --></ul>
+    </div>
 
     <div class="form__group">
         <label class="control__label">Choices</label>


### PR DESCRIPTION
Does not apply to datagrid pagination.

<img width="687" alt="screen shot 2016-07-01 at 08 36 03" src="https://cloud.githubusercontent.com/assets/18653/16514947/e8d880d0-3f66-11e6-9d12-60050b8891e2.png">

Closes #240 
