### PR TITLE
Make select2 elements have same disabled styling as regular selects

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -75,6 +75,12 @@ fieldset {
         @include ie-lte(8) {
             height: 24px;
         }
+
+        // remove the caret in IE 11 and below, other browsers are taken care of
+        // by the `appearance` property
+        &::-ms-expand {
+            display: none;
+        }
     }
 
     &.file {

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -70,7 +70,7 @@ fieldset {
         background-position: 97%;
         background-repeat: no-repeat;
         border: 1px solid $input-border;
-        padding: 0 0 0 $padding-base-horizontal;
+        padding: 0 20px 0 $padding-base-horizontal;
 
         @include ie-lte(8) {
             height: 24px;

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -65,6 +65,10 @@ fieldset {
     }
 
     &.select {
+        appearance: none;
+        background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAFZJREFUOBFjYBgFVA+Bp0AT/xPAT/DZ6gWU/IPHgN9AOQ98BoDkMoAYlytSCWmGyXdhMaQNJkkMzQhUtBLJkGVANkiMJMABVL0PiHcBMTtJOkcVkxYCADK5Iu6w+agDAAAAAElFTkSuQmCC');
+        background-position: 97%;
+        background-repeat: no-repeat;
         border: 1px solid $input-border;
         padding: 0 0 0 $padding-base-horizontal;
 
@@ -142,9 +146,9 @@ fieldset {
     // Note: HTML5 says that inputs under a fieldset > legend:first-child won't be
     // disabled if the fieldset is disabled. Due to implementation difficulty,
     // we don't honor that edge case; we style them as disabled anyway.
-    &[disabled],
-    &[readonly],
-    fieldset[disabled] & {
+    &:not(.checkbox):not(.radio):not(.file)[disabled],
+    &:not(.checkbox):not(.radio):not(.file)[readonly],
+    fieldset[disabled] &:not(.checkbox):not(.radio):not(.file) {
         cursor: not-allowed;
         background-color: $input-bg-disabled;
     }

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -76,7 +76,13 @@ fieldset {
             height: 24px;
         }
 
-        // remove the caret in IE 11 and below, other browsers are taken care of
+        // select arrows can't be hidden in IE8 & 9, so reset to default styles
+        @include ie-lte(9) {
+            background-image: none;
+            padding-right: 0;
+        }
+
+        // remove the arrow in IE10 & 11, modern browsers are taken care of
         // by the `appearance` property
         &::-ms-expand {
             display: none;
@@ -128,7 +134,7 @@ fieldset {
             @include ie-lte(8) {
                 border: 1px solid $input-border;
                 max-width: 100%;
-                padding: 0 $padding-base-horizontal;
+                padding: 0 0 0 $padding-base-horizontal;
                 width: 300px;
             }
         }

--- a/tests/css/visual-regression-layout.html.twig
+++ b/tests/css/visual-regression-layout.html.twig
@@ -29,7 +29,7 @@
     <!--[if lt IE 9]>
     <script type="text/javascript" src="{{ libsPath ~ 'html5shiv/dist/html5shiv.js' }}"></script>
     <script type="text/javascript" src="{{ libsPath ~ 'nwmatcher/src/nwmatcher.js' }}"></script>
-    <script type="text/javascript" src="{{ libsPath ~ 'selectivizr/selectivizr.js' }}"></script>
+
     <script type="text/javascript" src="{{ libsPath ~ 'respond/dest/respond.min.js' }}"></script>
     <![endif]-->
 


### PR DESCRIPTION
<img width="652" alt="screen shot 2016-12-13 at 16 29 19" src="https://cloud.githubusercontent.com/assets/18653/21148947/c6d1ccf4-c151-11e6-9b59-5402ae73851b.png">

Closes #430

## Browser testing

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge
- [x] IE11
- [x] IE10
- [x] IE9
- [x] IE8
- [x] Mobile Safari
- [x] Samsung Internet
