### PR TITLE
Disabled ui component

### DIFF
--- a/js/DisableUiComponent.js
+++ b/js/DisableUiComponent.js
@@ -38,18 +38,7 @@ DisableUiComponent.prototype.init = function () {
             .addClass('u-cursor-not-allowed');
 
         // Wrap with disabled wrapper to visually disable
-        // Check if masterswitch as we don't want to add 2 overlays
-        if ($this.hasClass('masterswitch')) {
-            // If the master switch is enabled, wrap in disabled overlay
-            if ($this.find('.form__control.toggle-switch').is(':checked')) {
-                $this.wrap('<div class="u-ui-disabled"></div>');
-            } else {
-                // If not, only wrap the control and let the master switch add the overlay
-                $this.find('.masterswitch-control').wrap('<div class="u-ui-disabled"></div>');
-            }
-        } else {
-            $this.wrap('<div class="u-ui-disabled"></div>');
-        }
+        $this.wrap('<div class="u-ui-disabled"></div>');
     });
 };
 

--- a/js/DisableUiComponent.js
+++ b/js/DisableUiComponent.js
@@ -4,7 +4,7 @@ var $ = require('jquery');
 
 function DisableUiComponent(html) {
     this.$html = html;
-};
+}
 
 function preventDefaultAndStopPropagation(e) {
     e.preventDefault();

--- a/js/DisableUiComponent.js
+++ b/js/DisableUiComponent.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var $ = require('jquery');
+
+function DisableUiComponent(html) {
+    this.$html = html;
+};
+
+function preventDefaultAndStopPropagation(e) {
+    e.preventDefault();
+    e.stopPropagation();
+}
+
+DisableUiComponent.prototype.init = function () {
+    var component = this;
+
+    component.$container = this.$html.find('[data-disable-ui="true"]');
+
+    component.$container.each(function() {
+
+        var $this = $(this),
+            FORM_ELEMENTS = 'button:not(.disabled), input:not(.disabled), select:not(.disabled)',
+            LINK_ELEMENTS = 'a:not(.disabled)',
+            LABEL_ELEMENTS = 'label';
+
+        // // Disable form elements
+        $this.find(FORM_ELEMENTS)
+            .on('click', preventDefaultAndStopPropagation)
+            .addClass('disabled')
+            .attr('disabled', 'disabled');
+
+        // Disable labels
+        $this.find(LABEL_ELEMENTS).addClass('u-cursor-not-allowed');
+
+        // // Disable links
+        $this.find(LINK_ELEMENTS)
+            .on('click', preventDefaultAndStopPropagation)
+            .addClass('u-cursor-not-allowed');
+
+        // Wrap with disabled wrapper to visually disable
+        // Check if masterswitch as we don't want to add 2 overlays
+        if ($this.hasClass('masterswitch')) {
+            // If the master switch is enabled, wrap in disabled overlay
+            if ($this.find('.form__control.toggle-switch').is(':checked')) {
+                $this.wrap('<div class="u-ui-disabled"></div>');
+            } else {
+                // If not, only wrap the control and let the master switch add the overlay
+                $this.find('.masterswitch-control').wrap('<div class="u-ui-disabled"></div>');
+            }
+        } else {
+            $this.wrap('<div class="u-ui-disabled"></div>');
+        }
+    });
+};
+
+module.exports = DisableUiComponent;

--- a/js/DisableUiComponent.js
+++ b/js/DisableUiComponent.js
@@ -23,7 +23,7 @@ DisableUiComponent.prototype.init = function () {
             LINK_ELEMENTS = 'a:not(.disabled)',
             LABEL_ELEMENTS = 'label';
 
-        // // Disable form elements
+        // Disable form elements
         $this.find(FORM_ELEMENTS)
             .on('click', preventDefaultAndStopPropagation)
             .addClass('disabled')
@@ -32,7 +32,7 @@ DisableUiComponent.prototype.init = function () {
         // Disable labels
         $this.find(LABEL_ELEMENTS).addClass('u-cursor-not-allowed');
 
-        // // Disable links
+        // Disable links
         $this.find(LINK_ELEMENTS)
             .on('click', preventDefaultAndStopPropagation)
             .addClass('u-cursor-not-allowed');

--- a/js/index.js
+++ b/js/index.js
@@ -34,6 +34,7 @@ var $                     = require('jquery'),
     dt_select     = require('datatables.net-select')(window, $),
 
     ButtonComponent = require('./ButtonComponent'),
+    DisableUiComponent = require('./DisableUiComponent'),
     HelpTextComponent = require('./HelpTextComponent'),
     FilterBarComponent = require('./FilterBarComponent'),
     FlashMessageComponent = require('./FlashMessageComponent'),
@@ -48,6 +49,7 @@ var $                     = require('jquery'),
 
 module.exports = {
     ButtonComponent: ButtonComponent,
+    DisableUiComponent: DisableUiComponent,
     HelpTextComponent: HelpTextComponent,
     FilterBarComponent: FilterBarComponent,
     FlashMessageComponent: FlashMessageComponent,

--- a/js/main.js
+++ b/js/main.js
@@ -10,6 +10,7 @@
     $html.removeClass('no-js');
 
     pulsar.button       = new pulsar.ButtonComponent($html);
+    pulsar.disableUi    = new pulsar.DisableUiComponent($html);
     pulsar.flash        = new pulsar.FlashMessageComponent($html);
     pulsar.helpText     = new pulsar.HelpTextComponent($html, window, document);
     pulsar.pulsarForm   = new pulsar.PulsarFormComponent($html);
@@ -33,6 +34,7 @@
         pulsar.modulePermissions.init();
         pulsar.navMain.init();
         pulsar.filterBar.init();
+        pulsar.disableUi.init();
 
         // Switch out .svg for .png for <img> elements in older browsers
         pulsar.svgeezy.init('nocheck', 'png');

--- a/stylesheets/_component.masterswitch.scss
+++ b/stylesheets/_component.masterswitch.scss
@@ -13,5 +13,9 @@
 	&.is-disabled {
 		cursor: not-allowed;
 		opacity: .25;
+
+		.u-ui-disabled & {
+			opacity: 1;
+		}
 	}
 }

--- a/stylesheets/_utility.utilities.scss
+++ b/stylesheets/_utility.utilities.scss
@@ -303,10 +303,12 @@ div.no-results {
 }
 
 .u-ui-disabled {
-    cursor: not-allowed;
+    @extend %u-cursor-not-allowed;
+
     opacity: .25;
 }
 
+%u-cursor-not-allowed,
 .u-cursor-not-allowed {
     cursor: not-allowed !important;
 }

--- a/stylesheets/_utility.utilities.scss
+++ b/stylesheets/_utility.utilities.scss
@@ -301,3 +301,12 @@ div.no-results {
 .u-text-align-justify {
     text-align: justify;
 }
+
+.u-ui-disabled {
+    cursor: not-allowed;
+    opacity: .25;
+}
+
+.u-cursor-not-allowed {
+    cursor: not-allowed !important;
+}

--- a/tests/js/web/DisableUiComponentTest.js
+++ b/tests/js/web/DisableUiComponentTest.js
@@ -1,0 +1,123 @@
+/*jshint multistr: true */
+
+'use strict';
+
+var $ = require('jquery'),
+	DisableUiComponent = require('../../../js/DisableUiComponent');
+
+describe('DisableUi component', function() {
+
+	beforeEach(function() {
+		this.$html = $('<html></html>');
+		this.$body = $('<body></body>').appendTo(this.$html);
+		this.$standardForm = $(
+			'<div data-disable-ui="true">' +
+			'	<label for="inputText" class="control__label text-label">Text input</label>' +
+			'	<input id="inputText" type="text" class="form__control">' +
+			'	<a href="http://google.com">External link</a>' +
+			'	<select><option>foo</option></select>' +
+			'	<button class="btn btn--primary" >Save Changes</button>' +
+	        '</div>'
+        ).appendTo(this.$body);
+        this.$masterswitchDisabled = $(
+        	'<div class="masterswitch" data-disable-ui="true" id="masterswitch1">' +
+			'	<div class="form__group masterswitch-control form__group--toggle">' +
+			'		<input id="toggletest" type="checkbox" class="form__control toggle-switch">' +
+			'		<label for="toggletest" class="control__label toggle-switch-label"><span class="hide">Enable masterswitch content</span></label>' +
+			'	</div>' +
+			'	<section class="masterswitch-content is-disabled">' +
+			'		<label for="inputText2" class="control__label">Text input</label>' +
+			'		<input id="inputText2" name="inputText2" type="text" class="form__control disabled">' +
+			'	</section>' +
+	        '</div>'
+        ).appendTo(this.$body);
+        this.$masterswitchEnabled = $(
+        	'<div class="masterswitch" data-disable-ui="true" id="masterswitch2">' +
+			'	<div class="form__group masterswitch-control form__group--toggle">' +
+			'		<input id="toggletest2" type="checkbox" class="form__control toggle-switch" checked="checked">' +
+			'		<label for="toggletest2" class="control__label toggle-switch-label"><span class="hide">Enable masterswitch content</span></label>' +
+			'	</div>' +
+			'	<section class="masterswitch-content">' +
+			'		<label for="inputText3" class="control__label">Text input</label>' +
+			'		<input id="inputText3" name="inputText3" type="text" class="form__control">' +
+			'	</section>' +
+	        '</div>'
+        ).appendTo(this.$body);
+
+		this.$link = this.$body.find('a');
+		this.$label = this.$body.find('.text-label');
+		this.$button = this.$body.find('.btn--primary');
+		this.$textInput = this.$body.find('input');
+		this.$select = this.$body.find('select');
+		this.$masterSwitchDisabledControl = this.$body.find('#masterswitch1 .masterswitch-control');
+		this.$masterswitchEnabledContainer = this.$body.find('#masterswitch2');
+		this.disableUi = new DisableUiComponent(this.$html);
+	});
+
+	describe('on init', function() {
+
+		beforeEach(function() {
+			this.disableUi.init();
+		});
+
+		it('should prevent default on links', function() {
+			var clickEvent = $.Event('click');
+
+			this.$link.trigger(clickEvent);
+
+			expect(clickEvent.isDefaultPrevented()).to.be.true;
+		});
+
+		it('should stop propagation of the click event', function() {
+			var clickEvent = $.Event('click');
+
+			this.$link.trigger(clickEvent);
+
+			expect(clickEvent.isPropagationStopped()).to.be.true;
+		});
+
+		it('should add the u-cursor-not-allowed class to the link', function () {
+			var clickEvent = $.Event('click');
+
+			this.$link.trigger(clickEvent);
+
+			expect(this.$link.hasClass('u-cursor-not-allowed')).to.be.true;
+		});
+
+		it('should add the u-cursor-not-allowed class to form labels', function () {
+			expect(this.$label.hasClass('u-cursor-not-allowed')).to.be.true;
+		})
+
+		it('should add the disabled attribute to buttons', function() {
+			expect(this.$button.attr('disabled')).to.equal('disabled');
+		});
+
+		it('should add the disabled attribute to inputs', function() {
+			expect(this.$textInput.attr('disabled')).to.equal('disabled');
+		});
+
+		it('should add the disabled attribute to selects', function() {
+			expect(this.$select.attr('disabled')).to.equal('disabled');
+		});
+
+		it('should add the disabled class to form inputs', function() {
+			expect(this.$textInput.hasClass('disabled')).to.be.true;
+		});
+
+		it('should wrap the container in a div with the .u-ui-disabled class', function() {
+			expect(this.$standardForm.parent().hasClass('u-ui-disabled')).to.be.true;
+		})
+
+		describe('when a masterswitch is present', function() {
+
+			it('should wrap the master switch container in a div with the .u-ui-disabled class when the masterswitch is enabled', function() {
+				expect(this.$masterswitchEnabledContainer.parent().hasClass('u-ui-disabled')).to.be.true;
+			});
+
+			it('should wrap the master switch control in a div with the .u-ui-disabled class when the masterswitch is disabled', function() {
+				expect(this.$masterSwitchDisabledControl.parent().hasClass('u-ui-disabled')).to.be.true;
+			});
+
+		});
+	});
+});

--- a/tests/js/web/DisableUiComponentTest.js
+++ b/tests/js/web/DisableUiComponentTest.js
@@ -86,7 +86,7 @@ describe('DisableUi component', function() {
 
 		it('should add the u-cursor-not-allowed class to form labels', function () {
 			expect(this.$label.hasClass('u-cursor-not-allowed')).to.be.true;
-		})
+		});
 
 		it('should add the disabled attribute to buttons', function() {
 			expect(this.$button.attr('disabled')).to.equal('disabled');
@@ -106,7 +106,7 @@ describe('DisableUi component', function() {
 
 		it('should wrap the container in a div with the .u-ui-disabled class', function() {
 			expect(this.$standardForm.parent().hasClass('u-ui-disabled')).to.be.true;
-		})
+		});
 
 		describe('when a masterswitch is present', function() {
 

--- a/tests/js/web/DisableUiComponentTest.js
+++ b/tests/js/web/DisableUiComponentTest.js
@@ -19,38 +19,12 @@ describe('DisableUi component', function() {
 			'	<button class="btn btn--primary" >Save Changes</button>' +
 	        '</div>'
         ).appendTo(this.$body);
-        this.$masterswitchDisabled = $(
-        	'<div class="masterswitch" data-disable-ui="true" id="masterswitch1">' +
-			'	<div class="form__group masterswitch-control form__group--toggle">' +
-			'		<input id="toggletest" type="checkbox" class="form__control toggle-switch">' +
-			'		<label for="toggletest" class="control__label toggle-switch-label"><span class="hide">Enable masterswitch content</span></label>' +
-			'	</div>' +
-			'	<section class="masterswitch-content is-disabled">' +
-			'		<label for="inputText2" class="control__label">Text input</label>' +
-			'		<input id="inputText2" name="inputText2" type="text" class="form__control disabled">' +
-			'	</section>' +
-	        '</div>'
-        ).appendTo(this.$body);
-        this.$masterswitchEnabled = $(
-        	'<div class="masterswitch" data-disable-ui="true" id="masterswitch2">' +
-			'	<div class="form__group masterswitch-control form__group--toggle">' +
-			'		<input id="toggletest2" type="checkbox" class="form__control toggle-switch" checked="checked">' +
-			'		<label for="toggletest2" class="control__label toggle-switch-label"><span class="hide">Enable masterswitch content</span></label>' +
-			'	</div>' +
-			'	<section class="masterswitch-content">' +
-			'		<label for="inputText3" class="control__label">Text input</label>' +
-			'		<input id="inputText3" name="inputText3" type="text" class="form__control">' +
-			'	</section>' +
-	        '</div>'
-        ).appendTo(this.$body);
 
 		this.$link = this.$body.find('a');
 		this.$label = this.$body.find('.text-label');
 		this.$button = this.$body.find('.btn--primary');
 		this.$textInput = this.$body.find('input');
 		this.$select = this.$body.find('select');
-		this.$masterSwitchDisabledControl = this.$body.find('#masterswitch1 .masterswitch-control');
-		this.$masterswitchEnabledContainer = this.$body.find('#masterswitch2');
 		this.disableUi = new DisableUiComponent(this.$html);
 	});
 
@@ -106,18 +80,6 @@ describe('DisableUi component', function() {
 
 		it('should wrap the container in a div with the .u-ui-disabled class', function() {
 			expect(this.$standardForm.parent().hasClass('u-ui-disabled')).to.be.true;
-		});
-
-		describe('when a masterswitch is present', function() {
-
-			it('should wrap the master switch container in a div with the .u-ui-disabled class when the masterswitch is enabled', function() {
-				expect(this.$masterswitchEnabledContainer.parent().hasClass('u-ui-disabled')).to.be.true;
-			});
-
-			it('should wrap the master switch control in a div with the .u-ui-disabled class when the masterswitch is disabled', function() {
-				expect(this.$masterSwitchDisabledControl.parent().hasClass('u-ui-disabled')).to.be.true;
-			});
-
 		});
 	});
 });


### PR DESCRIPTION
Allows you to disable parts of a UI by adding the data-disable-ui="true" data attribute.
Form elements are disabled, links can not be clicked and a faded overlay is added.

![disabled ui](https://cloud.githubusercontent.com/assets/756393/24414181/882c4688-13d5-11e7-8bc3-2a6444e96da5.gif)
