### PR TITLE
527_html5-input-styles

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -65,12 +65,23 @@ fieldset {
         }
     }
 
+    &[type="color"],
+    &[type="date"],
     &[type="email"],
+    &[type="month"],
+    &[type="number"],
     &[type="password"],
+    &[type="search"],
     &[type="tel"],
     &[type="text"],
-    &[type="url"] {
+    &[type="time"],
+    &[type="url"],
+    &[type="week"] {
         border: 1px solid $input-border;
+    }
+
+    &[type="search"] {
+        box-sizing: border-box;
     }
 
     &.checkbox,
@@ -143,10 +154,18 @@ fieldset {
 
     // IE8 - position text in the middle of inputs
     @at-root {
-        input[type="text"]#{&},
-        input[type="url"]#{&},
+        input[type="color"]#{&},
+        input[type="date"]#{&},
+        input[type="email"]#{&},
+        input[type="month"]#{&},
+        input[type="number"]#{&},
         input[type="password"]#{&},
-        input[type="email"]#{&} {
+        input[type="search"]#{&},
+        input[type="tel"]#{&},
+        input[type="text"]#{&},
+        input[type="time"]#{&},
+        input[type="url"]#{&},
+        input[type="week"]#{&} {
             @include ie-lte(8) {
                 line-height: 48px;
             }
@@ -155,10 +174,18 @@ fieldset {
 
     // IE8 - fix widths of inputs and add border/padding
     @at-root {
-        .form__group input[type="text"]#{&} ,
-        .form__group input[type="url"]#{&},
-        .form__group input[type="password"]#{&},
+        .form__group input[type="color"]#{&},
+        .form__group input[type="date"]#{&},
         .form__group input[type="email"]#{&},
+        .form__group input[type="month"]#{&},
+        .form__group input[type="number"]#{&},
+        .form__group input[type="password"]#{&},
+        .form__group input[type="search"]#{&},
+        .form__group input[type="tel"]#{&},
+        .form__group input[type="text"]#{&} ,
+        .form__group input[type="time"]#{&},
+        .form__group input[type="url"]#{&},
+        .form__group input[type="week"]#{&},
         .form__group select#{&},
         .form__group textarea#{&} {
             @include ie-lte(8) {
@@ -172,10 +199,18 @@ fieldset {
 
     // IE8 - fix widths of inputs on form__group--full
     @at-root {
-        .form__group--full input[type="text"]#{&} ,
-        .form__group--full input[type="url"]#{&},
-        .form__group--full input[type="password"]#{&},
+        .form__group--full input[type="color"]#{&},
+        .form__group--full input[type="date"]#{&},
         .form__group--full input[type="email"]#{&},
+        .form__group--full input[type="month"]#{&},
+        .form__group--full input[type="number"]#{&},
+        .form__group--full input[type="password"]#{&},
+        .form__group--full input[type="search"]#{&},
+        .form__group--full input[type="tel"]#{&},
+        .form__group--full input[type="text"]#{&} ,
+        .form__group--full input[type="time"]#{&},
+        .form__group--full input[type="url"]#{&},
+        .form__group--full input[type="week"]#{&},
         .form__group--full select#{&},
         .form__group--full textarea#{&} {
             @include ie-lte(8) {

--- a/views/lexicon/forms/text.html.twig
+++ b/views/lexicon/forms/text.html.twig
@@ -286,6 +286,82 @@
 
     {{ form.fieldset_end() }}
 
+    {{ form.fieldset_start({ 'legend': 'HTML5 Input Types' }) }}
+
+    {{
+        form.text({
+            'id': 'number',
+            'label': 'Number',
+            'type': 'number'
+        })
+    }}
+
+    {{
+        form.text({
+            'id': 'tel',
+            'label': 'Tel',
+            'type': 'tel'
+        })
+    }}
+
+    {{
+        form.text({
+            'id': 'url',
+            'label': 'Url',
+            'type': 'url'
+        })
+    }}
+
+    {{
+        form.text({
+            'id': 'email',
+            'label': 'Email',
+            'type': 'email'
+        })
+    }}
+
+    {{
+        form.text({
+            'id': 'date',
+            'label': 'Date',
+            'type': 'date'
+        })
+    }}
+
+    {{
+        form.text({
+            'id': 'month',
+            'label': 'Month',
+            'type': 'month'
+        })
+    }}
+
+    {{
+        form.text({
+            'id': 'week',
+            'label': 'Week',
+            'type': 'week'
+        })
+    }}
+
+    {{
+        form.text({
+            'id': 'time',
+            'label': 'Time',
+            'type': 'time'
+        })
+    }}
+
+    {{
+        form.text({
+            'id': 'search',
+            'label': 'Search',
+            'type': 'search'
+        })
+    }}
+    
+    {{ form.fieldset_end() }}
+
     {{
         form.end()
     }}


### PR DESCRIPTION
Expanded form__control styles to cover common HTML5 input types.

![screen shot 2017-04-05 at 12 37 09](https://cloud.githubusercontent.com/assets/756393/24703737/66e9d544-19fc-11e7-920c-3dac3567b0f1.png)

Note: additional enhancements could be made to cover `type="color"` and `type="range"` in the future and haven't been included in this ticket.

Fixes #527 