### PR TITLE
Prevent prototype library from removing toolbar dropdown elements whe…

### DIFF
--- a/js/libs/dropdown.js
+++ b/js/libs/dropdown.js
@@ -98,7 +98,7 @@ var $ = require('jquery');
       if (!$parent.hasClass('open')) return
       $parent.trigger(e = $.Event('hide.bs.dropdown'))
       if (e.isDefaultPrevented()) return
-      $parent.removeClass('open').trigger('hidden.bs.dropdown')
+      $parent.removeClass('open').trigger('hidden.bs.dropdown').css('display', '');
     })
   }
 


### PR DESCRIPTION
…n escape key is pressed

This is down to a conflict with prototype’s `hide()` method which is still present on legacy Continuum UIs.