### PR TITLE
Stop some CMS UIs from being non-scrollable

### DIFF
--- a/stylesheets/_structure.scaffolding.scss
+++ b/stylesheets/_structure.scaffolding.scss
@@ -31,7 +31,7 @@ body {
   display: table;
   height: 100%;
   margin: 0;
-  overflow: hidden;
+  overflow-x: hidden;
   position: relative;
   width: 100%;
 


### PR DESCRIPTION
Have had a look at this change on Lexicon & CMS and can't see anything has broken