### PR TITLE
Primary nav should be correctly hidden again when in small-screen res…

### DIFF
--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -219,11 +219,14 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
 .nav-primary {
     background-color: $nav-color-light;
     box-shadow: inset 0 0 0 $nav-color-dark;
-    position: fixed;
     text-align: center;
     transition: box-shadow 100ms linear;
     width: $nav-primary-width;
     z-index: $zindex-nav;
+
+    @include respond-min($screen-desktop) {
+        position: fixed;
+    }
 
     .is-active {
         background-color: $nav-color-dark;


### PR DESCRIPTION
…ponsive mode

Fixes #448

However, this restores the bug reported in issue #386 where the primary navigation can be scrolled on touch devices. As the IE issue is a more critical bug, I’m going to allow the minor touch issue to be reintroduced briefly so that IE can be fixed.

Reverts this commit:

```
$ git log ae03c9cd -1
commit ae03c9cdf0fa2b389ca54208ebf5ff27f665fb7c
Author: Paul Stanton <paul.stanton@jadu.net>
Date:   Tue Oct 25 10:03:16 2016 +0100

    Primary navigation should no longer be scrollable on touch devices

    Closes #386
```