### PR TITLE
Restore outline to checkbox and radio inputs in iOS

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -22,7 +22,6 @@ fieldset {
 
 .form__control {
     border-radius: $input-border-radius;
-    border: 1px solid $input-border;
     height: $input-height-base;
     line-height: $input-height-base;
     padding: 0 $padding-base-horizontal;
@@ -36,23 +35,25 @@ fieldset {
         }
     }
 
+    &[type="password"],
+    &[type="text"] {
+        border: 1px solid $input-border;
+    }
+
     &.checkbox,
     &.radio {
         border-radius: 0;
-        border: 0;
         height: auto;
         padding: 0;
         vertical-align: baseline;
-    }
 
-    &.select,
-    &.checkbox,
-    &.radio {
-        border: 0;
-        padding: 0;
+        @include ie-lte(9) {
+            border: 0;
+        }
     }
 
     &.textarea {
+        border: 1px solid $input-border;
         height: auto;
         line-height: $line-height-base;
         min-height: 68px;

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-many-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-many-guidance-container.html
@@ -1,7 +1,7 @@
 <div class="form__group form-choice">
     <label class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i></label>
     <div class="controls">
-        <select class="form__control js-select2">
+        <select class="form__control select js-select2">
             <option value="foo">Foo</option>
             <option value="bar">Bar</option>
             <option value="baz">Baz</option>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-many-guidance.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-many-guidance.html
@@ -1,7 +1,7 @@
 <div class="form__group form-choice">
     <label class="control__label">foo <i data-container="body" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i></label>
     <div class="controls">
-        <select class="form__control js-select2">
+        <select class="form__control select js-select2">
             <option value="foo">Foo</option>
             <option value="bar">Bar</option>
             <option value="baz">Baz</option>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-many.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-many.html
@@ -1,6 +1,6 @@
 <div class="form__group form-choice">
     <div class="controls">
-        <select class="form__control js-select2">
+        <select class="form__control select js-select2">
             <option value="foo">Foo</option>
             <option value="bar">Bar</option>
             <option value="baz">Baz</option>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-multiple.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-multiple.html
@@ -1,6 +1,6 @@
 <div class="form__group form-choice">
     <div class="controls">
-        <select multiple class="form__control js-select2">
+        <select multiple class="form__control select js-select2">
             <option value="one">One</option>
             <option value="two">Two</option>
             <option value="three">Three</option>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize.html
@@ -1,6 +1,6 @@
 <div class="form__group form-choice">
     <div class="controls">
-        <select class="form__control js-select2">
+        <select class="form__control select js-select2">
             <option value="one">One</option>
             <option value="two">Two</option>
             <option value="three">Three</option>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-bare.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-bare.html
@@ -1,4 +1,4 @@
-<select class="form__control js-select2">
+<select class="form__control select js-select2">
     <option value="foo">bar</option>
     <option value="bar">baz</option>
 </select>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-error.html
@@ -1,6 +1,6 @@
 <div class="form__group has-error">
     <div class="controls">
-        <select class="form__control js-select2">
+        <select class="form__control select js-select2">
             <option value="foo">bar</option>
             <option value="bar">baz</option>
         </select>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-guidance-container.html
@@ -1,7 +1,7 @@
 <div class="form__group">
     <label class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i></label>
     <div class="controls">
-        <select class="form__control js-select2">
+        <select class="form__control select js-select2">
             <option value="baz">baz</option>
             <option value="qux">qux</option>
         </select>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-guidance.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-guidance.html
@@ -1,7 +1,7 @@
 <div class="form__group">
     <label class="control__label">foo <i data-container="body" data-content="bar" data-placement="top" rel="clickover" class="icon-question-sign input-group-guidance"></i></label>
     <div class="controls">
-        <select class="form__control js-select2">
+        <select class="form__control select js-select2">
             <option value="baz">baz</option>
             <option value="qux">qux</option>
         </select>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-multiple.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-multiple.html
@@ -1,6 +1,6 @@
 <div class="form__group">
     <div class="controls">
-        <select multiple class="form__control js-select2">
+        <select multiple class="form__control select js-select2">
             <option value="foo">bar</option>
             <option value="bar">baz</option>
         </select>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2.html
@@ -1,6 +1,6 @@
 <div class="form__group">
     <div class="controls">
-        <select class="form__control js-select2">
+        <select class="form__control select js-select2">
             <option value="foo">bar</option>
             <option value="bar">baz</option>
         </select>

--- a/views/pulsar/v2/helpers/elem.html.twig
+++ b/views/pulsar/v2/helpers/elem.html.twig
@@ -236,7 +236,7 @@ value       | string | Specifies the value of the input
 {% spaceless %}
     {% import _self as elem %}
 
-    {{ elem.select(options|merge({'class': 'js-select2'})) }}
+    {{ elem.select(options|merge({'class': 'select js-select2'})) }}
 
 {% endspaceless %}
 {% endmacro %}


### PR DESCRIPTION
Rather than setting a border on all inputs, they're now only set on text, textarea, password and select/select2 leaving the browser to style checkboxes and radios as they see fit.

Closes #370

## iPad (iOS5)
![img_5688](https://cloud.githubusercontent.com/assets/18653/19494121/84cd090c-9575-11e6-967d-5f81b231b3e9.jpg)
![img_5692](https://cloud.githubusercontent.com/assets/18653/19494122/84f57608-9575-11e6-8f8d-8910f50d1c06.jpg)

## iPhone 4s (iOS9)

![img_5689](https://cloud.githubusercontent.com/assets/18653/19494178/bc46dc32-9575-11e6-88b1-5946d0e8cce2.jpg)
![img_5693](https://cloud.githubusercontent.com/assets/18653/19494180/bc7324f4-9575-11e6-8240-9855bbf1d088.jpg)

## Galaxy s5 (Android Nougat)

![img_5697](https://cloud.githubusercontent.com/assets/18653/19494207/f0ea7ff2-9575-11e6-8ac1-b40e96a8bd4f.jpg)
![img_5695](https://cloud.githubusercontent.com/assets/18653/19494212/f3b3b212-9575-11e6-882b-1d14ba06a87d.jpg)

## Windows Phone 7 (for't laugh)

![img_5691](https://cloud.githubusercontent.com/assets/18653/19494233/0bd8c94a-9576-11e6-9537-b1babe52dbef.jpg)
![img_5694](https://cloud.githubusercontent.com/assets/18653/19494234/0c00e75e-9576-11e6-90c1-4e941ad178d1.jpg)
