### PR TITLE
Progress list component no longer looks broken or hides labels at sma…

### DIFF
--- a/stylesheets/_component.progress-lists.scss
+++ b/stylesheets/_component.progress-lists.scss
@@ -85,6 +85,10 @@
     box-shadow: inset 0 -1px 0 rgba(0, 0, 0, .15);
     color: color(success, alt);
 
+    .badge {
+        color: color(white) !important;
+    }
+
     &:not(:last-child)::after {
         border-left-color: color(success);
     }
@@ -104,6 +108,10 @@
     background-color: color(primary);
     box-shadow: inset 0 -1px 0 rgba(0, 0, 0, .15);
     color: color(primary, alt);
+
+    .badge {
+        color: color(white) !important;
+    }
 
     &:not(:last-child)::after {
         border-left-color: color(primary);

--- a/stylesheets/_component.progress-lists.scss
+++ b/stylesheets/_component.progress-lists.scss
@@ -14,6 +14,7 @@
     display: table-cell;
     padding: .75em 0 .75em 40px;
     text-decoration: none;
+    vertical-align: top;
 
     &:not(:last-child) {
         @include css-arrow(23px, right, $progress-bg);
@@ -56,11 +57,11 @@
 .progress-list__label {
     @include word-break-all;
 
-    display: inline;
+    display: inline-block;
     position: relative;
     text-align: left;
-    z-index: 2;
     width: 100%;
+    z-index: 2;
 
     .badge {
         display: none;

--- a/stylesheets/_component.progress-lists.scss
+++ b/stylesheets/_component.progress-lists.scss
@@ -8,10 +8,11 @@
 
 .progress-list__item {
     background-color: $progress-bg;
+    border-right: 3px solid color(white);
     box-shadow: inset 2px 1px 2px rgba(0, 0, 0, .1);
     color: color(black);
     display: table-cell;
-    padding: .75em 0;
+    padding: .75em 0 .75em 40px;
     text-decoration: none;
 
     &:not(:last-child) {
@@ -27,6 +28,7 @@
     &:first-child {
         border-top-left-radius: $border-radius;
         border-bottom-left-radius: $border-radius;
+        padding-left: 15px;
     }
 
     &:last-child {
@@ -52,8 +54,9 @@
 
 
 .progress-list__label {
+    @include word-break-all;
+
     display: inline;
-    padding-left: 40px;
     position: relative;
     text-align: left;
     z-index: 2;
@@ -66,10 +69,6 @@
         @include respond-min($screen-desktop) {
             display: inline-block;
         }
-    }
-
-    .progress-list__item:first-child & {
-        padding-left: 15px;
     }
 }
 

--- a/stylesheets/_mixin.mixins-to-organise.scss
+++ b/stylesheets/_mixin.mixins-to-organise.scss
@@ -43,6 +43,17 @@
     white-space: nowrap;
 }
 
+@mixin word-break-all() {
+    // Warning: Needed for oldIE support, but words are broken up letter-by-letter
+    word-break: break-all;
+
+    // Non standard for webkit
+    word-break: break-word;
+
+    // Fancy locale-aware hyphenation
+    hyphens: auto;
+}
+
 // Single side border-radius
 @mixin border-top-radius($radius) {
     border-top-right-radius: $radius;

--- a/views/lexicon/tabs/progress_bars.html.twig
+++ b/views/lexicon/tabs/progress_bars.html.twig
@@ -201,7 +201,7 @@
 
         <a href="#" class="progress-list__item progress-list__item--complete">
             <span class="progress-list__label">
-                <span class="badge badge--round badge--outline">Step 3</span>
+                <span class="badge badge--round badge--outline">Step 4</span>
                 Complete
             </span>
             <span class="progress-list__arrow">&gt;</span>
@@ -209,7 +209,7 @@
 
         <a href="#" class="progress-list__item progress-list__item--complete">
             <span class="progress-list__label">
-                <span class="badge badge--round badge--outline">Step 3</span>
+                <span class="badge badge--round badge--outline">Step 5</span>
                 Complete
             </span>
             <span class="progress-list__arrow">&gt;</span>

--- a/views/lexicon/tabs/progress_bars.html.twig
+++ b/views/lexicon/tabs/progress_bars.html.twig
@@ -199,6 +199,22 @@
             <span class="progress-list__arrow">&gt;</span>
         </a>
 
+        <a href="#" class="progress-list__item progress-list__item--complete">
+            <span class="progress-list__label">
+                <span class="badge badge--round badge--outline">Step 3</span>
+                Complete
+            </span>
+            <span class="progress-list__arrow">&gt;</span>
+        </a>
+
+        <a href="#" class="progress-list__item progress-list__item--complete">
+            <span class="progress-list__label">
+                <span class="badge badge--round badge--outline">Step 3</span>
+                Complete
+            </span>
+            <span class="progress-list__arrow">&gt;</span>
+        </a>
+
     </div>
 
 {% endblock tab_content %}


### PR DESCRIPTION
…ller screen widths

Closes #372

## Cross browser tests

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] IE Edge
- [x] IE 11
- [x] IE 10
- [x] IE 9
- [x] IE 8

- [x] Mobile Safari 
- [x] Samsung Internet

## Before:

<img width="317" alt="screen shot 2016-11-20 at 13 16 00" src="https://cloud.githubusercontent.com/assets/18653/20463077/82f6d74e-af23-11e6-8107-1fac42db4957.png">

## After: 

![progress-list](https://cloud.githubusercontent.com/assets/18653/20463080/88c2fcac-af23-11e6-827c-53619e2cc98f.gif)