### PR TITLE
Allow inline navigation links to be disabled

### DIFF
--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -97,7 +97,10 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
             .caret {
                 border-top-color: color(black);
             }
+        }
 
+        &.is-disabled {
+            color: color(text, disabled);
         }
 
         .caret {

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-disabled.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-disabled.html
@@ -1,0 +1,10 @@
+<div class="nav-inline t-nav-inline">
+    <ul class="nav-inline__list">
+        <li class="nav-inline__item">
+            <a href="#" data-toggle="link" disabled aria-disabled="true" class="nav-inline__link is-disabled">bar</a>
+        </li>
+    </ul>
+</div>
+<div class="tab__pane" id="foo">
+    baz
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-disabled.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-disabled.html.twig
@@ -1,0 +1,13 @@
+{% import '@pulsar/pulsar/v2/helpers/tabs.html.twig' as tabs %}
+{%
+    set nav = [
+        {
+          "id"    : "foo",
+          "label" : "bar",
+          "src"   : 'baz',
+          "disabled": true
+        }
+    ]
+%}
+{{ tabs.list(nav) }}
+{{ tabs.content(nav) }}

--- a/views/pulsar/v2/helpers/tabs.html.twig
+++ b/views/pulsar/v2/helpers/tabs.html.twig
@@ -5,22 +5,27 @@
         <ul class="nav-inline__list">
     {%- for tab in tabs -%}
             <li class="nav-inline__item{% if tab.active is defined and tab.active == tab.id %} nav-inline__item--is-active is-active{% endif %}{% if tab.hidden is defined and tab.hidden == true %} hide{% endif %}">
-                {% set href = '#' ~ tab.id %}
-                {% set type = 'tab' %}
-                {%
-                    if tab.src is defined
-                    and tab.src != null
-                    and (
-                           tab.src|json_encode|slice(0, 1) == '/'
-                        or tab.src|json_encode|slice(1, 1) == '#'
-                        or tab.src|json_encode|slice(1, 4) == 'http'
-                    )
-                %}
+                {% if tab.disabled is defined and tab.disabled == true %}
+                    {% set href = '#' %}
                     {% set type = 'link' %}
-                    {% set href = tab.src %}
-                {% elseif tab.href is defined and tab.href != null %}
-                    {% set type = 'link' %}
-                    {% set href = tab.href %}
+                {% else %}
+                    {% set href = '#' ~ tab.id %}
+                    {% set type = 'tab' %}
+                    {%
+                        if tab.src is defined
+                        and tab.src != null
+                        and (
+                               tab.src|json_encode|slice(0, 1) == '/'
+                            or tab.src|json_encode|slice(1, 1) == '#'
+                            or tab.src|json_encode|slice(1, 4) == 'http'
+                        )
+                    %}
+                        {% set type = 'link' %}
+                        {% set href = tab.src %}
+                    {% elseif tab.href is defined and tab.href != null %}
+                        {% set type = 'link' %}
+                        {% set href = tab.href %}
+                    {% endif %}
                 {% endif %}
 
                 {%
@@ -28,7 +33,8 @@
                         'class': 'nav-inline__link',
                         'label': tab.label,
                         'href': href,
-                        'data-toggle': type
+                        'data-toggle': type,
+                        'disabled': tab.disabled|default(false)
                     }
                 %}
                 {{ html.link(options|merge(tab.data|default({}))) }}


### PR DESCRIPTION
Example:

```
...
{
    "id"    : "buttons",
    "label" : "Buttons",
    "src"   : tab_buttons,
    "disabled": true
}
...
```

<img width="511" alt="screen shot 2016-07-18 at 14 21 23" src="https://cloud.githubusercontent.com/assets/18653/16916122/217aca6c-4cf3-11e6-9e71-831224743bba.png">

Closes #233 