### PR TITLE
Fix Android Right Extra Space

### DIFF
--- a/stylesheets/_structure.scaffolding.scss
+++ b/stylesheets/_structure.scaffolding.scss
@@ -27,7 +27,7 @@ body {
   height: 100%;
   // Allow any content to clear the fixed footer
   margin: 0 0 40px;
-  overflow-x: hidden;
+  overflow: hidden;
   position: relative;
   width: 100%;
 


### PR DESCRIPTION
This issue was encountered in Android 6.0.1.
closes #456

Tested on Samsung Galaxy, iPad and OnePlus3.