### PR TITLE
CMS - Change Perceptive Content>Views>Table Full Width

### DIFF
--- a/stylesheets/_component.piano.scss
+++ b/stylesheets/_component.piano.scss
@@ -354,3 +354,10 @@
 .setting__actions {
     padding: 10px;
 }
+
+.piano-wrapper {
+    .tab__content {
+        display: table;
+        width: 100%;
+    }
+}


### PR DESCRIPTION
This is a fix for ticket: [https://jadultd.atlassian.net/browse/PER-149](https://jadultd.atlassian.net/browse/PER-149)

Makes the table inside Utilities>Integrations>Perceptive Content>Views full width in any browser IE8 up.