### PR TITLE
CMS - Fix Typo and Missing Class

### DIFF
--- a/stylesheets/_component.piano.scss
+++ b/stylesheets/_component.piano.scss
@@ -356,7 +356,12 @@
 }
 
 .piano-wrapper {
+
     .tab__content {
+        display: table;
+    }
+
+    .tabs__content {
         display: table;
         width: 100%;
     }


### PR DESCRIPTION
Fixed a typo in class name and added missing class. This is part of the PER-149 ticket of CMS.