### PR TITLE
Form group small should no longer constrain help text to the input width

### DIFF
--- a/stylesheets/_override.shame.scss
+++ b/stylesheets/_override.shame.scss
@@ -94,39 +94,6 @@
     margin: 0;
   }
 
-
-
-  .form__group--small {
-    .controls {
-      @include respond-min($screen-xsmall) {
-        display: inline-block;
-        max-width: 150px;
-        min-width: 70px;
-        width: 61.5%;
-      }
-
-      @include respond-min($screen-small) {
-        width: 30%;
-      }
-    }
-
-    .form__control:not(.checkbox):not(.radio) {
-      margin: 0;
-
-      @include respond-min($screen-xsmall) {
-        width: 130px;
-      }
-    }
-
-    .controls + .controls {
-      margin: 0;
-
-      @include respond-min($screen-xsmall) {
-        margin-left: 10px;
-      }
-    }
-  }
-
   .form__group .form__collection ul {
     margin-left: 0;
   }


### PR DESCRIPTION
Removed a possible CXM specific override (circa July 2015) which, if still required, should perhaps be a modifier class instead of default behaviour? @jamesjacobs could you please review and see if this will break any CXM UI?

Before:

<img width="1063" alt="screen shot 2016-10-10 at 20 55 32" src="https://cloud.githubusercontent.com/assets/18653/19249858/7a262944-8f2f-11e6-9606-ac187f4220e9.png">

After:

<img width="1298" alt="screen shot 2016-10-10 at 21 15 24" src="https://cloud.githubusercontent.com/assets/18653/19249866/82e24a2c-8f2f-11e6-9ba6-587eedd33bad.png">

Closes #261