### PR TITLE
Drag & Drop disable browse files

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -17,7 +17,7 @@
     "noempty": true,
     "nonew": true,
     "plusplus": false,
-    "strict": "global",
+    "strict": false,
     "trailing": true,
     "undef": true,
     "unused": true,

--- a/js/DropZone/DropZoneBrowseNodeFactory.js
+++ b/js/DropZone/DropZoneBrowseNodeFactory.js
@@ -1,0 +1,14 @@
+import DropZoneBrowseNodeManager from './DropZoneBrowseNodeManager';
+
+class DropZoneBrowseNodeFactory {
+    /**
+     * Create a Browse Node manager instance
+     * @param {Element} node
+     * @returns {DropZoneBrowseNodeManager}
+     */
+    static create (node) {
+        return new DropZoneBrowseNodeManager(node);
+    }
+}
+
+module.exports = DropZoneBrowseNodeFactory;

--- a/js/DropZone/DropZoneBrowseNodeManager.js
+++ b/js/DropZone/DropZoneBrowseNodeManager.js
@@ -3,7 +3,7 @@ class DropZoneBrowseNodeManager {
         this.node = node;
         this.events = [];
         // we always want to prevent default whether the node is enabled or not
-        if (this.node) {
+        if (node) {
             this.node.addEventListener('click', event => {
                 event.preventDefault();
             });

--- a/js/DropZone/DropZoneBrowseNodeManager.js
+++ b/js/DropZone/DropZoneBrowseNodeManager.js
@@ -3,9 +3,11 @@ class DropZoneBrowseNodeManager {
         this.node = node;
         this.events = [];
         // we always want to prevent default whether the node is enabled or not
-        this.node.addEventListener('click', event => {
-            event.preventDefault();
-        });
+        if (this.node) {
+            this.node.addEventListener('click', event => {
+                event.preventDefault();
+            });
+        }
     }
 
     /**

--- a/js/DropZone/DropZoneBrowseNodeManager.js
+++ b/js/DropZone/DropZoneBrowseNodeManager.js
@@ -2,7 +2,7 @@ class DropZoneBrowseNodeManager {
     constructor (node) {
         this.node = node;
         this.events = [];
-        // we always want to prevent default whether the node is enabled or not
+        // We always want to prevent default whether the node is enabled or not
         if (node) {
             this.node.addEventListener('click', event => {
                 event.preventDefault();
@@ -11,7 +11,7 @@ class DropZoneBrowseNodeManager {
     }
 
     /**
-     * Uodate node reference
+     * Update node reference
      * @param {Element} node
      */
     update (node) {

--- a/js/DropZone/DropZoneBrowseNodeManager.js
+++ b/js/DropZone/DropZoneBrowseNodeManager.js
@@ -1,0 +1,61 @@
+class DropZoneBrowseNodeManager {
+    constructor (node) {
+        this.node = node;
+        this.events = [];
+        // we always want to prevent default whether the node is enabled or not
+        this.node.addEventListener('click', event => {
+            event.preventDefault();
+        });
+    }
+
+    /**
+     * Uodate node reference
+     * @param {Element} node
+     */
+    update (node) {
+        this.node = node;
+        this.node.addEventListener('click', event => {
+            event.preventDefault();
+        });
+    }
+
+    /**
+     * Return node
+     * @returns {Element}
+     */
+    getNode () {
+        return this.node;
+    }
+
+    /**
+     * Add an event listener to node
+     * @param {String} event
+     * @param {Function} handler
+     */
+    addEvent (event, handler) {
+        this.events.push({ event, handler, active: true });
+        this.node.addEventListener(event, handler);
+    }
+
+    /**
+     * Remove attached events
+     */
+    disableEvents () {
+        this.events = this.events.map(event => {
+            this.node.removeEventListener(event.event, event.handler);
+            return { event: event.event, handler: event.handler, active: false };
+        });
+    }
+
+    /**
+     * Re-attach events
+     */
+    enableEvents () {
+        this.events = this.events.map(event => {
+            this.node.addEventListener(event.event, event.handler);
+            return { event: event.event, handler: event.handler, active: true };
+        });
+    }
+}
+
+module.exports = DropZoneBrowseNodeManager;

--- a/js/DropZone/DropZoneComponent.js
+++ b/js/DropZone/DropZoneComponent.js
@@ -579,6 +579,16 @@ class DropZoneComponent {
     disable (id) {
         this.instanceManager.disableInstance(id);
     }
+
+    /**
+     * Get instance Browse Files node
+     * @param {Number} id
+     */
+    getBrowseNode (id) {
+        const { browse } = this.instanceManager.getInstance(id);
+
+        return browse;
+    }
 }
 
 module.exports = DropZoneComponent;

--- a/js/DropZone/DropZoneComponent.js
+++ b/js/DropZone/DropZoneComponent.js
@@ -102,7 +102,7 @@ class DropZoneComponent {
                 this.processInputNode(instance.input, instance.id, instance.options.showInputNode);
 
                 if (instance.browse) {
-                    this.processBrowseNode(instance.browse, instance.input);
+                    instance.browse.addEvent('click', this.handleBrowseNodeClick.bind(this, instance.input));
                 }
             }
         });
@@ -147,17 +147,13 @@ class DropZoneComponent {
     }
 
     /**
-     * Adds the browse files functionality to our DropZone
-     * @param {Element} browse
+     * Handle browse node click
      * @param {Element} input
      */
-    processBrowseNode (browse, input) {
-        browse.addEventListener('click', event => {
-            event.preventDefault();
-            // trigger a synthetic click on the input node which will activate the
-            // native Browse Files interaction
-            input.click();
-        });
+    handleBrowseNodeClick (input) {
+        // trigger a synthetic click on the input node which will activate the
+        // native Browse Files interaction
+        input.click();
     }
 
     /**
@@ -166,7 +162,7 @@ class DropZoneComponent {
      * @param {String} string
      */
     updateInfoState (id, string) {
-        const { info, input, node } = this.instanceManager.getInstance(id);
+        const { info, node } = this.instanceManager.getInstance(id);
         const options = this.optionsManager.getInstanceOptions(id);
 
         if (info) {
@@ -175,8 +171,7 @@ class DropZoneComponent {
             const browse = node.querySelector(`.${options.nodeClasses.browse}`);
 
             if (browse) {
-                this.instanceManager.updateInstance(id, 'browse', browse);
-                this.processBrowseNode(browse, input);
+                this.instanceManager.updateBrowseNode(id, browse);
             }
         }
     }
@@ -587,7 +582,23 @@ class DropZoneComponent {
     getBrowseNode (id) {
         const { browse } = this.instanceManager.getInstance(id);
 
-        return browse;
+        return browse.getNode();
+    }
+
+    /**
+     * Disable browse node functionality
+     * @param {Number} id
+     */
+    disableBrowseNode (id) {
+        this.instanceManager.disableBrowseNode(id);
+    }
+
+    /**
+     * Enable browse node functionality
+     * @param {Number} id
+     */
+    enableBrowseNode (id) {
+        this.instanceManager.enableBrowseNode(id);
     }
 }
 

--- a/js/DropZone/DropZoneComponentFactory.js
+++ b/js/DropZone/DropZoneComponentFactory.js
@@ -6,6 +6,7 @@ import DropZoneComponentUtils from './DropZoneComponentUtils';
 import DropZoneComponentValidationManager from './DropZoneComponentValidationManager';
 import DropZoneBodyClassManager from './DropZoneBodyClassManager';
 import MimeTyper from '../libs/MimeTyper';
+import DropZoneBrowseNodeFactory from './DropZoneBrowseNodeFactory';
 
 class DropZoneComponentFactory {
     /**
@@ -21,7 +22,7 @@ class DropZoneComponentFactory {
         return new DropZoneComponent(
             html,
             selector,
-            new DropZoneInstanceManager(html, DropZoneFactory),
+            new DropZoneInstanceManager(html, DropZoneFactory, DropZoneBrowseNodeFactory),
             new DropZoneOptionsManager(utilsManager),
             utilsManager,
             new DropZoneComponentValidationManager(),

--- a/js/DropZone/DropZoneInstanceManager.js
+++ b/js/DropZone/DropZoneInstanceManager.js
@@ -1,11 +1,11 @@
 import _ from 'lodash';
 
 class DropZoneInstanceManager {
-    constructor (html, DropZoneFactory, optionsManager) {
+    constructor (html, DropZoneFactory, BrowseNodeFactory) {
         this.html = html;
         this.instances = [];
         this.DropZoneFactory = DropZoneFactory;
-        this.optionsManager = optionsManager;
+        this.BrowseNodeFactory = BrowseNodeFactory;
     }
 
     /**
@@ -18,7 +18,7 @@ class DropZoneInstanceManager {
         const options = optionsManager.buildInstanceOptions(node, id);
         const errorOptions = optionsManager.buildValidatorOptions(options);
         const input = options.inputNodeId ? this.html.querySelector(`#${options.inputNodeId}`) : null;
-        const browse = node.querySelector(`.${options.nodeClasses.browse}`);
+        const browse = this.BrowseNodeFactory.create(node.querySelector(`.${options.nodeClasses.browse}`));
         const info = node.querySelector(`.${options.nodeClasses.info}`);
         const dropZone = this.DropZoneFactory.create(node, options, errorOptions);
 
@@ -33,13 +33,35 @@ class DropZoneInstanceManager {
     }
 
     /**
-     * Update an instance property, useful if we need to re-reference elements
-     * @param {number} id
-     * @param {string} prop
-     * @param {*} value
+     * Update ref to browse node and re-attach events
+     * @param {Number} id
+     * @param {Element} node
      */
-    updateInstance (id, prop, value) {
-        _.find(this.instances, i => i.id === id)[prop] = value;
+    updateBrowseNode (id, node) {
+        const instance = _.find(this.instances, i => i.id === id);
+
+        instance.browse.update(node);
+        instance.browse.enableEvents();
+    }
+
+    /**
+     * Enable browse node events
+     * @param {Number} id
+     */
+    enableBrowseNode (id) {
+        const instance = _.find(this.instances, i => i.id === id);
+
+        instance.browse.enableEvents();
+    }
+
+    /**
+     * Disable browse node events
+     * @param {Number} id
+     */
+    disableBrowseNode (id) {
+        const instance = _.find(this.instances, i => i.id === id);
+
+        instance.browse.disableEvents();
     }
 
     /**

--- a/tests/js/web/DropZoneBrowseNodeFactoryTest.js
+++ b/tests/js/web/DropZoneBrowseNodeFactoryTest.js
@@ -1,0 +1,12 @@
+import DropZoneBrowseNodeFactory from '../../../js/DropZone/DropZoneBrowseNodeFactory';
+import DropZoneBrowseNodeManager from '../../../js/DropZone/DropZoneBrowseNodeManager';
+
+describe('DropZoneBrowseNodeFactory', () => {
+    describe('create', () => {
+        it('should return a browse node manager instance', () => {
+            expect(DropZoneBrowseNodeFactory.create({
+                addEventListener: () => {}
+            })).to.be.instanceOf(DropZoneBrowseNodeManager);
+        });
+    });
+});

--- a/tests/js/web/DropZoneBrowseNodeManagerTest.js
+++ b/tests/js/web/DropZoneBrowseNodeManagerTest.js
@@ -1,0 +1,127 @@
+import DropZoneBrowseNodeManager from '../../../js/DropZone/DropZoneBrowseNodeManager';
+
+describe('DropZoneBrowseNodeManager', () => {
+    let manager;
+    let nodeStub;
+
+    beforeEach(() => {
+        nodeStub = {
+            addEventListener: sinon.spy(),
+            removeEventListener: sinon.spy()
+        };
+        manager = new DropZoneBrowseNodeManager(nodeStub);
+    });
+
+    describe('constructor()', () => {
+        it('should return a manager object', () => {
+            expect(manager).to.deep.equal({
+                node: nodeStub,
+                events: []
+            });
+        });
+
+        it('should add a click event to the node', () => {
+            expect(nodeStub.addEventListener).to.have.been.calledOnce;
+            expect(nodeStub.addEventListener).to.have.been.calledWith('click');
+        });
+
+        it('should prevent the default behaviour of the click', () => {
+            const node = document.createElement('div');
+            const click = new Event('click');
+
+            sinon.stub(click, 'preventDefault');
+            manager = new DropZoneBrowseNodeManager(node);
+            node.dispatchEvent(click);
+
+            expect(click.preventDefault).to.have.been.calledOnce;
+        });
+    });
+
+    describe('update()', () => {
+        it('should update the existing node reference', () => {
+            const newRef = document.createElement('span');
+
+            manager.update(newRef);
+
+            expect(manager.node).to.deep.equal(newRef);
+        });
+
+        it('should prevent the default behaviour of the click', () => {
+            const node = document.createElement('div');
+            const click = new Event('click');
+
+            sinon.stub(click, 'preventDefault');
+            manager.update(node);
+            node.dispatchEvent(click);
+
+            expect(click.preventDefault).to.have.been.calledOnce;
+        });
+    });
+
+    describe('getNode()', () => {
+        it('should return browseNode ref', () => {
+            expect(manager.getNode()).to.deep.equal(nodeStub);
+        });
+    });
+
+    describe('addEvent()', () => {
+        it('should store the event', () => {
+            manager.addEvent('click', 'handler');
+
+            expect(manager.events).to.deep.equal([{
+                event: 'click',
+                handler: 'handler',
+                active: true
+            }]);
+        });
+
+        it('should attach an event', () => {
+            manager.addEvent('click', 'handler');
+
+            expect(nodeStub.addEventListener).to.have.been.calledWith('click', 'handler');
+        });
+    });
+
+    describe('disableEvents()', () => {
+        beforeEach(() => {
+            manager.events = [
+                { event: 'click', handler: 'foo', active: true },
+                { event: 'punch', handler: 'bar', active: true }
+            ];
+        });
+
+        it('should remove active events and update events state', () => {
+            manager.disableEvents();
+
+            expect(nodeStub.removeEventListener).to.have.been.calledTwice;
+            expect(nodeStub.removeEventListener).to.have.been.calledWith('click', 'foo');
+            expect(nodeStub.removeEventListener).to.have.been.calledWith('punch', 'bar');
+            expect(manager.events).to.deep.equal([
+                { event: 'click', handler: 'foo', active: false },
+                { event: 'punch', handler: 'bar', active: false }
+            ]);
+        });
+    });
+
+    describe('enableEvents()', () => {
+        beforeEach(() => {
+            manager.events = [
+                { event: 'click', handler: 'foo', active: false },
+                { event: 'punch', handler: 'bar', active: false }
+            ];
+        });
+
+        it('should attach active events and update events state', () => {
+            manager.enableEvents();
+
+            // called 3 times here to account for the initial preventDefault handler
+            expect(nodeStub.addEventListener).to.have.been.calledThrice;
+            expect(nodeStub.addEventListener).to.have.been.calledWith('click', 'foo');
+            expect(nodeStub.addEventListener).to.have.been.calledWith('punch', 'bar');
+            expect(manager.events).to.deep.equal([
+                { event: 'click', handler: 'foo', active: true },
+                { event: 'punch', handler: 'bar', active: true }
+            ]);
+        });
+    });
+});

--- a/tests/js/web/DropZoneBrowseNodeManagerTest.js
+++ b/tests/js/web/DropZoneBrowseNodeManagerTest.js
@@ -20,9 +20,16 @@ describe('DropZoneBrowseNodeManager', () => {
             });
         });
 
-        it('should add a click event to the node', () => {
+        it('should add a click event to the node if we have one', () => {
             expect(nodeStub.addEventListener).to.have.been.calledOnce;
             expect(nodeStub.addEventListener).to.have.been.calledWith('click');
+        });
+
+        it('should not add a click event to the node if we do not have one', () => {
+            nodeStub.addEventListener.reset();
+            manager = new DropZoneBrowseNodeManager();
+
+            expect(nodeStub.addEventListener).to.have.not.been.called;
         });
 
         it('should prevent the default behaviour of the click', () => {

--- a/tests/js/web/DropZoneComponentTest.js
+++ b/tests/js/web/DropZoneComponentTest.js
@@ -31,7 +31,7 @@ describe('DropZoneComponent', () => {
         validation = sinon.createStubInstance(DropZoneComponentValidation);
         classManager = sinon.createStubInstance(DropZoneBodyClassManager);
 
-        instanceManager.getInstance.returns({ node: $dropZone[0], info: $info[0] });
+        instanceManager.getInstance.returns({ node: $dropZone[0], info: $info[0], browse: $browse[0] });
         instanceManager.getFiles.returns(['file']);
         optionsManager.getInstanceOptions.returns({
             nodeClasses: {
@@ -926,6 +926,16 @@ describe('DropZoneComponent', () => {
 
             expect(instanceManager.disableInstance).to.have.been.calledOnce;
             expect(instanceManager.disableInstance).to.have.been.calledWith(88);
+        });
+    });
+
+    describe('getBrowseNode()', () => {
+        it('should return an instances browse node', () => {
+            const browse = dropZoneComponent.getBrowseNode(0);
+
+            expect(instanceManager.getInstance).to.have.been.calledOnce;
+            expect(instanceManager.getInstance).to.have.been.calledWith(0);
+            expect(browse).to.equal($browse[0]);
         });
     });
 });

--- a/tests/js/web/DropZoneComponentTest.js
+++ b/tests/js/web/DropZoneComponentTest.js
@@ -17,6 +17,7 @@ describe('DropZoneComponent', () => {
     let utils;
     let validation;
     let classManager;
+    let browseNodeInstance;
 
     beforeEach(() => {
         $body = $('<div></div>');
@@ -30,8 +31,16 @@ describe('DropZoneComponent', () => {
         utils = sinon.createStubInstance(DropZoneComponentUtils);
         validation = sinon.createStubInstance(DropZoneComponentValidation);
         classManager = sinon.createStubInstance(DropZoneBodyClassManager);
+        browseNodeInstance = {
+            addEvent: sinon.spy(),
+            getNode: () => $browse[0]
+        };
 
-        instanceManager.getInstance.returns({ node: $dropZone[0], info: $info[0], browse: $browse[0] });
+        instanceManager.getInstance.returns({
+            node: $dropZone[0],
+            info: $info[0],
+            browse: browseNodeInstance
+        });
         instanceManager.getFiles.returns(['file']);
         optionsManager.getInstanceOptions.returns({
             nodeClasses: {
@@ -55,7 +64,6 @@ describe('DropZoneComponent', () => {
 
     describe('init()', () => {
         let inputStub;
-        let browseStub;
 
         beforeEach(() => {
             $('<div class="dropzone test"></div>').appendTo($body);
@@ -64,33 +72,36 @@ describe('DropZoneComponent', () => {
             $('<div class="dropzone test"></div>').appendTo($body);
 
             inputStub = sinon.stub(dropZoneComponent, 'processInputNode');
-            browseStub = sinon.stub(dropZoneComponent, 'processBrowseNode');
+
             instanceManager.getInstance.returns([
-                { id: 0 },
-                { id: 1, input: {}, options: {}, browse: {} }
+                { id: 0, input: {}, options: {}, browse: browseNodeInstance }
             ]);
         });
 
         it('should build the base component options', () => {
             dropZoneComponent.init();
+
             expect(optionsManager.buildComponentOptions).to.have.been.calledOnce;
         });
 
         it('should create an instance for each node matching the selector', () => {
             dropZoneComponent.init();
+
             expect(instanceManager.addInstance).to.have.callCount(5);
         });
 
         // partial stub
         it('should process each instances input node', () => {
             dropZoneComponent.init();
+
             expect(inputStub).to.have.been.calledOnce;
         });
 
         // partial stub
         it('should process each instances browse node', () => {
             dropZoneComponent.init();
-            expect(browseStub).to.have.been.calledOnce;
+
+            expect(browseNodeInstance.addEvent).to.have.been.calledOnce;
         });
     });
 
@@ -99,6 +110,7 @@ describe('DropZoneComponent', () => {
 
         it('should hide the input if specified in options', () => {
             dropZoneComponent.processInputNode($fileInput[0], 0, options.showInputNode);
+
             expect($fileInput.css('display')).to.equal('none');
         });
 
@@ -130,25 +142,18 @@ describe('DropZoneComponent', () => {
         });
     });
 
-    describe('processBrowseNode()', () => {
+    describe('handleBrowseNodeClick()', () => {
         it('should trigger a click on the corresponding input node', () => {
             const clickSpy = sinon.spy();
-            const click = new Event('click');
 
             $fileInput[0].addEventListener('click', clickSpy);
-            dropZoneComponent.processBrowseNode($browse[0], $fileInput[0]);
-            $browse[0].dispatchEvent(click);
+            dropZoneComponent.handleBrowseNodeClick($fileInput[0]);
+
             expect(clickSpy).to.have.been.calledOnce;
         });
     });
 
     describe('updateInfoState()', () => {
-        let browseStub;
-
-        beforeEach(() => {
-            browseStub = sinon.stub(dropZoneComponent, 'processBrowseNode');
-        });
-
         it('should update the info node', () => {
             dropZoneComponent.updateInfoState(0, 'foo');
             expect($info.html()).to.equal('foo');
@@ -157,7 +162,7 @@ describe('DropZoneComponent', () => {
         // partial stub
         it('should re-attach the Browse Files handler', () => {
             dropZoneComponent.updateInfoState(0, '<span class="browse"></span>');
-            expect(browseStub).to.have.been.calledOnce;
+            expect(instanceManager.updateBrowseNode).to.have.been.calledOnce;
         });
     });
 
@@ -936,6 +941,24 @@ describe('DropZoneComponent', () => {
             expect(instanceManager.getInstance).to.have.been.calledOnce;
             expect(instanceManager.getInstance).to.have.been.calledWith(0);
             expect(browse).to.equal($browse[0]);
+        });
+    });
+
+    describe('disableBrowseNode()', () => {
+        it('should invoke the disableBrowseNode method on the instance manager', () => {
+            dropZoneComponent.disableBrowseNode(88);
+
+            expect(instanceManager.disableBrowseNode).to.have.been.calledOnce;
+            expect(instanceManager.disableBrowseNode).to.have.been.calledWith(88);
+        });
+    });
+
+    describe('enableBrowseNode()', () => {
+        it('should invoke the enableBrowseNode method on the instance manager', () => {
+            dropZoneComponent.enableBrowseNode(88);
+
+            expect(instanceManager.enableBrowseNode).to.have.been.calledOnce;
+            expect(instanceManager.enableBrowseNode).to.have.been.calledWith(88);
         });
     });
 });

--- a/tests/js/web/DropZoneInstanceManagerTest.js
+++ b/tests/js/web/DropZoneInstanceManagerTest.js
@@ -2,6 +2,8 @@ import DropZoneInstanceManager from '../../../js/DropZone/DropZoneInstanceManage
 import DropZoneFactory from '../../../js/DropZone/DropZoneFactory';
 import DropZoneOptionsManager from '../../../js/DropZone/DropZoneOptionsManager';
 import DropZone from '../../../js/DropZone/DropZone';
+import DropZoneBrowseNodeFactory from '../../../js/DropZone/DropZoneBrowseNodeFactory';
+import DropZoneBrowseNodeManager from '../../../js/DropZone/DropZoneBrowseNodeManager';
 
 describe('DropZoneInstanceManager', () => {
     let $html;
@@ -13,6 +15,8 @@ describe('DropZoneInstanceManager', () => {
     let optionsManagerStub;
     let factoryStub;
     let dropZoneStub;
+    let browseNodeStub;
+    let browseNodeFactoryStub;
     let stubOptions = {
         inputNodeId: 'input',
         nodeClasses: {
@@ -28,21 +32,28 @@ describe('DropZoneInstanceManager', () => {
         $browse = $('<p class="browse"></p>').appendTo($dropZone);
         $info = $('<p class="info"></p>').appendTo($dropZone);
 
+        browseNodeStub = sinon.createStubInstance(DropZoneBrowseNodeManager);
+        browseNodeFactoryStub = sinon.stub(DropZoneBrowseNodeFactory, 'create');
+        browseNodeFactoryStub.returns(browseNodeStub);
+
         dropZoneStub = sinon.createStubInstance(DropZone);
         factoryStub = sinon.stub(DropZoneFactory, 'create');
         factoryStub.returns(dropZoneStub);
+
         optionsManagerStub = sinon.createStubInstance(DropZoneOptionsManager);
         optionsManagerStub.buildInstanceOptions.returns(stubOptions);
         optionsManagerStub.buildValidatorOptions.returns({});
 
         instanceManager = new DropZoneInstanceManager(
             document.documentElement,
-            DropZoneFactory
+            DropZoneFactory,
+            DropZoneBrowseNodeFactory
         );
     });
 
     afterEach(() => {
         factoryStub.restore();
+        browseNodeFactoryStub.restore();
         $html.html('');
     });
 
@@ -53,7 +64,7 @@ describe('DropZoneInstanceManager', () => {
                 node: $dropZone[0],
                 options: stubOptions,
                 id: 0,
-                browse: $browse[0],
+                browse: browseNodeStub,
                 input: $input[0],
                 info: $info[0],
                 dropZone: dropZoneStub
@@ -70,15 +81,6 @@ describe('DropZoneInstanceManager', () => {
             instanceManager.addInstance($dropZone[0], optionsManagerStub);
 
             expect(dropZoneStub.init).to.have.been.calledOnce;
-        });
-    });
-
-    describe('updateInstance()', () => {
-        it('should update a property on an instance', () => {
-            instanceManager.instances = [{ id: 0, foo: 'bar' }];
-            instanceManager.updateInstance(0, 'foo', 'foo');
-
-            expect(instanceManager.instances[0].foo).to.equal('foo');
         });
     });
 
@@ -124,6 +126,50 @@ describe('DropZoneInstanceManager', () => {
 
             expect(mockInstance.dropZone.addFiles).to.have.been.calledOnce;
             expect(mockInstance.dropZone.addFiles.calledWith(files, meta)).to.be.true;
+        });
+    });
+
+    describe('updateBrowseNode()', () => {
+        beforeEach(() => {
+            instanceManager.instances = [
+                { id: 88, browse: browseNodeStub }
+            ];
+        });
+
+        it('should update the browse node and enable events', () => {
+            instanceManager.updateBrowseNode(88, 'node');
+
+            expect(browseNodeStub.update).to.have.been.calledOnce;
+            expect(browseNodeStub.update).to.have.been.calledWith('node');
+            expect(browseNodeStub.enableEvents).to.have.been.calledOnce;
+        });
+    });
+
+    describe('enableBrowseNode()', () => {
+        beforeEach(() => {
+            instanceManager.instances = [
+                { id: 88, browse: browseNodeStub }
+            ];
+        });
+
+        it('should enable events on the browse node', () => {
+            instanceManager.enableBrowseNode(88);
+
+            expect(browseNodeStub.enableEvents).to.have.been.calledOnce;
+        });
+    });
+
+    describe('disableBrowseNode()', () => {
+        beforeEach(() => {
+            instanceManager.instances = [
+                { id: 88, browse: browseNodeStub }
+            ];
+        });
+
+        it('should disable events on the browse node', () => {
+            instanceManager.disableBrowseNode(88);
+
+            expect(browseNodeStub.disableEvents).to.have.been.calledOnce;
         });
     });
 


### PR DESCRIPTION
An improvement to the DropZone API to allow toggling of the "Browse Files" functionality.
![jul-27-2017 10-01-29](https://user-images.githubusercontent.com/9677023/28662641-c1e9265c-72b2-11e7-92a3-4e5b3c66c5f9.gif)
