### PR TITLE
Remove extra padding when using a control label within a help block

### DIFF
--- a/makefile
+++ b/makefile
@@ -70,6 +70,7 @@ build:
 	@ echo "\n${CHECK} Done"
 
 	@ echo "${HR}\nCopy Proxima Nova (if available)...${HR}"
+	@ mkdir ./fonts
 	@ touch ./fonts/_config.fonts.scss
 	@ cp -r ../pulsar-fonts/src/* ./fonts 2>/dev/null || :
 	@ git update-index --skip-worktree fonts/_config.fonts.scss

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -313,7 +313,6 @@ $inputs: (
     padding: 0;
 }
 
-
 // if help block is next to the main label, space it appropriately
 .form__group > .control__label + .help-block {
     margin: -.5em 0 .5em;

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -307,6 +307,13 @@ $inputs: (
     font-size: $font-size-small;
 }
 
+// if a control label is in the help block (like a bare input) it doesn't need
+// the extra padding
+.help-block > .control__label {
+    padding: 0;
+}
+
+
 // if help block is next to the main label, space it appropriately
 .form__group > .control__label + .help-block {
     margin: -.5em 0 .5em;


### PR DESCRIPTION
Improves the appearance of bare `checkbox_inline` elements within the `help-block`

Before:

![screen shot 2017-03-01 at 11 11 22](https://cloud.githubusercontent.com/assets/18653/23457802/5513f788-fe71-11e6-938a-8feffab60a72.png)

After:

![screen shot 2017-03-01 at 11 10 56](https://cloud.githubusercontent.com/assets/18653/23457813/5b72494a-fe71-11e6-8b92-cbd2b662ea5d.png)