### PR TITLE
Fix unnecessary scrolling

### DIFF
--- a/stylesheets/_layout.tabs.scss
+++ b/stylesheets/_layout.tabs.scss
@@ -29,7 +29,7 @@
     -webkit-transition: -webkit-transform 500ms ease;
     backface-visibility: hidden;
     display: table;
-    height: 100vh;
+    height: calc(100vh - 37px);
     left: 0;
     padding-bottom: 24px; // make sure content clears the footer
     position: relative;


### PR DESCRIPTION
Fixed by removing footer height from `.inner-wrapper` height.

![safari](https://cloud.githubusercontent.com/assets/756393/24298361/b06be148-109d-11e7-9f7d-390657961f82.gif)
![ie9](https://cloud.githubusercontent.com/assets/756393/24298380/bee97fe6-109d-11e7-820c-b1c8a48db508.gif)

Tested in:
- [x] IE9-Edge
- [x] Safari
- [x] Chrome
- [x] Firefox 

Fixes #498 