### PR TITLE
Replaced repeated column base styles with placeholder extend

### DIFF
--- a/stylesheets/_structure.grid.scss
+++ b/stylesheets/_structure.grid.scss
@@ -1,12 +1,15 @@
 $columns:       12;
 $gutter_pc:     1;
 
-@mixin column($first: false) {
+%column {
     background-clip: padding-box !important;
     box-sizing: border-box;
     display: block;
     float: left;
     padding: 0;
+}
+
+@mixin column($first: false) {
     @if $first {
         margin-left: 0;
     }
@@ -51,6 +54,7 @@ $gutter_pc:     1;
 
 @for $i from 1 through 12 {
     .g-col--#{$i} {
+        @extend %column;
         @include span($i);
     }
 }


### PR DESCRIPTION
Small change, noticed that the base grid columns styles were repeated for each `g-col` instead of combining selectors.

**Hunger-games/develop**
```
┌──────────────┬─────────┐
│ Size         │ 532.1KB │
├──────────────┼─────────┤
│ Rules        │ 3706    │
├──────────────┼─────────┤
│ Selectors    │ 6871    │
├──────────────┼─────────┤
│ Declarations │ 7722    │
└──────────────┴─────────┘
```
**This branch**
```
┌──────────────┬─────────┐
│ Size         │ 530.1KB │
├──────────────┼─────────┤
│ Rules        │ 3695    │
├──────────────┼─────────┤
│ Selectors    │ 6871    │
├──────────────┼─────────┤
│ Declarations │ 7652    │
└──────────────┴─────────┘
```

Tested change in lexicon.