### PR TITLE
Add a highlight effect around toggle switches when they’re focused

### DIFF
--- a/stylesheets/_component.toggle-switch.scss
+++ b/stylesheets/_component.toggle-switch.scss
@@ -30,6 +30,10 @@
         }
     }
 
+    &:focus + .toggle-switch-label {
+        box-shadow: 0 0 0 2px white, 0 0 2px 5px highlight;
+    }
+
     &.toggle-switch--large + .toggle-switch-label {
         height: 2em;
         width: 4em;


### PR DESCRIPTION
Mainly to allow easy keyboard accessibility.

![togglez](https://user-images.githubusercontent.com/18653/27737257-654878d0-5d9f-11e7-8582-ad9a1aa20f4b.gif)

Closes #573

- [x] IE9
- [x] IE10
- [x] Edge
- [x] Safari
- [x] Chrome