### PR TITLE
Make datatables automatically render 'no results' message

### DIFF
--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -47,12 +47,25 @@ PulsarUIComponent.prototype.initDataTables = function () {
     datatables.each(function() {
         var $this = $(this);
 
+        var select = {
+            className: 'dt-row-selected',
+            style:     'multi',
+            selector:  'td.table-selection'
+        }
+
+        var dom = '<"dataTables_top"Birf><"dataTables_actions"T>t<"dataTables_bottom"lp>';
+
         if (!$this.data('empty-table')) {
             $this.data('empty-table', 'There are currently no items to display');
         }
 
+        if ($this.data('select') == false) {
+            dom = '<"dataTables_top"irf><"dataTables_actions"T><"dt-disable-selection"t><"dataTables_bottom"lp>';
+            select = false;
+        }
+
         $this.DataTable({
-            dom: '<"dataTables_top"Birf><"dataTables_actions"T>t<"dataTables_bottom"lp>',
+            dom: dom,
             aaSorting: [],
             bAutoWidth: false,
             buttons: [
@@ -76,11 +89,7 @@ PulsarUIComponent.prototype.initDataTables = function () {
                     type: 'column'
                 }
             },
-            select: {
-                className: 'dt-row-selected',
-                style:     'multi',
-                selector:  'td.table-selection'
-            },
+            select: select,
             stateSave: false
         });
     });

--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -42,39 +42,47 @@ PulsarUIComponent.prototype.initTables = function () {
 
 PulsarUIComponent.prototype.initDataTables = function () {
 
-    this.$html.find('.datatable').DataTable({
-        dom: '<"dataTables_top"Birf><"dataTables_actions"T>t<"dataTables_bottom"lp>',
-        aaSorting: [],
-        bAutoWidth: false,
-        buttons: [
-            'selectAll',
-            'selectNone'
-        ],
-        columnDefs: [
-            { className: 'control', orderable: false, targets: 0 },
-            { "searchable": false, "targets": [0, 1] },
-            { "orderable": false, "targets": [0, 1] }
-        ],
-        oLanguage: {
-         sSearch: "Filter:"
-        },
-        language: {
-            buttons: {
-                selectAll: "Select all items",
-                selectNone: "Select none"
-            }
-        },
-        responsive: {
-            details: {
-                type: 'column'
-            }
-        },
-        select: {
-            className: 'dt-row-selected',
-            style:     'multi',
-            selector:  'td.table-selection'
-        },
-        stateSave: false
+    var datatables = this.$html.find('.datatable');
+
+    datatables.each(function() {
+        var $this = $(this);
+
+        if (!$this.data('empty-table')) {
+            $this.data('empty-table', 'There are currently no items to display');
+        }
+
+        $this.DataTable({
+            dom: '<"dataTables_top"Birf><"dataTables_actions"T>t<"dataTables_bottom"lp>',
+            aaSorting: [],
+            bAutoWidth: false,
+            buttons: [
+                'selectAll',
+                'selectNone'
+            ],
+            columnDefs: [
+                { className: 'control', orderable: false, targets: 0 },
+                { "searchable": false, "targets": [0, 1] },
+                { "orderable": false, "targets": [0, 1] }
+            ],
+            language: {
+                "emptyTable": $this.data('empty-table'),
+                "info": "Showing _START_ to _END_ of _TOTAL_ items",
+                "infoEmpty": 'No items',
+                "infoFiltered": " (filtered from _MAX_ items)",
+                "zeroRecords": "No items matched your filter, please clear it and try again"
+            },
+            responsive: {
+                details: {
+                    type: 'column'
+                }
+            },
+            select: {
+                className: 'dt-row-selected',
+                style:     'multi',
+                selector:  'td.table-selection'
+            },
+            stateSave: false
+        });
     });
 
     // Refresh datatables when tabs are switched, this fixes some layout issues

--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -23,6 +23,15 @@
     }
 }
 
+.dt-disable-selection .table-selection {
+    min-width: 0;
+    padding: 0;
+    width: 0;
+
+    .table-row-select {
+        display: none;
+    }
+}
 
 // scss-lint:disable SelectorFormat
 .datatable .dt-row-selected {

--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -277,19 +277,7 @@ th.sorting_disabled:hover {
 
 // scss-lint:disable SelectorFormat
 .dataTables_empty {
-    color: color(danger);
-    height: 73px;
-    padding-left: 10px;
-    vertical-align: middle;
-
-    &::before {
-        content: $frown;
-        color: color(danger);
-        font-family: fontawesome;
-        font-size: 48px;
-        margin-right: 20px;
-        vertical-align: middle;
-    }
+    @extend .no-results;
 }
 
 .dataTables_bottom {

--- a/stylesheets/_component.tables.scss
+++ b/stylesheets/_component.tables.scss
@@ -34,9 +34,8 @@
         }
     }
 
-    tr.no-results td,
-    tr.row--no-results td {
-      padding: 1em 0;
+    .no-results {
+      padding: 2em 0;
       text-align: center;
     }
 
@@ -44,7 +43,6 @@
     td {
         border-bottom: 1px solid color(border);
         padding: 11px 10px 12px;
-        text-align: left;
 
         &.centered {
             @include respond-min($screen-tablet) {

--- a/stylesheets/_component.tables.scss
+++ b/stylesheets/_component.tables.scss
@@ -39,6 +39,10 @@
       text-align: center;
     }
 
+    th {
+        text-align: left;
+    }
+
     th,
     td {
         border-bottom: 1px solid color(border);

--- a/tests/js/web/PulsarUIComponentTest.js
+++ b/tests/js/web/PulsarUIComponentTest.js
@@ -14,6 +14,8 @@ describe('Pulsar UI Component', function() {
             <table class="table qa-table"></table>\
             <table class="table--datagrid qa-datagrid"></table>\
             <table class="table datatable qa-datatable"></table>\
+            <table class="table datatable qa-datatable-empty-message" data-empty-table="foo"></table>\
+            <table class="table datatable qa-datatable-no-selection" data-select="false"></table>\
             <div class="table-container"><table class="table qa-table-dupe"></table></div>\
             <a href="#tab" data-toggle="tab">foo</a>\
             <div class="tab__pane" id="tab">\
@@ -27,6 +29,8 @@ describe('Pulsar UI Component', function() {
         this.$basicTable = this.$html.find('.qa-table');
         this.$datagridTable = this.$html.find('.qa-datagrid');
         this.$datatableTable = this.$html.find('.qa-datatable');
+        this.$datatableWithCustomMessage = this.$html.find('.qa-datatable-empty-message');
+        this.$datatableDisableSelection = this.$html.find('.qa-datatable-no-selection');
         this.$tableDupe = this.$html.find('.qa-table-dupe');
         this.$countdownOne = this.$html.find('.qa-countdown-one');
 
@@ -80,6 +84,18 @@ describe('Pulsar UI Component', function() {
 
         it('should NOT wrap tables which already have the container', function() {
             expect(this.$tableDupe.parent().parent().hasClass('table-container')).to.be.false;
+        });
+
+        it('should show the default empty table message', function() {
+            expect(this.$datatableTable.find('.dataTables_empty').text()).to.equal('There are currently no items to display');
+        });
+
+        it('should allow the empty table message to be overridden', function() {
+            expect(this.$datatableWithCustomMessage.find('.dataTables_empty').text()).to.equal('foo');
+        });
+
+        it('should wrap the table with the disable class when the data-select attribute is false', function() {
+            expect(this.$datatableDisableSelection.parent().hasClass('dt-disable-selection')).to.be.true;
         });
     });
 


### PR DESCRIPTION
## No results

If your table has no results in the `tbody` then the table will show a generic message. This message can, and should, be customised to suit the content in question via the `data-empty-table` attribute.

```
<table class="table datatable" data-empty-table="There are currently no documents to display">
    ... 
</table>
```

## Disable row selection

Datatables allow selection of rows by default, this behaviour can be disabled through the `data-selection` attribute. This will hide the related elements in the UI.

```
<table class="table datatable" data-selection="false">
   ...   
</table>
```