### PR TITLE
Add data attribute to prevent select2s from being automatically initialised

### DIFF
--- a/docs/_form-helpers/select2.md
+++ b/docs/_form-helpers/select2.md
@@ -71,6 +71,7 @@ options     | hash    | The `<option>` attributes formatted as `{ 'value': 'labe
 required    | bool    | Adds `required` and `aria-required="true"` attributes
 selected    | string  | The `id` of the item in `options` that should be initially selected
 size        | int     | The number of items to display when the list is shown
+data-init   | string  | If 'false', will prevent the select2 javascript behaviour being initialised
 data-*      | string  | Data attributes, eg: `'data-foo': 'bar'`
 
 *Any other options not listed here will be applied to the input.
@@ -78,6 +79,19 @@ data-*      | string  | Data attributes, eg: `'data-foo': 'bar'`
 ## Manually creating select2 elements
 
 The select2 plugin will be called on any `select` element that contain the `js-select2` class.
+
+You can prevent this from happening via the `data-init="false"` attribute, you might want to do this so that you can write your own select2 initialiser to do certain things.
+
+{% raw %}
+```twig
+{{
+    form.select2({
+        'label': 'Pick a colour',
+        'id': 'foo',
+        'data-init': 'false',
+        ...
+```
+{% endraw %}
 
 ## Using optgroups
 

--- a/js/PulsarFormComponent.js
+++ b/js/PulsarFormComponent.js
@@ -25,7 +25,7 @@ PulsarFormComponent.prototype.init = function () {
         format: 'DD/MM/YYYY'
     });
 
-    component.$select2 = this.$html.find('.js-select2');
+    component.$select2 = this.$html.find('.js-select2:not([data-init="false"])');
 
     component.$select2.each(function() {
         function formatOption(data) {

--- a/views/lexicon/forms/select2.html.twig
+++ b/views/lexicon/forms/select2.html.twig
@@ -673,6 +673,25 @@
     {{ form.fieldset_end() }}
 
     {{
+        form.select2({
+            'id': 'select2-30',
+            'label': 'data-init="false"',
+            'class': 'foo',
+            'data-init': 'false',
+            'options': [
+                {
+                    'label': 'Value one',
+                    'value': 'value1'
+                },
+                {
+                    'label': 'Value two',
+                    'value': 'value2'
+                }
+            ]
+        })
+    }}
+
+    {{
         form.end()
     }}
 

--- a/views/pulsar/v2/helpers/elem.html.twig
+++ b/views/pulsar/v2/helpers/elem.html.twig
@@ -184,7 +184,7 @@ value       | string | Specifies the value of the input
 
     <select{{
         attributes(options
-            |exclude('bare label selected value options')
+            |exclude('append bare label prepend selected value options')
             |defaults({
                 'class': 'form__control'
             })


### PR DESCRIPTION
Example:

```twig
{{
    form.select2({
        'label': 'Pick a colour',
        'id': 'foo',
        'data-init': 'false',
        ...
```