### PR TITLE
PR #535 hotfix, switched browse node re-declaration _after_ its refer…

### DIFF
--- a/js/DropZone/DropZoneComponent.js
+++ b/js/DropZone/DropZoneComponent.js
@@ -170,9 +170,9 @@ class DropZoneComponent {
         const options = this.optionsManager.getInstanceOptions(id);
 
         if (info) {
-            const browse = node.querySelector(`.${options.nodeClasses.browse}`);
-
             info.innerHTML = string;
+
+            const browse = node.querySelector(`.${options.nodeClasses.browse}`);
 
             if (browse) {
                 this.instanceManager.updateInstance(id, 'browse', browse);


### PR DESCRIPTION
Spotted a regression, the associated file input browse node was being re-referenced prior to it's reference being wiped.

Moved this line below we wipe the reference to ensure the new reference points to the attached browse node.