### PR TITLE
Stop disabled link helper from generating invalid HTML

### DIFF
--- a/src/Jadu/Pulsar/Twig.js/Extension/AttributeParserExtension.js
+++ b/src/Jadu/Pulsar/Twig.js/Extension/AttributeParserExtension.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var _ = require('lodash');
 
 function htmlEntities(str) {
@@ -37,11 +39,7 @@ AttributeParserExtension.prototype.parseAttributes = function (attributes, args)
         if (value && !_.isArray(value)) {
             if (typeof(value) === 'boolean') {
 
-                if (
-                    (!usingTag || args.tag != 'a')
-                        ||
-                    (usingTag && key != 'disabled')
-                ) {
+                if ((!usingTag || args.tag !== 'a') || (usingTag && key !== 'disabled')) {
                     html.push(key);
                 }
 

--- a/src/Jadu/Pulsar/Twig.js/Extension/AttributeParserExtension.js
+++ b/src/Jadu/Pulsar/Twig.js/Extension/AttributeParserExtension.js
@@ -12,7 +12,13 @@ AttributeParserExtension.prototype.getName = function () {
 };
 
 AttributeParserExtension.prototype.parseAttributes = function (attributes, args) {
-    if (!attributes || Object.keys(attributes).length === 0) {
+    var html = [''],
+        usingTag = false;
+
+    if (typeof args !== 'undefined' && 'tag' in args) {
+        usingTag = true;
+        html.push(args.tag);
+    } else if (!attributes || Object.keys(attributes).length === 0) {
         return '';
     }
 
@@ -25,24 +31,27 @@ AttributeParserExtension.prototype.parseAttributes = function (attributes, args)
 
     delete attributes['class'];
 
-    var html = [''];
-
     var addDisabledClass = false;
 
     _.forEach(attributes, function (value, key) {
         if (value && !_.isArray(value)) {
             if (typeof(value) === 'boolean') {
+
+                if (
+                    (!usingTag || args.tag != 'a')
+                        ||
+                    (usingTag && key != 'disabled')
+                ) {
+                    html.push(key);
+                }
+
                 switch (key) {
                     case 'required':
                         html.push('aria-required="true"');
                         break;
                     case 'disabled':
                         html.push('aria-disabled="true"');
-                        html.push(key);
                         addDisabledClass = true;
-                        break;
-                    default:
-                        html.push(key);
                         break;
                 }
             }
@@ -62,7 +71,13 @@ AttributeParserExtension.prototype.parseAttributes = function (attributes, args)
         html.push('class="' + classes.join(' ') + '"');
     }
 
-    return html.join(' ');
+    if (usingTag) {
+        return html.join(' ').trim();
+    }
+    else {
+        return html.join(' ');
+    }
+
 };
 
 AttributeParserExtension.prototype.defaultAttributes = function (attributes, defaults) {

--- a/src/Jadu/Pulsar/Twig/Extension/AttributeParserExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/AttributeParserExtension.php
@@ -129,11 +129,7 @@ class AttributeParserExtension extends \Twig_Extension
 
                             // Don't output `disabled` boolean on links as it
                             // throws a W3C validation error
-                            if (
-                                (!$usingTag || $args['tag'] != 'a')
-                                    ||
-                                ($usingTag && $key != 'disabled')
-                            ) {
+                            if ((!$usingTag || $args['tag'] != 'a') || ($usingTag && $key != 'disabled')) {
                                 $html[] = htmlspecialchars($key);
                             }
 

--- a/src/Jadu/Pulsar/Twig/Extension/AttributeParserExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/AttributeParserExtension.php
@@ -80,28 +80,38 @@ class AttributeParserExtension extends \Twig_Extension
      *
      * @param  array  $attributes An array of attributes to parse
      * @param  array  $args       Arguments to affect the output:
-     *                [exclude] A list of keys to remove. This takes precedence
-     *                over other options
-     *                [include] A list of keys to be output, all others will be
-     *                ignored
-     *                [default] Additional attributes to be included, if the
-     *                attribute exists in both $attributes and $args, the values
-     *                will be merged
+     *                [tag] A tag name to also include in the output, mainly
+     *                used to allow us to prevent invalid attributes from being
+     *                passed to the markup
+     *
+     *                Example:
+     *                    attributes({'disabled'}, {'tag': ('a')})
+     *
+     *                The above example will let us pass the disabled option to
+     *                allow us to create the necessary ARIA attributes and
+     *                classes, but we can test the tag argument to then strip
+     *                the `disabled` boolean from also being output as it's
+     *                invalid HTML
      * @return string A space separated string of key="value" attributes ready
      *                for including in an HTML element
      */
     public function parseAttributes($attributes, array $args = array())
     {
-        if (empty($attributes)) {
+        $html = array();
+        $usingTag = false;
+
+        if (isset($args['tag'])) {
+            $usingTag = true;
+            $html[] = $args['tag'];
+        }
+        else if (empty($attributes)) {
             return '';
         }
-
-        $html = array();
 
         // As classes can be supplied as a string, we'll' switch them to an
         // array to allow us to add new classes based on other attributes
         $classes = isset($attributes['class']) ? explode(' ', $attributes['class']) : array();
-		unset($attributes['class']);
+        unset($attributes['class']);
 
         // Parse the attributes
         foreach ($attributes as $key => &$value) {
@@ -116,7 +126,16 @@ class AttributeParserExtension extends \Twig_Extension
 
                         // Only output the key if true, do nothing if false
                         if ($value) {
-                            $html[] = htmlspecialchars($key);
+
+                            // Don't output `disabled` boolean on links as it
+                            // throws a W3C validation error
+                            if (
+                                (!$usingTag || $args['tag'] != 'a')
+                                    ||
+                                ($usingTag && $key != 'disabled')
+                            ) {
+                                $html[] = htmlspecialchars($key);
+                            }
 
                             // Add extra attributes based on certain properties
                             if ($key == 'required') {
@@ -137,11 +156,16 @@ class AttributeParserExtension extends \Twig_Extension
 
         // Re-stringify the classes array, as long as we have some
         if (!empty($classes)) {
-        	$html[] = ' class="' . implode(' ', array_unique($classes)) . '"';
+            $html[] = ' class="' . implode(' ', array_unique($classes)) . '"';
         }
 
         if (!empty($html)) {
-            return ' ' . implode(' ', $html);
+            if ($usingTag) {
+                return implode(' ', $html);
+            }
+            else {
+                return ' ' . implode(' ', $html);
+            }
         }
 
         return '';

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/link-disabled.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/link-disabled.html
@@ -1,0 +1,1 @@
+<a href="#foo" aria-disabled="true" class="is-disabled">foo</a>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/link-disabled.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/link-disabled.html.twig
@@ -1,0 +1,10 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    html.link({
+        'href': '#foo',
+        'label': 'foo',
+        'disabled': true
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-disabled.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-disabled.html
@@ -1,7 +1,7 @@
 <div class="nav-inline t-nav-inline">
     <ul class="nav-inline__list">
         <li class="nav-inline__item nav-inline__item--is-active is-active">
-            <a href="#" data-toggle="link" disabled aria-disabled="true" class="nav-inline__link is-disabled">bar</a>
+            <a href="#" data-toggle="link" aria-disabled="true" class="nav-inline__link is-disabled">bar</a>
         </li>
     </ul>
 </div>

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -786,7 +786,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
-    <a{{ attributes(options|exclude('icon label type')) }}>
+    <{{ attributes(options|exclude('icon label type'), {'tag': ('a')}) }}>
 
         {%- if options.icon is defined and options.icon is not empty -%}
             {{- html.icon(options.icon) -}}&nbsp;


### PR DESCRIPTION
- [x] Update PHP version of AttributeParserExtension
- [x] PHP tests passing
- [x] Update JS version of AttributeParserExtension
- [x] JS tests passing
----
Passing the `disabled` option to the `html.link` helper will no longer output the `disabled` boolean attribute in the markup which was throwing W3C validation errors.

This has required changes to the AttributeParserExtension (both PHP and JS) to allow us to pass an optional `tag` to the parser letting us modify the parsers output on a tag by tag basis.

Given this example:

```
html.link({
    'label': 'foo',
    'href': '#',
    'disabled': true
})
```

We need the `disabled` option to be passed to the parser in order for the `aria-disabled="true"` and `class="is-disabled"`attributes to be created, so we can't simply add `excludes('disabled')`, but we **do not** want the plain `disabled` attribute to be present on links, but we **do** want it on other elements like form inputs.

Passing the tag name for links lets us add tag-specific logic in the parser to prevent the `disabled` boolean from being output.

Usage:

```
<{{ attributes(options|exclude('icon label type'), {'tag': ('a')}) }}>
```

Closes #467 