### PR TITLE
476 Broken footer and mobile menu styles in IE10/9

### DIFF
--- a/stylesheets/_component.footer.scss
+++ b/stylesheets/_component.footer.scss
@@ -33,6 +33,10 @@
             -webkit-transform: none;
             transform: none;
         }
+
+        @include ie-lte(9) {
+            left: $nav-primary-width;
+        }
     }
 
     .open-help & {

--- a/stylesheets/_component.footer.scss
+++ b/stylesheets/_component.footer.scss
@@ -28,7 +28,6 @@
     }
 
     .open-nav & {
-
         @include respond-min($screen-desktop) {
             left: $nav-primary-width;
             -webkit-transform: none;
@@ -37,7 +36,6 @@
     }
 
     .open-help & {
-
         @include respond-min($screen-desktop) {
             left: $nav-primary-width;
             -webkit-transform: none;
@@ -54,23 +52,6 @@
         &:hover {
             color: color(link);
         }
-    }
-}
-
-.lt-ie10 .footer {
-    position: relative;
-    left: 0;
-}
-
-.lt-ie10 .open-nav .footer {
-    left: 0;
-}
-
-.lt-ie10.open-help .footer {
-    right: 300px;
-
-    @include respond-min($screen-desktop) {
-        right: 0;
     }
 }
 

--- a/stylesheets/_layout.tabs.scss
+++ b/stylesheets/_layout.tabs.scss
@@ -29,7 +29,7 @@
     -webkit-transition: -webkit-transform 500ms ease;
     backface-visibility: hidden;
     display: table;
-    height: 100%;
+    height: 100vh;
     left: 0;
     padding-bottom: 24px; // make sure content clears the footer
     position: relative;

--- a/stylesheets/_layout.tabs.scss
+++ b/stylesheets/_layout.tabs.scss
@@ -1,7 +1,3 @@
-.container {
-    height: 100%;
-}
-
 .content-main {
     position: relative;
     display: table;
@@ -45,10 +41,6 @@
         display: table-row;
         left: auto;
         position: static;
-    }
-
-    .lt-ie10 & {
-        left: 0;
     }
 }
 


### PR DESCRIPTION
![ie9 fix](https://cloud.githubusercontent.com/assets/756393/24247336/3800f912-0fc3-11e7-91fc-a17b96931667.gif)
![ie10 fix](https://cloud.githubusercontent.com/assets/756393/24247340/3a6910cc-0fc3-11e7-8c1a-6bb5011d443e.gif)

Fixes #476 