### PR TITLE
Use correct outputStyle option name in Grunt Sass task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,7 +62,7 @@ module.exports = function(grunt) {
         sass: {
             dev: {
                 options: {
-                    style: 'nested',
+                    outputStyle: 'nested',
                     sourceMap: true
                 },
                 files: [{
@@ -104,7 +104,7 @@ module.exports = function(grunt) {
             },
             email: {
                 options: {
-                    style: 'nested',
+                    outputStyle: 'nested',
                     sourceMap: true
                 },
                 files: [{


### PR DESCRIPTION
This should fix the issue where css output within `/dist` wasn’t compressed.

Closes #399
