### PR TITLE
Help/error blocks should no longer sit alongside choice groups

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -280,6 +280,7 @@ $inputs: (
 }
 
 .help-block {
+    clear: both;
     color: color(text, light);
     display: block;
     font-size: $font-size-small;


### PR DESCRIPTION
<img width="787" alt="screen shot 2016-09-19 at 19 57 07" src="https://cloud.githubusercontent.com/assets/18653/18645158/10f83da4-7ea4-11e6-80d7-3e8f1fba6541.png">

Fixes #322 
