### PR TITLE
Toggle switch helper should add class param to its container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pulsar
 
-[![Build Status](https://travis-ci.org/jadu/pulsar.svg?branch=develop)](https://travis-ci.org/jadu/pulsar) [![codecov.io](https://codecov.io/github/jadu/pulsar/coverage.svg?branch=develop)](https://codecov.io/github/jadu/pulsar?branch=develop)
+[![Build Status](https://travis-ci.org/jadu/pulsar.svg?branch=develop)](https://travis-ci.org/jadu/pulsar) [![Codecov](https://img.shields.io/codecov/c/github/jadu/pulsar.svg?label=codecov&maxAge=2592000)]() [![license](https://img.shields.io/github/license/jadu/pulsar.svg?maxAge=2592000)]()
 
 Pulsar is the User Experience and Interface framework for [Jadu](http://jadu.net) software.
 

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-class.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-class.html
@@ -1,0 +1,9 @@
+<div class="form__group foo form__group--toggle">
+    <label for="toggletest" class="control__label">Toggle</label>
+    <div class="controls">
+        <input label="Toggle" id="toggletest" type="checkbox" class="form__control toggle-switch" />
+        <label for="toggletest" class="control__label toggle-switch-label">
+            <span class="hide">Toggle</span>
+        </label>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-class.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-class.html.twig
@@ -1,0 +1,10 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.toggle_switch({
+        'class': 'foo',
+        'label': 'Toggle',
+        'id': 'toggletest'
+    })
+}}
+{% endblock %}

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -1803,7 +1803,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
             'parent': options
                 |only('bare class error guidance guidance-container help id label required')
                 |merge({
-                    'class': 'form__group--toggle'
+                    'class': options.class|default ~ ' form__group--toggle'
                 }),
             'inputs': [toggle]
         })


### PR DESCRIPTION
Resolves an issue introduced recently in 0259c65 which overrode existing `class` options and broke CMS masterswitch UIs. Added test cases to avoid this happening again.