### PR TITLE
Remove pre-commit git hook and grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -503,7 +503,11 @@ module.exports = function(grunt) {
         'email-build'
     ]);
 
-    grunt.registerTask('post-merge', ['sass:dev', 'browserify', 'email-build']);
+    grunt.registerTask('post-merge', [
+        'sass:dev',
+        'browserify',
+        'email-build'
+    ]);
 
     grunt.registerTask('build', [
         'scsslint',
@@ -537,11 +541,6 @@ module.exports = function(grunt) {
     grunt.registerTask('email-test', [
         'email-build',
         'mailgun'
-    ]);
-
-    grunt.registerTask('pre-commit', [
-        'asciify',
-        'phpunit'
     ]);
 
     grunt.registerTask('wraith', [

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,3 +1,0 @@
-PATH="/usr/local/bin:/usr/local/share/npm/bin:$PATH"
-#!/bin/sh
-grunt pre-commit


### PR DESCRIPTION
PHPUnit tests take ~1 minute to run and slow down regular development, these should be run by the developer as part of their own testing process before pushing to GitHub.

The pre-commit hook was also added before we had Travis running build jobs.