### PR TITLE
Fix issue where guidance popovers were hidden when used in a modal, and didn't scroll correctly

### DIFF
--- a/stylesheets/_component.modals.scss
+++ b/stylesheets/_component.modals.scss
@@ -196,3 +196,6 @@
     }
 }
 
+.modal__backdrop.in + .popover {
+    z-index: $zindex-modal + 1;
+}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-guidance-container.html
@@ -1,0 +1,11 @@
+<div class="form__group form__button-group">
+    <label class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i></label>
+    <div class="controls btn__group">
+        <input name="bands" type="radio" class="form__control radio" />
+        <label class="control__label">AM</label>
+        <input name="bands" type="radio" class="form__control radio" />
+        <label class="control__label">FM</label>
+        <input name="bands" type="radio" class="form__control radio" />
+        <label class="control__label">MW</label>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-guidance-container.html.twig
@@ -1,0 +1,25 @@
+{#
+    Test basic button_group method
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.button_group({
+        'label': 'foo',
+        'guidance': 'bar',
+        'guidance-container': 'baz',
+        'items': [
+            form.radio_simple({
+                'label': 'AM',
+                'name': 'bands'
+            }),
+            form.radio_simple({
+                'label': 'FM',
+                'name': 'bands'
+            }),
+            form.radio_simple({
+                'label': 'MW',
+                'name': 'bands'
+            })
+        ]
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox-guidance-container.html
@@ -1,0 +1,8 @@
+<div class="form__group form-checkbox">
+    <label class="control__label">foo
+        <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i>
+    </label>
+    <div class="controls">
+        <input type="checkbox" class="form__control checkbox" />
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox-guidance-container.html.twig
@@ -1,0 +1,11 @@
+{#
+    Test basic checkbox method
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.checkbox({
+        'label': 'foo',
+        'guidance': 'bar',
+        'guidance-container': 'baz'
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox_inline-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox_inline-guidance-container.html
@@ -1,0 +1,5 @@
+<div class="form__group form-checkbox-inline">
+    <div class="controls">
+        <label class="control__label"><input type="checkbox" class="form__control checkbox" />foo <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i></label>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox_inline-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox_inline-guidance-container.html.twig
@@ -1,0 +1,11 @@
+{#
+    Test basic checkbox_inline method
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.checkbox_inline({
+        'label': 'foo',
+        'guidance': 'bar',
+        'guidance-container': 'baz'
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-guidance-container.html
@@ -1,0 +1,14 @@
+<div class="form__group form-choice">
+    <label class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i></label>
+    <div class="controls">
+        <label class="control__label">
+            <input name="choice" value="foo" type="radio" class="form__control radio" />Foo
+        </label>
+        <label class="control__label">
+            <input name="choice" value="bar" type="radio" class="form__control radio" />Bar
+        </label>
+        <label class="control__label">
+            <input name="choice" value="baz" type="radio" class="form__control radio" />Baz
+        </label>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-guidance-container.html.twig
@@ -1,0 +1,28 @@
+{#
+    Test basic choice method
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.choice({
+        'label': 'foo',
+        'guidance': 'bar',
+        'guidance-container': 'baz',
+        'options': [
+            {
+                'label': 'Foo',
+                'name': 'choice',
+                'value': 'foo'
+            },
+            {
+                'label': 'Bar',
+                'name': 'choice',
+                'value': 'bar'
+            },
+            {
+                'label': 'Baz',
+                'name': 'choice',
+                'value': 'baz'
+            }
+        ]
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-many-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-many-guidance-container.html
@@ -1,0 +1,10 @@
+<div class="form__group form-choice">
+    <label class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i></label>
+    <div class="controls">
+        <select class="form__control js-select2">
+            <option value="foo">Foo</option>
+            <option value="bar">Bar</option>
+            <option value="baz">Baz</option>
+        </select>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-many-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-many-guidance-container.html.twig
@@ -1,0 +1,29 @@
+{#
+    Test optimize-many choice method
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.choice({
+        'label': 'foo',
+        'optimize': 'many',
+        'guidance': 'bar',
+        'guidance-container': 'baz',
+        'options': [
+            {
+                'label': 'Foo',
+                'name': 'choice',
+                'value': 'foo'
+            },
+            {
+                'label': 'Bar',
+                'name': 'choice',
+                'value': 'bar'
+            },
+            {
+                'label': 'Baz',
+                'name': 'choice',
+                'value': 'baz'
+            }
+        ]
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/date-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/date-guidance-container.html
@@ -1,0 +1,8 @@
+<div class="form__group">
+<label class="control__label">foo
+        <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i>
+    </label>
+    <div class="controls">
+        <input placeholder="dd/mm/yyyy" data-datepicker="true" type="text" class="form__control" />
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/date-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/date-guidance-container.html.twig
@@ -1,0 +1,11 @@
+{#
+    Test basic date method
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.date({
+        'label': 'foo',
+        'guidance': 'bar',
+        'guidance-container': 'baz'
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-guidance-container.html
@@ -1,0 +1,8 @@
+<div class="form__group">
+    <label class="control__label">foo
+        <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i>
+    </label>
+    <div class="controls">
+        <input type="file" class="form__control file" />
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-guidance-container.html.twig
@@ -1,0 +1,11 @@
+{#
+    Test basic file method
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.file({
+        'label': 'foo',
+        'guidance': 'bar',
+        'guidance-container': 'baz'
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-label.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-label.html
@@ -1,6 +1,0 @@
-<div class="form__group">
-    <label class="control__label">foo</label>
-    <div class="controls">
-        <input type="file" class="form__control file" />
-    </div>
-</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-label.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-label.html.twig
@@ -1,9 +1,0 @@
-{#
-    Test file method with label
-#}
-{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
-{{
-    form.file({
-        'label': 'foo'
-    })
-}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file.html
@@ -1,4 +1,5 @@
 <div class="form__group">
+    <label class="control__label">foo</label>
     <div class="controls">
         <input type="file" class="form__control file" />
     </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file.html.twig
@@ -1,7 +1,9 @@
 {#
-    Test basic file method
+    Test file method with label
 #}
 {% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
 {{
-    form.file()
+    form.file({
+        'label': 'foo'
+    })
 }}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio_inline-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio_inline-guidance-container.html
@@ -1,0 +1,5 @@
+<div class="form__group form-radio-inline">
+    <div class="controls">
+        <label class="control__label"><input type="radio" class="form__control radio" />foo <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i></label>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio_inline-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio_inline-guidance-container.html.twig
@@ -1,0 +1,11 @@
+{#
+    Test basic checkbox_inline method
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.radio_inline({
+        'label': 'foo',
+        'guidance': 'bar',
+        'guidance-container': 'baz'
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-guidance-container.html
@@ -1,0 +1,9 @@
+<div class="form__group">
+    <label class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i></label>
+    <div class="controls">
+        <select class="form__control select">
+            <option value="baz">baz</option>
+            <option value="qux">qux</option>
+        </select>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-guidance-container.html.twig
@@ -1,0 +1,15 @@
+{#
+    Test basic select input with guidance
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.select({
+        'label': 'foo',
+        'guidance': 'bar',
+        'guidance-container': 'baz',
+        'options': {
+            'baz': 'baz',
+            'qux': 'qux'
+        }
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-guidance-container.html
@@ -1,0 +1,9 @@
+<div class="form__group">
+    <label class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i></label>
+    <div class="controls">
+        <select class="form__control js-select2">
+            <option value="baz">baz</option>
+            <option value="qux">qux</option>
+        </select>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-guidance-container.html.twig
@@ -1,0 +1,15 @@
+{#
+    Test basic select2 input
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.select2({
+        'label': 'foo',
+        'guidance': 'bar',
+        'guidance-container': 'baz',
+        'options': {
+            'baz': 'baz',
+            'qux': 'qux'
+        }
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-append-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-append-guidance-container.html
@@ -1,0 +1,11 @@
+<div class="form__group">
+    <label class="control__label">foo
+        <i data-container="qux" data-content="baz" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i>
+    </label>
+    <div class="controls">
+        <div class="input-group">
+            <input type="text" class="form__control" />
+            <span class="input-group-addon">bar</span>
+        </div>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-append-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-append-guidance-container.html.twig
@@ -1,0 +1,12 @@
+{#
+    Test appended text input
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.text({
+        'label': 'foo',
+        'append': 'bar',
+        'guidance': 'baz',
+        'guidance-container': 'qux'
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-guidance-container.html
@@ -1,0 +1,8 @@
+<div class="form__group">
+    <label class="control__label">foo
+        <i data-container="baz" data-content="foo &lt;span class=&quot;bar&quot;&gt;bar&lt;/span&gt;" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i>
+    </label>
+    <div class="controls">
+        <input type="text" class="form__control" />
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-guidance-container.html.twig
@@ -1,0 +1,11 @@
+{#
+    Test basic text input
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.text({
+        'label': 'foo',
+        'guidance': 'foo <span class="bar">bar</span>',
+        'guidance-container': 'baz'
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-prepend-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-prepend-guidance-container.html
@@ -1,0 +1,11 @@
+<div class="form__group">
+    <label class="control__label">foo
+        <i data-container="qux" data-content="baz" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i>
+    </label>
+    <div class="controls">
+        <div class="input-group">
+            <span class="input-group-addon">bar</span>
+            <input type="text" class="form__control" />
+        </div>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-prepend-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-prepend-guidance-container.html.twig
@@ -1,0 +1,12 @@
+{#
+    Test prepended text input
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.text({
+        'label': 'foo',
+        'prepend': 'bar',
+        'guidance': 'baz',
+        'guidance-container': 'qux'
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea-guidance-container.html
@@ -1,0 +1,6 @@
+<div class="form__group">
+    <label class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i></label>
+    <div class="controls">
+        <textarea class="form__control textarea"></textarea>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea-guidance-container.html.twig
@@ -1,0 +1,11 @@
+{#
+    Test basic textarea input
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+{{
+    form.textarea({
+        'label': 'foo',
+        'guidance': 'bar',
+        'guidance-container': 'baz'
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea.html
@@ -1,4 +1,5 @@
 <div class="form__group">
+    <label class="control__label">foo</label>
     <div class="controls">
         <textarea class="form__control textarea"></textarea>
     </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea.html.twig
@@ -3,5 +3,7 @@
 #}
 {% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
 {{
-    form.textarea()
+    form.textarea({
+        'label': 'foo'
+    })
 }}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance-container.html
@@ -1,0 +1,9 @@
+<div class="form__group">
+    <label for="toggletest" class="control__label">Toggle <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i></label>
+    <div class="controls">
+        <input label="Toggle" id="toggletest" type="checkbox" class="form__control toggle-switch" />
+        <label for="toggletest" class="control__label toggle-switch-label">
+            <span class="hide">Toggle</span>
+        </label>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance-container.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance-container.html.twig
@@ -1,0 +1,13 @@
+{#
+    Test toggle switch with label
+#}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+
+{{
+    form.toggle_switch({
+        'label': 'Toggle',
+        'guidance': 'bar',
+        'id': 'toggletest',
+        'guidance-container': 'baz'
+    })
+}}

--- a/views/pulsar/v2/helpers/elem.html.twig
+++ b/views/pulsar/v2/helpers/elem.html.twig
@@ -84,7 +84,7 @@ name    | string | The name of this control
     {% if options.label is not empty or options.guidance is not empty %}
         <label{{
             attributes(options
-                |exclude('guidance label required')
+                |exclude('container guidance guidance-container label required')
                 |defaults({
                     'class': 'control__label'
                 })
@@ -92,7 +92,7 @@ name    | string | The name of this control
         }}>
             {{- options.label|raw -}}
             {{ util.required(options.required|default(false)) }}
-            {{ util.guidance(options.guidance|default) }}
+            {{ util.guidance(options.guidance|default, { 'guidance-container': options['guidance-container']|default }) }}
         </label>
     {% endif %}
 

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -56,7 +56,7 @@ items         | array  | An array of items to put in the dropdown list (usually 
     {{
         form.group({
             'parent': options
-                |only('bare class error guidance help id label required')
+                |only('bare class error guidance guidance-container help id label required')
                 |merge({'class': options.class|default ~ ' form__button-group'}),
             'controls': {'class': 'btn__group'},
             'inputs': options.items
@@ -118,14 +118,14 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
     {{
         form.group({
             'parent': options
-                |only('bare class error guidance help id label required')
+                |only('bare class error guidance guidance-container help id label required')
                 |defaults({
                     'class': 'form-checkbox'
                 }),
             'inputs': [
                 elem.input(
                     options
-                        |exclude('bare class error guidance help label')
+                        |exclude('bare class error guidance guidance-container help label')
                         |defaults({
                             'class': 'checkbox',
                             'type': 'checkbox'
@@ -203,7 +203,7 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {%
         set input = elem.input(options
-            |exclude('error guidance')
+            |exclude('error guidance guidance-container')
             |merge({
                 'class': inputClass,
                 'label': null,
@@ -232,7 +232,8 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
                     'for': options.id|default,
                     'guidance': options.guidance|default,
                     'label': label,
-                    'required': options.required|default
+                    'required': options.required|default,
+                    'guidance-container': options['guidance-container']|default
                 })
             ]
         })
@@ -341,7 +342,7 @@ multiple | bool   | If `true`, uses checkboxes instead of radios, or passes the 
     {{
         form.group({
             'parent': options
-                |only('bare class error guidance help id label required')
+                |only('bare class error guidance guidance-container help id label required')
                 |exclude('multiple')
                 |defaults({'class': 'form-choice'}),
             'inputs': inputs
@@ -401,10 +402,10 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {{
         form.group({
-            'parent': options|only('bare class error guidance help id label'),
+            'parent': options|only('bare class error guidance guidance-container help id label'),
             'inputs': [
                 elem.paragraph(
-                    options|exclude('bare class error guidance help label')
+                    options|exclude('bare class error guidance guidance-container help label')
                 )
             ]
         })
@@ -800,10 +801,10 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {{
         form.group({
-            'parent': options|only('bare class error guidance help id label required'),
+            'parent': options|only('bare class error guidance guidance-container help id label required'),
             'inputs': [
                 elem.input(options
-                    |exclude('bare class guidance error help label')
+                    |exclude('bare class guidance guidance-container error help label')
                     |defaults({'type': 'file'})
                     |merge({'class': 'file'})
                 )
@@ -931,7 +932,8 @@ controls.class   | string | A space separated list of class names
                 'for': options.parent.id|default,
                 'guidance': options.parent.guidance|default,
                 'label': options.parent.label|default,
-                'required': options.parent.required|default
+                'required': options.parent.required|default,
+                'guidance-container': options.parent['guidance-container']|default
             })
         }}
 
@@ -1201,13 +1203,13 @@ data-*   | string | Data attributes, eg: `'data-foo': 'bar'`
     {{
         form.group({
             'parent': options
-                |only('bare class error guidance help id label required')
+                |only('bare class error guidance guidance-container help id label required')
                 |defaults({
                     'class': 'form-radio'
                 }),
             'inputs': [
                 elem.input(options
-                    |exclude('bare class error guidance help label')
+                    |exclude('bare class error guidance guidance-container help label')
                     |defaults({
                         'class': 'radio',
                         'type': 'radio'
@@ -1283,7 +1285,7 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {%
         set input = elem.input(options
-            |exclude('error guidance')
+            |exclude('error guidance guidance-container')
             |merge({
                 'class': inputClass,
                 'label': null,
@@ -1304,7 +1306,7 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
     {{
         form.group({
             'parent': options
-                |only('bare class error help id')
+                |only('bare class error guidance-container help id')
                 |defaults({
                     'class': 'form-radio-inline'
                 }),
@@ -1313,7 +1315,8 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
                     'for': options.id|default,
                     'label': label,
                     'required': options.required|default,
-                    'guidance': options.guidance|default
+                    'guidance': options.guidance|default,
+                    'guidance-container': options['guidance-container']|default
                 })
             ]
         })
@@ -1379,7 +1382,7 @@ required | bool   | Visually indicates that the field must be completed
 
     {{
         elem.input(options
-            |exclude('class for label')
+            |exclude('class for guidance-container label')
             |defaults({
                 'type': 'radio'
             })
@@ -1388,7 +1391,7 @@ required | bool   | Visually indicates that the field must be completed
     }}
     {{
         elem.label(options
-            |only('class label for required')
+            |only('class label for guidance-container required')
             |defaults({'for': options.id|default})
         )
     }}
@@ -1454,11 +1457,11 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {{
         form.group({
-            'parent': options|only('bare class error guidance help id label required'),
+            'parent': options|only('bare class error guidance guidance-container help id label required'),
             'inputs': [
                 elem.select(
                     options
-					|exclude('bare class error guidance help label')
+					|exclude('bare class error guidance guidance-container help label')
 					|merge({'class': 'select'})
                 )
             ]
@@ -1528,10 +1531,10 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {{
         form.group({
-            'parent': options|only('bare class error guidance help id label required'),
+            'parent': options|only('bare class error guidance guidance-container help id label required'),
             'inputs': [
                 elem.select2(options
-                    |exclude('bare class error guidance help label')
+                    |exclude('bare class error guidance guidance-container help label')
                 )
             ]
         })
@@ -1643,10 +1646,10 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {{
         form.group({
-            'parent': options|only('append append_type bare class error guidance help id label prepend prepend_type required'),
+            'parent': options|only('append append_type bare class error guidance guidance-container help id label prepend prepend_type required'),
             'inputs': [
                 elem.input(
-                    options|exclude('append_type bare class error guidance help label prepend_type')
+                    options|exclude('append_type bare class error guidance guidance-container help label prepend_type')
                 )
             ]
         })
@@ -1708,10 +1711,10 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {{
         form.group({
-            'parent': options|only('bare class error guidance help id label required'),
+            'parent': options|only('bare class error guidance guidance-container help id label required'),
             'inputs': [
                 elem.textarea(options
-                    |exclude('bare class error guidance help label')
+                    |exclude('bare class error guidance guidance-container help label')
                     |merge({'class': 'textarea'})
                 )
             ]
@@ -1774,7 +1777,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {%
         set toggle = elem.input(options
-            |exclude('error guidance')
+            |exclude('error guidance guidance-container')
             |merge({
                 'class': 'toggle-switch',
                 'type': 'checkbox'
@@ -1790,7 +1793,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
     {{
         form.group({
             'parent': options
-                |only('bare class error guidance help id label required'),
+                |only('bare class error guidance guidance-container help id label required'),
             'inputs': [toggle]
         })
     }}

--- a/views/pulsar/v2/helpers/util.html.twig
+++ b/views/pulsar/v2/helpers/util.html.twig
@@ -75,14 +75,14 @@
 {% endmacro %}
 
 
-{% macro guidance(value) %}
+{% macro guidance(value, options) %}
 {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% spaceless %}
     {% if value is not empty %}
     {{
         html.icon('question-sign', {
             'class': 'input-group-guidance',
-            'data-container': 'body',
+            'data-container': options['guidance-container']|default('body'),
             'data-content': value,
             'data-placement': 'top',
             'rel': 'clickover',


### PR DESCRIPTION
Popovers have a lower z-index than modals, I didn't really want to increase it by default as the default popover behaviour (without `clickover`) would remain visible when a modal is opened and quickly unleash the awesome fury of our test engineers. This change should only increase the z-index of any popovers created after a modal is opened.

Popovers are appended before `</body>` so can’t be `.modal .popover` but handily they’re appended after the modal backdrop, so we can target that as a sibling 🙌

<img width="525" alt="screen shot 2016-08-28 at 21 13 26" src="https://cloud.githubusercontent.com/assets/18653/18036521/4ff7d02e-6d64-11e6-8f23-fe0b2acd3df4.png">

Closes #262

A new `guidance-container` attribute can be passed to form helpers which will be passed to the guidance popover's `data-container` attribute, allowing a popover to be bound, for example, to a modal container rather than `body`. Closes #300