### PR TITLE
Primary nav no longer shows incorrect 1px offset

### DIFF
--- a/stylesheets/_component.footer.scss
+++ b/stylesheets/_component.footer.scss
@@ -24,15 +24,15 @@
     }
 
     @include respond-min($screen-desktop) {
-        left: 75px;
+        left: $nav-primary-width;
     }
 
     .open-nav & {
-        -webkit-transform: translate3d(75px, 0, 0) scale3d(1, 1, 1);
-        transform: translate3d(75px, 0, 0) scale3d(1, 1, 1);
+        -webkit-transform: translate3d($nav-primary-width, 0, 0) scale3d(1, 1, 1);
+        transform: translate3d($nav-primary-width, 0, 0) scale3d(1, 1, 1);
 
         @include respond-min($screen-desktop) {
-            left: 75px;
+            left: $nav-primary-width;
             -webkit-transform: none;
             transform: none;
         }
@@ -43,7 +43,7 @@
         transform: translate3d(-300px, 0, 0) scale3d(1, 1, 1);
 
         @include respond-min($screen-desktop) {
-            left: 75px;
+            left: $nav-primary-width;
             -webkit-transform: none;
             transform: none;
         }
@@ -62,7 +62,7 @@
 }
 
 .lt-ie10 .open-nav .footer {
-    left: 75px;
+    left: $nav-primary-width;
 }
 
 .lt-ie10.open-help .footer {

--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -12,7 +12,7 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
     top: 0;
     transform: translate3d(-100%, 0, 0);
     vertical-align: top;
-    width: 74px;
+    width: $nav-primary-width;
     z-index: $zindex-nav;
 
     @include respond-min($screen-desktop) {
@@ -25,7 +25,7 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
     }
 
     .lt-ie10 & {
-        left: -75px;
+        left: -($nav-primary-width);
     }
 }
 
@@ -221,7 +221,7 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
     position: fixed;
     text-align: center;
     transition: box-shadow 100ms linear;
-    width: 75px;
+    width: $nav-primary-width;
     z-index: $zindex-nav;
 
     .is-active {
@@ -239,8 +239,8 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
         font-family: $font-family-regular;
         font-size: .75em;
         line-height: 1em;
-        max-width: 75px;
-        min-width: 75px;
+        max-width: $nav-primary-width;
+        min-width: $nav-primary-width;
         padding: 16px 5px 0;
         position: relative;
         text-overflow: ellipsis;
@@ -297,7 +297,7 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
 .nav-secondary {
     background-color: $nav-color-dark;
     box-shadow: inset -4px 0 0 darken($nav-color-dark, 4);
-    left: 75px;
+    left: $nav-primary-width;
     margin-left: -320px;
     overflow-x: hidden;
     overflow-y: auto;

--- a/stylesheets/_config.branding.scss
+++ b/stylesheets/_config.branding.scss
@@ -4,7 +4,7 @@
 
 $brand-image:                         $image-path + 'brand.png' !default;
 $brand-height:                        24px !default;
-$brand-width:                         75px !default;
+$brand-width:                         $nav-primary-width !default;
 $brand-background-size:               100% !default;
 
 $branding-site:                       $image-path + 'branding/logo-cms-white.svg';

--- a/stylesheets/_config.variables.scss
+++ b/stylesheets/_config.variables.scss
@@ -108,8 +108,7 @@ $padding-small-horizontal:            10px !default;
 //  Navigation
 // -----------------------------------------------------------------------------
 
-$nav-primary-width:                   45%;
-$nav-primary-item-width:              32%; // % of $nav-primary-width
+$nav-primary-width:                   74px;
 
 // -----------------------------------------------------------------------------
 //  Forms

--- a/stylesheets/_layout.tabs.scss
+++ b/stylesheets/_layout.tabs.scss
@@ -53,8 +53,8 @@
 }
 
 .open-nav .inner-wrapper {
-    -webkit-transform: translate3d(75px, 0, 0) scale3d(1, 1, 1);
-    transform: translate3d(75px, 0, 0) scale3d(1, 1, 1);
+    -webkit-transform: translate3d($nav-primary-width, 0, 0) scale3d(1, 1, 1);
+    transform: translate3d($nav-primary-width, 0, 0) scale3d(1, 1, 1);
 
     @include respond-min($screen-desktop) {
         -webkit-backface-visibility: hidden;
@@ -67,7 +67,7 @@
     }
 
     .lt-ie10 & {
-        left: 75px;
+        left: $nav-primary-width;
     }
 }
 
@@ -91,7 +91,7 @@
 }
 
 .lt-ie10 .open-nav .inner-wrapper {
-    left: 75px;
+    left: $nav-primary-width;
 }
 
 .tabs__content {


### PR DESCRIPTION
* Removes legacy navigation variable values
* Adds new nav width variable value and uses that whevever we’re calculating things for the layout  based on the nav width

![img_5728](https://cloud.githubusercontent.com/assets/18653/19685327/e457d774-9ab3-11e6-8b16-d4a1e0752f0d.jpg)
![img_5729](https://cloud.githubusercontent.com/assets/18653/19685326/e4576ece-9ab3-11e6-95cc-cf9fe50e7a03.jpg)
![img_5730](https://cloud.githubusercontent.com/assets/18653/19685328/e45b398c-9ab3-11e6-8b24-43dec2afe119.jpg)
![img_5731](https://cloud.githubusercontent.com/assets/18653/19685329/e45dd9ee-9ab3-11e6-9e72-552dddee4d0b.jpg)
