### PR TITLE
Make toolbar dropdowns fit screen width at smaller sizes

### DIFF
--- a/stylesheets/_component.toolbar.scss
+++ b/stylesheets/_component.toolbar.scss
@@ -24,9 +24,9 @@
 
     .dropdown__menu {
         clear: both;
-        left: 10px;
+        left: $padding-small-horizontal;
         position: absolute;
-        right: 10px;
+        right: $padding-small-horizontal;
         top: 60px;
 
         @include respond-min($screen-xsmall) {

--- a/stylesheets/_component.toolbar.scss
+++ b/stylesheets/_component.toolbar.scss
@@ -13,6 +13,30 @@
         margin-bottom: 0;
         padding: 14px 20px;
     }
+
+    .dropdown {
+        position: static;
+
+        @include respond-min($screen-xsmall) {
+            position: relative;
+        }
+    }
+
+    .dropdown__menu {
+        clear: both;
+        left: 10px;
+        position: absolute;
+        right: 10px;
+        top: 60px;
+
+        @include respond-min($screen-xsmall) {
+            left: auto;
+            right: 0;
+            top: auto;
+            width: auto;
+        }
+    }
+
 }
 
 .user-menu > .btn {
@@ -21,11 +45,6 @@
     &:hover {
         top: 0;
     }
-}
-
-.user-menu .dropdown__menu {
-    left: auto;
-    right: 0;
 }
 
 .nav-user {
@@ -47,12 +66,6 @@
         border-bottom: 1px solid $gray-lighter;
         font-family: $font-family-regular;
         padding: 3px 15px 3px 10px;
-    }
-
-    .dropdown__menu {
-        float: right;
-        right: 0;
-        left: auto;
     }
 
     .dropdown__menu .is-active {
@@ -144,4 +157,3 @@
         }
     }
 }
-


### PR DESCRIPTION
Dropdowns in the toolbar now follow the same behaviour as the notifications container.

![responsive-dropdowns](https://cloud.githubusercontent.com/assets/18653/18314244/160d6326-750a-11e6-9577-097fe75d16a8.gif)

Addresses #305 
