### PR TITLE
Make inline form inputs align correctly

### DIFF
--- a/stylesheets/_structure.forms.scss
+++ b/stylesheets/_structure.forms.scss
@@ -59,6 +59,7 @@ $control-column-width: 75%;
         clear: none;
         display: inline-block;
         float: none;
+        vertical-align: top;
     }
 
     // inline radio/checkboxes need spacing apart slightly


### PR DESCRIPTION
Raised by @rcwsr, inline form inputs weren't aligning correctly.

Observed in Chrome.

**Before**

![screen shot 2017-04-11 at 11 42 17](https://cloud.githubusercontent.com/assets/18653/24905457/f1cf6b66-1eab-11e7-88ee-f8ac45df6fd3.png)

**After**

![screen shot 2017-04-11 at 11 38 32](https://cloud.githubusercontent.com/assets/18653/24905380/bdeae5aa-1eab-11e7-9290-ca0b901fee09.png)
