### PR TITLE
alias jQuery version in libs folder for CMS installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "aliasify": {
     "aliases": {
-      "jquery": "./node_modules/jquery/dist/jquery"
+      "jquery": "./libs/jquery/dist/jquery"
     }
   },
   "browserify-shim": {


### PR DESCRIPTION
This bug was identified when building Pulsar in the Jadu CMS, the original work (by me) had aliased jQuery require statements to the jQuery dependency installed by NPM. When Pulsar is installed by composer and bundled in the CMS, node_modules are not installed. This meant it was looking for a dependency that did not exist. I've fixed this by aliasing the jQuery dependency installed via Bower, which _is_ copied across when installed.