### PR TITLE
Remove relative paths from Twig loaders

### DIFF
--- a/app/app.php
+++ b/app/app.php
@@ -1,9 +1,9 @@
 <?php
 
-$baseDir = '../';
-$templateDir = $baseDir . 'views';
+$baseDir = '/var/www/html';
+$templateDir = $baseDir . '/views';
 
-require_once __DIR__ . '/' . $baseDir . 'vendor/autoload.php';
+require_once $baseDir . '/vendor/autoload.php';
 
 use Jadu\Pulsar\Twig\Extension\ArrayExtension;
 use Jadu\Pulsar\Twig\Extension\AttributeParserExtension;

--- a/app/test.php
+++ b/app/test.php
@@ -1,9 +1,9 @@
 <?php
 
-$baseDir = '../';
-$templateDir = $baseDir . 'tests/twig';
+$baseDir = '/var/www/html';
+$templateDir = $baseDir . '/tests/twig';
 
-require_once __DIR__ . '/' . $baseDir . 'vendor/autoload.php';
+require_once $baseDir . '/vendor/autoload.php';
 
 use Jadu\Pulsar\Twig\Extension\ArrayExtension;
 use Jadu\Pulsar\Twig\Extension\AttributeParserExtension;

--- a/tests/css/DiffTest.php
+++ b/tests/css/DiffTest.php
@@ -1,9 +1,9 @@
 <?php
 
-$baseDir = __DIR__ . '/../../';
-$templateDir = $baseDir . 'tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures';
+$baseDir = '/var/www/html';
+$templateDir = $baseDir . '/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures';
 
-require_once $baseDir . 'vendor/autoload.php';
+require_once $baseDir . '/vendor/autoload.php';
 
 use Jadu\Pulsar\Twig\Extension\ArrayExtension;
 use Jadu\Pulsar\Twig\Extension\AttributeParserExtension;
@@ -13,9 +13,9 @@ use Jadu\Pulsar\Twig\Extension\UrlParamsExtension;
 use Jadu\Pulsar\Twig\Extension\TabsExtension;
 
 $loader = new Twig_Loader_Filesystem($templateDir);
-$loader->addPath($baseDir . 'views', 'pulsar');
-$loader->addPath($baseDir . 'tests/css', 'cssTests');
-$loader->addPath($baseDir . 'tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures', 'tests');
+$loader->addPath($baseDir . '/views', 'pulsar');
+$loader->addPath($baseDir . '/tests/css', 'cssTests');
+$loader->addPath($baseDir . '/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures', 'tests');
 
 $twig = new Twig_Environment($loader,
     array(


### PR DESCRIPTION
This resolves an issue caused a change in Twig 1.25 preventing pages from being loaded.

Closes #335