### PR TITLE
add --parents flag to mkdir to prevent makefile failing

### DIFF
--- a/makefile
+++ b/makefile
@@ -70,7 +70,7 @@ build:
 	@ echo "\n${CHECK} Done"
 
 	@ echo "${HR}\nCopy Proxima Nova (if available)...${HR}"
-	@ mkdir ./fonts
+	@ mkdir -p ./fonts
 	@ touch ./fonts/_config.fonts.scss
 	@ cp -r ../pulsar-fonts/src/* ./fonts 2>/dev/null || :
 	@ git update-index --skip-worktree fonts/_config.fonts.scss


### PR DESCRIPTION
The current build process attempts to create a directory called `fonts` that already exists in the repo, this directory currently contains 1 empty file `_config.fonts.scss`, adding the `-p` / `--parents` flag to the `mkdir` command in the makefile will prevent the error from killing the process if the `fonts` directory already exists.