### PR TITLE
fix npm v3 & v4 issues to ensure 1 instance of jquery is being used

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,7 +31,8 @@ module.exports = function(grunt) {
                 options: {
                     browserifyOptions: {
                         standalone: 'pulsar'
-                    }
+                    },
+                    transform: [['aliasify', { global: true }]]
                 }
             },
             dist: {
@@ -43,7 +44,7 @@ module.exports = function(grunt) {
                     browserifyOptions: {
                         standalone: 'pulsar'
                     },
-                    transform: ['uglifyify']
+                    transform: [['aliasify', { global: true }], 'uglifyify']
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -76,9 +76,13 @@
   },
   "browserify": {
     "transform": [
-      "aliasify",
       "browserify-shim"
     ]
+  },
+  "aliasify": {
+    "aliases": {
+      "jquery": "./node_modules/jquery/dist/jquery"
+    }
   },
   "browserify-shim": {
     "./libs/svgeezy/svgeezy.min.js": {


### PR DESCRIPTION
Looks like we are at the bottom of the `jstree` issues (although not specific to jstree, that was just a symptom). The reason we were getting different results is the the difference in npm versions we are running. Version 3 of npm was not pulling down jstree's deps which meant it was using our top-level version of jquery (which is what we want) however for people that have upgraded from 3 to 4 and perform a npm update or clean install, npm installs jstree's version of jquery which was the problem.

The fix is to use a browserify transform called aliasify, which will rewrite jstree's require call to ensure it uses our top-level version of jquery. This will essentially restore the dependency structure to the npm@v3 environments.