### PR TITLE
Close button alignment fix for chrome/safari in old OSX.

### DIFF
--- a/stylesheets/_component.modals.scss
+++ b/stylesheets/_component.modals.scss
@@ -204,6 +204,11 @@
 
 // Full screen modal
 .modal--full-screen {
+  
+    // Align close button correctly in old OSX chrome and Safari
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+
     .modal__content {
         bottom: 0;
         height: 100%;

--- a/stylesheets/_component.modals.scss
+++ b/stylesheets/_component.modals.scss
@@ -204,7 +204,6 @@
 
 // Full screen modal
 .modal--full-screen {
-  
     // Align close button correctly in old OSX chrome and Safari
     -webkit-transform: translate3d(0, 0, 0);
     transform: translate3d(0, 0, 0);


### PR DESCRIPTION
![screen shot 2017-03-06 at 12 01 52](https://cloud.githubusercontent.com/assets/756393/23609155/93a7109c-0264-11e7-8cde-e5ee8fc35665.png)

Close button aligned correctly.

Fixes #496 