### PR TITLE
Fix HTML validation issues

### DIFF
--- a/views/pulsar/layouts/base.html.twig
+++ b/views/pulsar/layouts/base.html.twig
@@ -75,7 +75,7 @@
 
     {% block pageStyle %}{% endblock %}
 </head>
-<body class="language-html theme-slate" id="top">
+<body class="language-html theme-slate">
 
 {% block body %}
     <div role="main" class="container" id="top">

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -786,7 +786,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
-    <a{{ attributes(options|exclude('icon label type')) }}>
+    <a{{ attributes(options|exclude('icon label type value')) }}>
 
         {%- if options.icon is defined and options.icon is not empty -%}
             {{- html.icon(options.icon) -}}&nbsp;

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1055,7 +1055,7 @@ data-*      | string    | Data attributes, eg: `'data-foo': 'bar'`
 
     <{{ type }}{{
         attributes(options
-            |exclude('action description icon icon_colour image image_alt title type')
+            |exclude('action description icon icon_colour image image_alt title type value')
             |defaults({
                 'class': 'media'
             })

--- a/views/pulsar/v2/helpers/nav.html.twig
+++ b/views/pulsar/v2/helpers/nav.html.twig
@@ -64,7 +64,7 @@
     <li
         {{
             attributes(options
-                |exclude('href data-toggle')
+                |exclude('data-toggle href icon')
                 |defaults({ 'class': 'nav-item t-nav-item' })
             )
         }}


### PR DESCRIPTION
Did a quick pass of Continuum CMS through the HTML validator and fixed a couple of minor issues.

- [x] Stop `html.link` helper from using the `value` attribute
- [x] Stop `html.media` helper from using the `value` attribute when using `link` type
- [x] Stop main navigation using the `icon` attribute on nav items