### PR TITLE
575_secondary-nav-links-focus

### DIFF
--- a/js/NavMainComponent.js
+++ b/js/NavMainComponent.js
@@ -45,6 +45,9 @@ NavMainComponent.prototype.init = function() {
     component.$closeLink.on('click', function(e) {
         e.preventDefault();
         component.closeNavs();
+        component.closeSubNavs();
+
+        component.$html.find('.nav-primary .nav-link').removeClass('is-active');
     });
 };
 
@@ -96,7 +99,7 @@ NavMainComponent.prototype.closeSubNavs = function() {
 
     var component = this;
 
-    component.$html.find('.nav-secondary .nav-container').removeClass('is-active');
+    component.$html.find('.nav-secondary .nav-list').removeClass('is-active');
 };
 
 module.exports = NavMainComponent;

--- a/stylesheets/_component.buttons.scss
+++ b/stylesheets/_component.buttons.scss
@@ -201,7 +201,7 @@ $btn-white:                 'white';
     }
 
     @each $state, $state-color, $state-color-alt in $state-colors {
-        .btn--#{$state} {
+        &.btn--#{$state} {
             border: 2px solid $state-color !important;
             box-shadow: none !important;
             color: color($state, dark) !important;

--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -252,12 +252,14 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
         transition: background-color 50ms linear, color 50ms linear;
     }
 
-    .nav-link:hover {
+    .nav-link:hover,
+    .nav-link:focus {
         background-color: darken($nav-color-dark, 2%);
         color: white;
     }
 
-    .nav-link.is-active:hover {
+    .nav-link.is-active:hover,
+    .nav-link.is-active:focus {
         background-color: $nav-color-dark;
     }
 
@@ -345,7 +347,8 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
         border-top-right-radius: 8px;
         border-bottom-left-radius: 8px;
 
-        &:hover {
+        &:hover,
+        &:focus {
             background-color: darken($nav-color-dark, 4%);
             color: white;
         }

--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -431,7 +431,8 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
     text-align: right;
     width: 100%;
 
-    &:hover i::before {
+    &:hover i::before,
+    &:focus i::before {
         content: '\f0a8';
         color: white;
     }

--- a/tests/js/web/NavMainComponentTest.js
+++ b/tests/js/web/NavMainComponentTest.js
@@ -39,7 +39,7 @@ describe('NavMain component', function() {
       <button>Go</button>\
     </form>\
 \
-    <div class="nav-container" data-nav="#one">\
+    <div class="nav-list" data-nav="#one">\
         <ul class="nav-items">\
           <li class="nav-item">\
             <a href="#one_one" class="nav-link">1.1</a>\
@@ -47,7 +47,7 @@ describe('NavMain component', function() {
         </ul>\
     </div>\
 \
-    <div class="nav-container" data-nav="#two">\
+    <div class="nav-list" data-nav="#two">\
         <ul class="nav-items">\
           <li class="nav-item">\
             <a href="#two_one" class="nav-link">2.1</a>\
@@ -202,6 +202,10 @@ describe('NavMain component', function() {
 
         it('should close the sub navigation', function() {
             expect(this.$html.find('.nav-main').hasClass('is-open')).to.be.false;
+        });
+
+        it('should remove the highlight from that sections primary nav item', function() {
+            expect(this.$html.find('.nav-primary .nav-link').hasClass('is-active')).to.be.false;
         });
 
     });


### PR DESCRIPTION
Fixes issue where `is-active` was not removed from a closed secondary navigation list meaning its links were still focusable (and therefore you could navigate to them using the keyboard) when the menu was closed.

Fixes #575 