### PR TITLE
Panel optimisation

### DIFF
--- a/stylesheets/_component.panels.scss
+++ b/stylesheets/_component.panels.scss
@@ -60,16 +60,6 @@
 
 }
 
-%panel-icon-color {
-    color: color(white);
-}
-
-@each $state, $state-color, $state-color-alt in $state-colors {
-    .panel--#{$state} .remove-button > [class^="icon-"] {
-        @extend %panel-icon-color;
-    }
-}
-
 .panel__icon {
     float: left;
     font-size: 24px;

--- a/stylesheets/_component.panels.scss
+++ b/stylesheets/_component.panels.scss
@@ -60,9 +60,13 @@
 
 }
 
+%panel-icon-color {
+    color: color(white);
+}
+
 @each $state, $state-color, $state-color-alt in $state-colors {
     .panel--#{$state} .remove-button > [class^="icon-"] {
-        color: color(white);
+        @extend %panel-icon-color;
     }
 }
 
@@ -73,19 +77,19 @@
 }
 
 @each $state, $state-color, $state-color-alt in $state-colors {
-        .panel--#{$state} {
-            background-color: $state-color;
-            color: $state-color-alt;
+    .panel--#{$state} {
+        background-color: $state-color;
+        color: $state-color-alt;
 
-            a,
-            a:link,
-            a:hover,
-            a:active,
-            a:visited {
-                color: $state-color-alt;
-            }
+        a,
+        a:link,
+        a:hover,
+        a:active,
+        a:visited {
+            color: $state-color-alt;
         }
     }
+}
 
 .form-v2 > .panel:first-of-type {
     margin-top: 0;
@@ -101,11 +105,11 @@
 }
 
 // Panels within form groups should respect their width
-@each $variant, $width in $input-widths {
-    .form__group .panel {
-        width: map-get($input-widths, xlarge);
-    }
+.form__group .panel {
+    width: map-get($input-widths, xlarge);
+}
 
+@each $variant, $width in $input-widths {
     .form__group--#{$variant} .panel {
         width: #{$width};
     }


### PR DESCRIPTION
Used `@extend` to remove some duplicate declarations. Also moved `.form_group .panels` outside of the `@each` to prevent 7 duplicate blocks.

**hunger-games/develop**
```
┌──────────────┬─────────┐
│ Size         │ 530.1KB │
├──────────────┼─────────┤
│ Rules        │ 3695    │
├──────────────┼─────────┤
│ Selectors    │ 6871    │
├──────────────┼─────────┤
│ Declarations │ 7652    │
└──────────────┴─────────┘
```

**This branch**
```
┌──────────────┬─────────┐
│ Size         │ 529.2KB │
├──────────────┼─────────┤
│ Rules        │ 3680    │
├──────────────┼─────────┤
│ Selectors    │ 6856    │
├──────────────┼─────────┤
│ Declarations │ 7637    │
└──────────────┴─────────┘
```