### PR TITLE
Fix issue where toolbar dropdowns were incorrectly positioned

### DIFF
--- a/stylesheets/_component.toolbar.scss
+++ b/stylesheets/_component.toolbar.scss
@@ -24,15 +24,19 @@
 
     .dropdown__menu {
         clear: both;
+
         left: $padding-small-horizontal;
-        position: absolute;
         right: $padding-small-horizontal;
-        top: 60px;
+
+        position: absolute;
+
+        top: auto;
 
         @include respond-min($screen-xsmall) {
             left: auto;
+            min-width: 340px;
             right: 0;
-            top: auto;
+            top: 60px;
             width: auto;
         }
     }

--- a/stylesheets/_component.toolbar.scss
+++ b/stylesheets/_component.toolbar.scss
@@ -24,20 +24,15 @@
 
     .dropdown__menu {
         clear: both;
-
         left: $padding-small-horizontal;
-        right: $padding-small-horizontal;
-
         position: absolute;
-
-        top: auto;
+        right: $padding-small-horizontal;
+        top: 60px;
 
         @include respond-min($screen-xsmall) {
             left: auto;
-            min-width: 340px;
             right: 0;
-            top: 60px;
-            width: auto;
+            top: 40px;
         }
     }
 

--- a/stylesheets/_component.toolbar.scss
+++ b/stylesheets/_component.toolbar.scss
@@ -32,7 +32,7 @@
         @include respond-min($screen-xsmall) {
             left: auto;
             right: 0;
-            top: 40px;
+            top: 35px;
         }
     }
 
@@ -82,14 +82,11 @@
 .nav-user > .dropdown > .btn, // pulsar
 .nav-user > .dropdown > .dropdown-toggle, // cms
 .site-switcher__label {
+    height: 42px;
     line-height: 42px;
     padding: 0;
     top: 0;
     vertical-align: top;
-
-    @include respond-min($screen-desktop) {
-        line-height: 42px;
-    }
 }
 
 .toolbar-icon,

--- a/views/lexicon/includes/notifications.html.twig
+++ b/views/lexicon/includes/notifications.html.twig
@@ -3,7 +3,7 @@
             html.link({
                 'class': 'notifications-toggle is-active',
                 'href': '#',
-                'label': html.icon('bell'),
+                'label': html.icon('bell-o'),
                 'data-toggle': 'dropdown'
             })
         }}

--- a/views/pulsar/layouts/base.html.twig
+++ b/views/pulsar/layouts/base.html.twig
@@ -79,6 +79,8 @@
 
                 <a href="#" class="mobile-menu-button t-mobile-menu-button">Menu</a>
 
+                {% block notifications %}{% endblock %}
+
                 <div class="nav-user">
                 {% block user_menu %}
                 {{
@@ -105,7 +107,6 @@
                 {% endblock %}
                 </div>
 
-                {% block notifications %}{% endblock %}
                 {% include '@pulsar/pulsar/components/nav_help.html.twig' %}
 
             </div>


### PR DESCRIPTION
Observed behaviour:

![_thumb_45287](https://cloud.githubusercontent.com/assets/18653/18745672/0523dcd6-80bb-11e6-86d5-80c1584a9d60.png)

After changes:

![responsive-dropdowns](https://cloud.githubusercontent.com/assets/18653/18745735/5f257b18-80bb-11e6-8a86-fc3f9dba69ed.gif)

