### PR TITLE
Restore remove icons for Select2 elements in IE

### DIFF
--- a/stylesheets/_component.select2.scss
+++ b/stylesheets/_component.select2.scss
@@ -275,21 +275,18 @@
 
 
 .select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+    color: #dedede;
     cursor: pointer;
     display: inline-block;
     float: right;
-    visibility: hidden;
 
     &:after {
+        color: #000;
         content: '\f057';
         font-family: 'FontAwesome';
         margin-right: 5px;
         visibility: visible;
     }
-}
-
-.select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
-    color: #333;
 }
 
 .select2-container--default[dir="rtl"] .select2-selection--multiple .select2-selection__choice,


### PR DESCRIPTION
Issue down to the way IE handles visibility on parents. Seems you can't set a parent to be hidden and a child to be visible.

Fixed by 'hiding' the original X character by setting it to be the same colour as the background and stopping it from becoming visible again through hover.

Tested in IE11 and IE9 (My IE10 VM isn't working at the moment)

<img width="468" alt="screen shot 2017-03-12 at 10 03 53" src="https://cloud.githubusercontent.com/assets/18653/23830896/1173728e-070d-11e7-9cbc-01809bdef4cb.png">
<img width="624" alt="screen shot 2017-03-12 at 10 09 38" src="https://cloud.githubusercontent.com/assets/18653/23830897/13a5804c-070d-11e7-8d4e-42e8c1b264a0.png">

Closes #505 