### PR TITLE
Move js bundle out of <head> in base template

### DIFF
--- a/views/pulsar/layouts/base.html.twig
+++ b/views/pulsar/layouts/base.html.twig
@@ -44,15 +44,6 @@
 
     <!-- <link rel="stylesheet" href="http://basehold.it/12"> -->
 
-    <script
-        src="{{ base_path ~ 'dist/js/bundle.js' }}"
-        type="text/javascript"
-        id="main-js"
-{% if pageModule is defined %}
-        data-page="{{ pageModule }}"
-{% endif %}
-    ></script>
-    <script src="{{ base_path ~ 'js/main.js' }}" type="text/javascript"></script>
     {% block pageStyle %}{% endblock %}
 </head>
 <body class="language-html theme-slate" id="top">
@@ -143,7 +134,17 @@
 {% endblock body %}
 
 {% block modals %}{% endblock %}
-{% block javascript %}{% endblock %}
 
+    <script
+        src="{{ base_path ~ 'dist/js/bundle.js' }}"
+        type="text/javascript"
+        id="main-js"
+{% if pageModule is defined %}
+        data-page="{{ pageModule }}"
+{% endif %}
+    ></script>
+    <script src="{{ base_path ~ 'js/main.js' }}" type="text/javascript"></script>
+
+{% block javascript %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
This change is mainly a test to prove that there's no adverse effects with moving the main js bundle out of the `<head>`

Closes #277 