### PR TITLE
Allow local use of Proxima Nova in Pulsar and the Lexicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 /coverage
 /css
 /dist
+/fonts
+/fonts/_config.fonts.scss
 /tests/logs
 /css
 libs/livereload-js

--- a/fonts/_config.fonts.scss
+++ b/fonts/_config.fonts.scss
@@ -1,0 +1,1 @@
+// This file intentionally left blank

--- a/makefile
+++ b/makefile
@@ -90,6 +90,11 @@ endif
 	@ chmod -R u+x .git/hooks/*
 	@ echo "\n${CHECK} Done"
 
+	@ echo "${HR}\nCopy Proxima Nova (if available)...${HR}"
+	@ git update-index --assume-unchanged ./fonts/_config.fonts.scss
+	@ cp -r ../pulsar-fonts/src/* ./fonts 2>/dev/null || :
+	@ echo "\n${CHECK} Done"
+
 	@ echo "${HR}\nCompiling the stylesheets...${HR}\n"
 	@ grunt sass:dev
 	@ echo "${CHECK} Done\n"

--- a/stylesheets/pulsar.scss
+++ b/stylesheets/pulsar.scss
@@ -24,6 +24,9 @@ $fa-css-prefix: 'icon';
 @import 'deprecated.icons';
 @import '../libs/font-awesome/scss/font-awesome';
 
+$font-path: '../fonts/';
+@import '../fonts/config.fonts';
+
 // Mixins
 @import 'mixin.border-radius';
 @import 'mixin.clear-fix';
@@ -37,7 +40,6 @@ $fa-css-prefix: 'icon';
 
 // Config
 @import 'config.variables';
-@import 'config.fonts';
 @import 'config.branding';
 
 // Functions


### PR DESCRIPTION
Jadu developers can now use Proxima Nova in the Lexicon. For licensing reasons, non Jadu developers will not be able to do this unless they add their own licensed files.

# Steps

Check out both the `pulsar` and `pulsar-fonts` repos (pulsar fonts available on Jadu's GitLab instance) to the same directory

eg: `localhost/pulsar` `localhost/pulsar-fonts`

In the pulsar repo, run `make`. This will copy the required pulsar fonts files from `pulsar-fonts/src` to `pulsar/fonts` as well as setting the existing empty `pulsar/fonts/_config.fonts.scss` to not track changes in git to precent accidental comitting of this file.

The lexicon should now be displayed with Proxima Nova 🙌
