### PR TITLE
Add optgroup support to select helpers

### DIFF
--- a/docs/_form-helpers/select.md
+++ b/docs/_form-helpers/select.md
@@ -71,6 +71,12 @@ value       | string  | Value for the `<option>`
 ```
 {% endraw %}
 
+## Using optgroups
+
+Your options can be arranged within `optgroups` by using the optgroup syntax.
+
+{% code_example form_helpers/select-optgroup %}
+
 ## Error state
 
 {% raw %}

--- a/docs/_form-helpers/select2.md
+++ b/docs/_form-helpers/select2.md
@@ -78,6 +78,12 @@ data-*      | string  | Data attributes, eg: `'data-foo': 'bar'`
 
 The select2 plugin will be called on any `select` element that contain the `js-select2` class.
 
+## Using optgroups
+
+Your options can be arranged within `optgroups` by using the optgroup syntax.
+
+{% code_example form_helpers/select2-optgroup %}
+
 ## Using HTML in select options
 
 With the select2 helper you can include HTML within your `<option>` labels, the whole option label will be wrapped in a `<span>`.

--- a/docs/assets/code_examples/form_helpers/html/select-optgroup
+++ b/docs/assets/code_examples/form_helpers/html/select-optgroup
@@ -1,0 +1,15 @@
+<div class="form__group">
+    <label class="control__label">Select with optgroups</label>
+    <div class="controls">
+        <select class="form__control select">
+            <optgroup label="optgroup one">
+                <option value="val-alpha">alpha</option>
+                <option value="val-bravo">bravo</option>
+            </optgroup>
+            <optgroup label="optgroup two">
+                <option value="val-charlie">charlie</option>
+                <option value="val-delta">delta</option>
+            </optgroup>
+        </select>
+    </div>
+</div>

--- a/docs/assets/code_examples/form_helpers/html/select2-optgroup
+++ b/docs/assets/code_examples/form_helpers/html/select2-optgroup
@@ -1,0 +1,15 @@
+<div class="form__group">
+    <label class="control__label">Select with optgroups</label>
+    <div class="controls">
+        <select class="form__control select">
+            <optgroup label="optgroup one">
+                <option value="val-alpha">alpha</option>
+                <option value="val-bravo">bravo</option>
+            </optgroup>
+            <optgroup label="optgroup two">
+                <option value="val-charlie">charlie</option>
+                <option value="val-delta">delta</option>
+            </optgroup>
+        </select>
+    </div>
+</div>

--- a/docs/assets/code_examples/form_helpers/html/select2-optgroup
+++ b/docs/assets/code_examples/form_helpers/html/select2-optgroup
@@ -1,7 +1,7 @@
 <div class="form__group">
     <label class="control__label">Select with optgroups</label>
     <div class="controls">
-        <select class="form__control select">
+        <select class="form__control select js-select2">
             <optgroup label="optgroup one">
                 <option value="val-alpha">alpha</option>
                 <option value="val-bravo">bravo</option>

--- a/docs/assets/code_examples/form_helpers/twig/select-optgroup
+++ b/docs/assets/code_examples/form_helpers/twig/select-optgroup
@@ -1,0 +1,34 @@
+{{
+    form.select2({
+        'label': 'Select with optgroups',
+        'options':
+        [
+            {
+                'label': 'optgroup one',
+                'options': [
+                    {
+                        'label': 'alpha',
+                        'value': 'val-alpha'
+                    },
+                    {
+                        'label': 'bravo',
+                        'value': 'val-bravo'
+                    }
+                ]
+            },
+            {
+                'label': 'optgroup two',
+                'options': [
+                    {
+                        'label': 'charlie',
+                        'value': 'val-charlie'
+                    },
+                    {
+                        'label': 'delta',
+                        'value': 'val-delta'
+                    }
+                ]
+            }
+        ]
+    })
+}}

--- a/docs/assets/code_examples/form_helpers/twig/select2-optgroup
+++ b/docs/assets/code_examples/form_helpers/twig/select2-optgroup
@@ -1,0 +1,34 @@
+{{
+    form.select2({
+        'label': 'Select with optgroups',
+        'options':
+        [
+            {
+                'label': 'optgroup one',
+                'options': [
+                    {
+                        'label': 'alpha',
+                        'value': 'val-alpha'
+                    },
+                    {
+                        'label': 'bravo',
+                        'value': 'val-bravo'
+                    }
+                ]
+            },
+            {
+                'label': 'optgroup two',
+                'options': [
+                    {
+                        'label': 'charlie',
+                        'value': 'val-charlie'
+                    },
+                    {
+                        'label': 'delta',
+                        'value': 'val-delta'
+                    }
+                ]
+            }
+        ]
+    })
+}}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-optgroup.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-optgroup.html
@@ -1,0 +1,14 @@
+<div class="form__group">
+    <div class="controls">
+        <select class="form__control select">
+            <optgroup>
+                <option value="optgroup-1-foo">optgroup-1-foo</option>
+                <option value="optgroup-1-bar">optgroup-1-bar</option>
+            </optgroup>
+            <optgroup>
+                <option value="optgroup-2-foo">optgroup-2-foo</option>
+                <option value="optgroup-2-bar">optgroup-2-bar</option>
+            </optgroup>
+        </select>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-optgroup.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-optgroup.html.twig
@@ -1,0 +1,29 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.select({
+        'options': [
+            [
+                {
+                    'label': 'optgroup-1-foo',
+                    'value': 'optgroup-1-foo'
+                },
+                {
+                    'label': 'optgroup-1-bar',
+                    'value': 'optgroup-1-bar'
+                }
+            ],
+            [
+                {
+                    'label': 'optgroup-2-foo',
+                    'value': 'optgroup-2-foo'
+                },
+                {
+                    'label': 'optgroup-2-bar',
+                    'value': 'optgroup-2-bar'
+                }
+            ]
+        ]
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-optgroup.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-optgroup.html
@@ -1,7 +1,7 @@
 <div class="form__group">
     <label class="control__label">Select with optgroups</label>
     <div class="controls">
-        <select class="form__control select">
+        <select class="form__control select js-select2">
             <optgroup label="optgroup-1">
                 <option value="1-foo-value">1-foo</option>
                 <option value="1-bar-value">1-bar</option>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-optgroup.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-optgroup.html.twig
@@ -1,7 +1,7 @@
 {% extends '@cssTests/visual-regression-layout.html.twig' %}
 {% block body %}
 {{
-    form.select({
+    form.select2({
         'label': 'Select with optgroups',
         'options':
         [

--- a/views/lexicon/forms/select.html.twig
+++ b/views/lexicon/forms/select.html.twig
@@ -96,6 +96,41 @@
         })
     }}
 
+    {{
+        form.select({
+            'label': 'Select with optgroups',
+            'options':
+            [
+                {
+                    'label': 'optgroup-1',
+                    'options': [
+                        {
+                            'label': '1-foo',
+                            'value': '1-foo-value'
+                        },
+                        {
+                            'label': '1-bar',
+                            'value': '1-bar-value'
+                        }
+                    ]
+                },
+                {
+                    'label': 'optgroup-2',
+                    'options': [
+                        {
+                            'label': '2-foo',
+                            'value': '2-foo-value'
+                        },
+                        {
+                            'label': '2-bar',
+                            'value': '2-bar-value'
+                        }
+                    ]
+                }
+            ]
+        })
+    }}
+
     {{ form.fieldset_end() }}
     {{ form.fieldset_start({ 'legend': 'Alignment' }) }}
 

--- a/views/lexicon/forms/select2.html.twig
+++ b/views/lexicon/forms/select2.html.twig
@@ -148,6 +148,41 @@
         })
     }}
 
+    {{
+        form.select2({
+            'label': 'Select2 with optgroups',
+            'options':
+            [
+                {
+                    'label': 'optgroup-1',
+                    'options': [
+                        {
+                            'label': '1-foo',
+                            'value': '1-foo-value'
+                        },
+                        {
+                            'label': '1-bar',
+                            'value': '1-bar-value'
+                        }
+                    ]
+                },
+                {
+                    'label': 'optgroup-2',
+                    'options': [
+                        {
+                            'label': '2-foo',
+                            'value': '2-foo-value'
+                        },
+                        {
+                            'label': '2-bar',
+                            'value': '2-bar-value'
+                        }
+                    ]
+                }
+            ]
+        })
+    }}
+
     {{ form.fieldset_end() }}
     {{ form.fieldset_start({ 'legend': 'Alignment' }) }}
 

--- a/views/pulsar/v2/helpers/elem.html.twig
+++ b/views/pulsar/v2/helpers/elem.html.twig
@@ -192,16 +192,44 @@ value       | string | Specifies the value of the input
             `disabled` or `selected` attributes to individual options
         #}
         {% if label is iterable %}
-            {% set options = label %}
-            {% set label = options.label %}
-            {% set value = options.value %}
-        {% endif %}
 
-        <option {{ util.value(value) }}
-            {%- if options.selected is defined and value == options.selected %} selected{% endif -%}
-            {%- if options.disabled is defined and options.disabled == true %} disabled="disabled"{% endif -%}>
-            {{- label -}}
-        </option>
+            {% set options = label %}
+
+            {% if options.options is defined and options.options is not empty %}
+
+                {# optgroup nested syntax #}
+                {% for option in options %}
+                    {% if option is iterable %}
+                        {% for item in option %}
+                            <option {{ util.value(item.value) }}
+                                {%- if item.selected is defined and item.value == item.selected %} selected{% endif -%}
+                                {%- if item.disabled is defined and item.disabled == true %} disabled="disabled"{% endif -%}>
+                                {{- item.label -}}
+                            </option>
+                            {% if loop.last %}
+                                </optgroup>
+                            {% endif %}
+                        {% endfor %}
+                    {% else %}
+                        <optgroup label="{{ option }}">
+                    {% endif %}
+                {% endfor %}
+
+            {# non-optgroup nested syntax #}
+            {% else %}
+                <option {{ util.value(label.value) }}
+                    {%- if label.selected is defined and label.value == label.selected %} selected{% endif -%}
+                    {%- if label.disabled is defined and label.disabled == true %} disabled="disabled"{% endif -%}>
+                    {{- label.label -}}
+                </option>
+            {% endif %}
+
+        {# legacy un-nested syntax #}
+        {% else %}
+            <option {{ util.value(value) }}>
+                {{- label -}}
+            </option>
+        {% endif %}
     {% endfor %}
 
     </select>


### PR DESCRIPTION
Allows select options to be grouped within `<optgroup>`.

Maintains backwards compatibility with other option syntaxes.

Example:

```
{{
    form.select2({
        'label': 'Select with optgroups',
        'options':
        [
            {
                'label': 'optgroup one',
                'options': [
                    {
                        'label': 'alpha',
                        'value': 'val-alpha'
                    },
                    {
                        'label': 'bravo',
                        'value': 'val-bravo'
                    }
                ]
            },
            {
                'label': 'optgroup two',
                'options': [
                    {
                        'label': 'charlie',
                        'value': 'val-charlie'
                    },
                    {
                        'label': 'delta',
                        'value': 'val-delta'
                    }
                ]
            }
        ]
    })
}}
```

Closes #543 