### PR TITLE
Changes required for CMS Maintenance UI

### DIFF
--- a/stylesheets/_component.buttons.scss
+++ b/stylesheets/_component.buttons.scss
@@ -216,6 +216,8 @@
 
 .btn--naked.is-disabled,
 .btn--naked:disabled {
+    background: none !important;
+    box-shadow: none !important;
     color: color(text, disabled) !important;
 
     &:hover {

--- a/stylesheets/_utility.utilities.scss
+++ b/stylesheets/_utility.utilities.scss
@@ -1,75 +1,75 @@
 .show-baseline {
-  @include baseline-grid;
+    @include baseline-grid;
 }
 
 %hide,
 .hide {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  border: 0;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    border: 0;
 }
 
 %show,
 .show {
-  clip: auto;
-  display: inline-block;
-  height: auto;
-  overflow: visible;
-  position: static;
-  width: auto;
+    clip: auto;
+    display: inline-block;
+    height: auto;
+    overflow: visible;
+    position: static;
+    width: auto;
 }
 
 .visually-hidden {
-  display: none;
+    display: none;
 }
 
 .muted {
-  color: color(gray, light);
+    color: color(gray, light);
 }
 
 .centered {
-  text-align: center;
+    text-align: center;
 }
 
 p.success {
-  background: rgba(0, 153, 51, .8);
-  color: color(white);
-  padding: 5px;
-  text-shadow: 0 0 2px rgba(0, 0, 0, .5);
+    background: rgba(0, 153, 51, .8);
+    color: color(white);
+    padding: 5px;
+    text-shadow: 0 0 2px rgba(0, 0, 0, .5);
 
-  i {
-    margin: 0 4px;
-  }
+    i {
+        margin: 0 4px;
+    }
 }
 
 // Removes default link styling
 .naked-link,
 .naked-link:hover {
-  text-decoration: none;
-  color: inherit;
+    text-decoration: none;
+    color: inherit;
 }
 
 .no-select {
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 // removes bottom margin from an element
 .bottomless {
-  margin-bottom: 0 !important;
+    margin-bottom: 0 !important;
 }
 
 .double-top {
-  margin-top: 2em;
+    margin-top: 2em;
 }
 
 .margin-left {

--- a/stylesheets/_utility.utilities.scss
+++ b/stylesheets/_utility.utilities.scss
@@ -65,7 +65,7 @@ p.success {
 
 // removes bottom margin from an element
 .bottomless {
-  margin-bottom: 0;
+  margin-bottom: 0 !important;
 }
 
 .double-top {

--- a/stylesheets/objects/_object.box.scss
+++ b/stylesheets/objects/_object.box.scss
@@ -6,3 +6,7 @@
 .box--rounded {
     border-radius: $border-radius;
 }
+
+.box--naked {
+    background-color: color(white);
+}


### PR DESCRIPTION
* Make `.bottomless` utility class immutable
* Fix disabled styling on naked buttons (spotted with wraith)
* Add `.box--naked` variant to allow a visually unboxed area to sit underneath a boxed area and maintain the same padding

e.g. here, the checkboxes on the white bg are with a `.box--naked` to match alignment with those within the grey box above.

![screen shot 2016-10-10 at 10 45 12](https://cloud.githubusercontent.com/assets/18653/19236954/16259dd6-8ef2-11e6-9145-661c77066792.png)