### PR TITLE
Restore expected colours to btn—white

### DIFF
--- a/stylesheets/_deprecated.styles.scss
+++ b/stylesheets/_deprecated.styles.scss
@@ -59,11 +59,3 @@ $info-color-alt:                #000;
 $inverse-color-alt:             #fff;
 
 $toolbar-bg-hover:              #f00;
-
-$state-colors: ("base", $base-color, $base-color-alt),
-               ("primary", $primary-color, $primary-color-alt),
-               ("success", $success-color, $success-color-alt),
-               ("warning", $warning-color, $warning-color-alt),
-               ("danger", $danger-color, $danger-color-alt),
-               ("info", $info-color, $info-color-alt),
-               ("inverse", $inverse-color, $inverse-color-alt);


### PR DESCRIPTION
An old `$state-colors` map was in the deprecated styles file, and was preventing the changes to the base palette from being included.

Closes #383 

![screen shot 2016-10-24 at 12 41 21](https://cloud.githubusercontent.com/assets/18653/19644379/3cb7fd36-99e7-11e6-80da-af67114b70f8.png)
![screen shot 2016-10-24 at 12 41 27](https://cloud.githubusercontent.com/assets/18653/19644381/3f0cee02-99e7-11e6-8ba3-d03635adc0e7.png)
![screen shot 2016-10-24 at 12 41 31](https://cloud.githubusercontent.com/assets/18653/19644385/42a070e8-99e7-11e6-9dbf-56e158cf62e3.png)
![screen shot 2016-10-24 at 12 41 39](https://cloud.githubusercontent.com/assets/18653/19644388/450be286-99e7-11e6-912d-b56559dcf0f9.png)