### PR TITLE
Fix button group border colours when state classes are used.

### DIFF
--- a/stylesheets/_component.button-groups.scss
+++ b/stylesheets/_component.button-groups.scss
@@ -33,7 +33,7 @@
     }
 
     @each $state, $state-color, $state-color-alt in $state-colors {
-        > .btn--#{$state}:not(:first-of-type):not(.btn--naked) {
+        > .btn--#{$state}:not(:first-of-type):not(.btn--naked):not(.edit-button):not(.remove-button) {
             border-left-color: darken(color($state), 10);
             border-right-color: darken(color($state), 10);
         }


### PR DESCRIPTION
Resolves #316 

![screen shot 2016-09-26 at 11 21 35](https://cloud.githubusercontent.com/assets/713141/18831043/83bcf668-83db-11e6-9a72-1ef877a526d1.png)

Bug was introduced with the commit 4faedf2e which made the default borders be of a higher specificity than those with state classes.