### PR TITLE
Fix issue where content longer than the viewport would be cut off by the footer

### DIFF
--- a/stylesheets/_structure.scaffolding.scss
+++ b/stylesheets/_structure.scaffolding.scss
@@ -32,7 +32,7 @@ body {
   width: 100%;
 
   @include respond-min($screen-small) {
-    margin: 0 0 37px;
+    padding: 0 0 37px;
   }
 
   @include ie-lte(8) {


### PR DESCRIPTION
Need padding instead of margin because of the way `.container` uses 100% height.

**Before:**

![screen shot 2017-03-22 at 09 40 54](https://cloud.githubusercontent.com/assets/18653/24191423/b9d5082e-0ee3-11e7-95f2-71434b4f890e.png)

**After:**

![screen shot 2017-03-22 at 09 40 30](https://cloud.githubusercontent.com/assets/18653/24191430/c000e9de-0ee3-11e7-8bf1-6dd0545f1dc6.png)
