### PR TITLE
Removed unneeded styles for open nav/open help and inner-wrapper

### DIFF
--- a/stylesheets/_layout.tabs.scss
+++ b/stylesheets/_layout.tabs.scss
@@ -49,16 +49,6 @@
     -webkit-transform: translate3d($nav-primary-width, 0, 0) scale3d(1, 1, 1);
     transform: translate3d($nav-primary-width, 0, 0) scale3d(1, 1, 1);
 
-    @include respond-min($screen-desktop) {
-        -webkit-backface-visibility: hidden;
-        -webkit-transform: none;
-        -webkit-transition: -webkit-transform 500ms ease;
-        backface-visibility: hidden;
-        transform: none;
-        transition: transform 500ms ease;
-        width: 100%;
-    }
-
     .lt-ie10 & {
         left: $nav-primary-width;
     }
@@ -67,16 +57,6 @@
 .open-help .inner-wrapper {
     -webkit-transform: translate3d(-300px, 0, 0) scale3d(1, 1, 1);
     transform: translate3d(-300px, 0, 0) scale3d(1, 1, 1);
-
-    @include respond-min($screen-desktop) {
-        -webkit-backface-visibility: hidden;
-        -webkit-transform: none;
-        -webkit-transition: -webkit-transform 500ms ease;
-        backface-visibility: hidden;
-        transform: none;
-        transition: transform 500ms ease;
-        width: 100%;
-    }
 }
 
 .lt-ie10.open-help .inner-wrapper {


### PR DESCRIPTION
Spotted some unneeded styles around open nav / open help and `inner-wrapper`

*hunger-games/develop*
```
┌──────────────┬─────────┐
│ Size         │ 530.1KB │
├──────────────┼─────────┤
│ Rules        │ 3695    │
├──────────────┼─────────┤
│ Selectors    │ 6871    │
├──────────────┼─────────┤
│ Declarations │ 7652    │
└──────────────┴─────────┘
```

*This branch*
```
┌──────────────┬─────────┐
│ Size         │ 529.1KB │
├──────────────┼─────────┤
│ Rules        │ 3693    │
├──────────────┼─────────┤
│ Selectors    │ 6869    │
├──────────────┼─────────┤
│ Declarations │ 7636    │
└──────────────┴─────────┘
```