### PR TITLE
Table rows can now be sorted if the table has the is-sortable class

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -54,9 +54,25 @@
             }
         });
 
-        $('.is-sortable').sortable({
+        $('div.is-sortable').sortable({
              placeholder: "form__group is-sorting",
              helper: "clone",
+             opacity: 0.9,
+             start: function(e, ui) {
+                $(ui.helper).addClass('is-dragging');
+            }
+        }).disableSelection();
+
+        var fixHelper = function(e, ui) {
+            ui.children().each(function() {
+                $(this).width($(this).width());
+            });
+            return ui;
+        };
+
+        $('.table.is-sortable tbody').sortable({
+             placeholder: "is-sorting",
+             helper: fixHelper,
              opacity: 0.9,
              start: function(e, ui) {
                 $(ui.helper).addClass('is-dragging');

--- a/stylesheets/_mixin.mixins-to-organise.scss
+++ b/stylesheets/_mixin.mixins-to-organise.scss
@@ -234,3 +234,12 @@ $is-ie: false !default;
         }
     }
 }
+
+@mixin cursor($cursor) {
+    @if $cursor == 'grab' {
+        cursor: move; /* fallback if grab cursor is unsupported */
+        cursor: grab;
+        cursor: -moz-grab;
+        cursor: -webkit-grab;
+    }
+}

--- a/stylesheets/_utility.sortable.scss
+++ b/stylesheets/_utility.sortable.scss
@@ -1,4 +1,13 @@
-.is-sortable {
+@mixin sortable-handle {
+    content: '\f0c9';
+    color: color(text, light);
+    font-family: fontawesome;
+    position: absolute;
+    left: 20px;
+    top: 10px;
+}
+
+div.is-sortable {
     .ui-sortable-handle {
         background-color: color(background, light);
         margin-bottom: 4px;
@@ -15,19 +24,11 @@
 
         &,
         .control__label {
-            cursor: move; /* fallback if grab cursor is unsupported */
-            cursor: grab;
-            cursor: -moz-grab;
-            cursor: -webkit-grab;
+            @include cursor('grab');
         }
 
         &::before {
-            content: '\f0c9';
-            color: color(text, light);
-            font-family: fontawesome;
-            position: absolute;
-            left: 20px;
-            top: 10px;
+            @include sortable-handle;
         }
 
         &.form__group::before {
@@ -40,7 +41,7 @@
     }
 }
 
-.is-sorting {
+div.is-sorting {
     background-color: color(sorting);
     border: 1px dashed color(sorting, dark);
     border-radius: 5px;
@@ -50,6 +51,37 @@
 
     &::before {
         display: none;
+    }
+}
+
+
+.table.is-sortable {
+    tr > th:first-of-type,
+    tr > td:first-of-type {
+        padding-left: 50px;
+    }
+
+    .ui-sortable-handle > td:first-of-type {
+        @include cursor('grab');
+        position: relative;
+
+        &::before {
+            @include sortable-handle;
+        }
+
+        &:hover {
+            &::before {
+                color: color(jadu-blue);
+            }
+        }
+    }
+
+    .ui-sortable-helper {
+        display: table;
+    }
+
+    .is-sorting {
+        background-color: color(sorting);
     }
 }
 

--- a/views/playground/sortable/tab.html.twig
+++ b/views/playground/sortable/tab.html.twig
@@ -2,7 +2,6 @@
 
 {% block tab_content %}
 
-
     <div class="is-sortable">
     {{
         form.text({
@@ -43,6 +42,79 @@
         })
     }}
     </div>
+
+    <br /><hr>
+
+    <h2>Sortable tables</h2>
+
+    <table class="table is-sortable table--full">
+        <thead>
+            <tr>
+                <th>File title</th>
+                <th>Type</th>
+                <th>Size</th>
+                <th>Filename / URL</th>
+                <th class="centered">Delete</th>
+            </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                My awesome document
+            </td>
+            <td>
+                {{ html.icon('file-word-o') }} .docx
+            </td>
+            <td>
+                685 KB
+            </td>
+            <td>
+                document.docx
+            </td>
+            <td class="centered">
+                {{ form.checkbox({'bare': 'true'}) }}
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+                Innocent screensaver
+            </td>
+            <td>
+                {{ html.icon('file-code-o') }} .exe
+            </td>
+            <td>
+                3.5 MB
+            </td>
+            <td>
+                anna_kournikova.exe
+            </td>
+            <td class="centered">
+                {{ form.checkbox({'bare': 'true'}) }}
+            </td>
+        </tr>
+
+        <tr>
+            <td>
+                My awesome PDF
+            </td>
+            <td>
+                {{ html.icon('file-pdf-o') }} .pdf
+            </td>
+            <td>
+                685 KB
+            </td>
+            <td>
+                sdfghjkhjifldshjkfdshajkl.pdf
+            </td>
+            <td class="centered">
+                {{ form.checkbox({'bare': 'true'}) }}
+            </td>
+        </tr>
+
+        </tbody>
+    </table>
+
 
 
 {% endblock %}


### PR DESCRIPTION
Just needs the `.is-sortable` class adding to a table, probably not advisable to use this in conjunction with datatables.

Will be used in Continuum CMS to add sortability to things like download files lists.

Had to qualify the is sortable class into `div.is-sortable` and `.table.is-sortable` so as not to break backwards compatibility with existing sortable items, happy to discuss better ways of doing this.

```
<table class="table is-sortable">
```

![sortable-tables](https://cloud.githubusercontent.com/assets/18653/20306800/348718f0-ab34-11e6-80d9-b093e2148c13.gif)