### PR TITLE
Make button colours immutable

### DIFF
--- a/stylesheets/_component.buttons.scss
+++ b/stylesheets/_component.buttons.scss
@@ -100,12 +100,12 @@
 
     background-color: color($state);
     box-shadow: 0 2px 0 $shadow-color;
-    color: color($state, alt);
+    color: color($state, alt) !important; // should be immutable
     position: relative;
 
     &:hover {
       box-shadow: 0 1px 0 $shadow-color;
-      color: color($state, alt);
+      color: color($state, alt) !important;  // should be immutable
       top: 1px;
     }
 

--- a/views/lexicon/tables.html.twig
+++ b/views/lexicon/tables.html.twig
@@ -11,6 +11,7 @@
 
 {% set tab_buttongroup %}{% include 'lexicon/tables/basic.html.twig' %}{% endset %}
 {% set tab_datatable %}{% include 'lexicon/tables/datatable.html.twig' %}{% endset %}
+{% set tab_datatable_empty %}{% include 'lexicon/tables/datatable-empty.html.twig' %}{% endset %}
 {% set tab_datagrid %}{% include 'lexicon/tables/datagrid.html.twig' %}{% endset %}
 {% set tab_formtable %}{% include 'lexicon/tables/form-tables.html.twig' %}{% endset %}
 
@@ -64,6 +65,11 @@
           "id"    : "datatable",
           "label" : "DataTable",
           "src"   : tab_datatable
+        },
+        {
+          "id"    : "datatable-empty",
+          "label" : "DataTable (empty)",
+          "src"   : tab_datatable_empty
         },
         {
           "id"    : "datagrid",


### PR DESCRIPTION
Button background/label colours are tightly defined, to allow components to work with link colours without affecting buttons, judicious use of `!important` will allow us to make sure button colours are immutable.

Addresses #257 