### PR TITLE
Clicking toggle control now toggles the element again

### DIFF
--- a/stylesheets/_component.tab-help.scss
+++ b/stylesheets/_component.tab-help.scss
@@ -32,7 +32,7 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
 
 .tab-help {
     filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=70);
-    padding: 20px;
+    padding: 40px 20px 20px;
     opacity: .7;
     transition-delay: ease, 0s;
     transform-origin: 50% 0%;

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-class.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-class.html
@@ -1,8 +1,8 @@
 <div class="form__group foo form__group--toggle">
-    <label for="toggletest" class="control__label">Toggle</label>
+    <label class="control__label">Toggle</label>
     <div class="controls">
         <input label="Toggle" id="toggletest" type="checkbox" class="form__control toggle-switch" />
-        <label class="control__label toggle-switch-label">
+        <label for="toggletest" class="control__label toggle-switch-label">
             <span class="hide">Toggle</span>
         </label>
     </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-error.html
@@ -1,8 +1,8 @@
 <div class="form__group has-error form__group--toggle">
-    <label for="toggletest" class="control__label">Toggle</label>
+    <label class="control__label">Toggle</label>
     <div class="controls">
         <input label="Toggle" id="toggletest" type="checkbox" class="form__control toggle-switch" />
-        <label class="control__label toggle-switch-label">
+        <label for="toggletest" class="control__label toggle-switch-label">
             <span class="hide">Toggle</span>
         </label>
         <span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance-container.html
@@ -1,8 +1,8 @@
 <div class="form__group form__group--toggle">
-    <label for="toggletest" class="control__label">Toggle <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></label>
+    <label class="control__label">Toggle <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></label>
     <div class="controls">
         <input label="Toggle" id="toggletest" type="checkbox" class="form__control toggle-switch" />
-        <label class="control__label toggle-switch-label">
+        <label for="toggletest" class="control__label toggle-switch-label">
             <span class="hide">Toggle</span>
         </label>
     </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance.html
@@ -1,8 +1,8 @@
 <div class="form__group form__group--toggle">
-    <label for="toggletest" class="control__label">Toggle <i data-container="body" data-content="bar" data-placement="top" rel="clickover" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></label>
+    <label class="control__label">Toggle <i data-container="body" data-content="bar" data-placement="top" rel="clickover" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></label>
     <div class="controls">
         <input label="Toggle" id="toggletest" type="checkbox" class="form__control toggle-switch" />
-        <label class="control__label toggle-switch-label">
+        <label for="toggletest" class="control__label toggle-switch-label">
             <span class="hide">Toggle</span>
         </label>
     </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch.html
@@ -1,8 +1,8 @@
 <div class="form__group form__group--toggle">
-    <label for="toggletest" class="control__label">Toggle</label>
+    <label class="control__label">Toggle</label>
     <div class="controls">
         <input label="Toggle" id="toggletest" type="checkbox" class="form__control toggle-switch" />
-        <label class="control__label toggle-switch-label">
+        <label for="toggletest" class="control__label toggle-switch-label">
             <span class="hide">Toggle</span>
         </label>
     </div>

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -1793,6 +1793,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
             })
         ) ~ elem.label({
                 'class': 'toggle-switch-label',
+                'for': options.id|default,
                 'label': toggleLabel,
                 'required': options.required|default
             })
@@ -1801,7 +1802,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
     {{
         form.group({
             'parent': options
-                |only('bare class error guidance guidance-container help id label required')
+                |only('bare class error guidance guidance-container help label required')
                 |merge({
                     'class': options.class|default ~ ' form__group--toggle'
                 }),


### PR DESCRIPTION
Revert change which removed the `for` attribute from the toggle control and meant it could no longer be clicked.