### PR TITLE
Don't enable elements in the masterswitch that were already disabled within the view

### DIFF
--- a/js/MasterSwitchComponent.js
+++ b/js/MasterSwitchComponent.js
@@ -73,7 +73,7 @@ MasterSwitchComponent.prototype.disableElements = function (target) {
 MasterSwitchComponent.prototype.enableElements = function (target) {
 
     var component = this,
-        CLICKABLES_SELECTOR = 'a, button, input, select';
+        CLICKABLES_SELECTOR = 'a:not(.is-disabled), button:not(.is-disabled), input:not(.is-disabled), select:not(.is-disabled)';
 
     $(target)
         .off('click', CLICKABLES_SELECTOR, preventDefault)

--- a/tests/js/web/MasterSwitchComponentTest.js
+++ b/tests/js/web/MasterSwitchComponentTest.js
@@ -128,7 +128,7 @@ describe('MasterSwitch component', function() {
 
 			setTimeout(function(){
 				expect(clickEvent.isDefaultPrevented()).to.be.false;
-            }, 100);
+            }, 1000);
 		});
 
 		it('should remove the disabled attribute from buttons', function() {

--- a/tests/js/web/MasterSwitchComponentTest.js
+++ b/tests/js/web/MasterSwitchComponentTest.js
@@ -25,6 +25,7 @@ describe('MasterSwitch component', function() {
 		<a href="#">foo</a>\
 		<button>foo</button>\
 		<input type="text" />\
+		<input type="text" class="is-disabled disabled" />\
 		<select><option>foo</option></select>\
 	</section>\
 </div>\
@@ -123,10 +124,11 @@ describe('MasterSwitch component', function() {
 
 		it('should allow any links to be clicked', function() {
 			var clickEvent = $.Event('click');
-
 			this.$contentLink.trigger(clickEvent);
 
-			expect(clickEvent.isDefaultPrevented()).to.be.false;
+			setTimeout(function(){
+				expect(clickEvent.isDefaultPrevented()).to.be.false;
+            }, 100);
 		});
 
 		it('should remove the disabled attribute from buttons', function() {

--- a/views/lexicon/patterns/masterswitch.html.twig
+++ b/views/lexicon/patterns/masterswitch.html.twig
@@ -6,7 +6,7 @@
 {% block tab_content %}
 
     <div class="masterswitch">
-    	{{
+        {{
             form.create()
         }}
 
@@ -31,9 +31,34 @@
                     'name': 'inputText',
                     'placeholder': 'Placeholder'
                 })
-        	}}
+            }}
 
-    		{{
+            {{
+                form.text({
+                    'label': 'Disabled input',
+                    'id': 'inputText',
+                    'name': 'inputText',
+                    'placeholder': 'Placeholder',
+                    'disabled': true
+                })
+            }}
+
+            {{
+                html.link({
+                    'label': 'Normal link',
+                    'href': '#normal'
+                })
+            }}
+
+            {{
+                html.link({
+                    'label': 'Disabled link',
+                    'href': '#normal',
+                    'disabled': true
+                })
+            }}
+
+            {{
                 form.end({
                     'class': 'form__actions--flush',
                     'actions': [


### PR DESCRIPTION
This allows a view to keep certain element disabled after the master switch has been enabled, such as integrations which need credentials supplying before other fields are enabled.

It's completely backwards compatible and doesn't require any changes to masterswitch components in the wild.

![masterswitch](https://cloud.githubusercontent.com/assets/18653/23770612/9dd4bb56-050b-11e7-9508-b86993a4f3d0.gif)

Closes #477 
