### PR TITLE
Move yaml dependency to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
         }
     },
     "require": {
-        "twig/twig": "^1.21",
-        "symfony/yaml": "~2.6.0"
+        "twig/twig": "^1.21"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "*",
+        "symfony/yaml": "~2.6.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "*",
-        "symfony/yaml": "~2.6.0"
+        "symfony/yaml": "*"
     }
 }


### PR DESCRIPTION
The `symfony/yaml` dependency is only used during the `grunt wraith-update` task to write to `wraith.yml` and so isn't used in production.

Moving this to a development dependency should stop CMS and CXM throwing a warning about mismatched versions.

###  CMS result

* Removing `/vendor` and running `composer install` passed fine

```
 - Installing symfony/yaml (v2.6.13)
    Loading from cache
```

* Running `composer update` on current state of `develop` worked fine

```
~/Localhost/1-12 on develop*
$ composer update
You are running composer with xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Updating jadu/pulsar dev-yaml (ea18b57 => 6a28238)
    Checking out 6a2823810d24c20da669efe730d933965738a56c

Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.
Writing lock file
Generating autoload files
> npm install
npm WARN Continuum_CMS@ No license field.
> grunt composer
Running "copy:pulsar_dist" (copy) task
Created 253 directories, copied 2274 files

Running "sass:dev" (sass) task

Running "sass:dist_modern" (sass) task

Running "sass:dist_ie" (sass) task

Running "autoprefixer:dev" (autoprefixer) task

Running "browserify:pulsar_dist" (browserify) task
>> Bundle public_html/jadu/pulsar/js/bundle.js created.

Done, without errors.
```