### PR TITLE
Flash message should no longer have 1px offset in some browsers

### DIFF
--- a/stylesheets/_component.flash.scss
+++ b/stylesheets/_component.flash.scss
@@ -96,7 +96,7 @@
     clear: both;
     top: -5px;
     left: 0;
-    margin-bottom: 0;
+    margin: 0 -1px;
     position: relative;
     width: auto;
     z-index: $zindex-flash;

--- a/stylesheets/_component.flash.scss
+++ b/stylesheets/_component.flash.scss
@@ -96,7 +96,7 @@
     clear: both;
     top: -5px;
     left: 0;
-    margin: 0 -1px;
+    margin-bottom: 0;
     position: relative;
     width: auto;
     z-index: $zindex-flash;

--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -12,7 +12,7 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
     top: 0;
     transform: translate3d(-100%, 0, 0);
     vertical-align: top;
-    width: 75px;
+    width: 74px;
     z-index: $zindex-nav;
 
     @include respond-min($screen-desktop) {


### PR DESCRIPTION
Fixes this issue:

![screen shot 2016-10-20 at 10 24 20](https://cloud.githubusercontent.com/assets/18653/19554205/768f1cf0-96af-11e6-8101-57a425b46db2.png)
