### PR TITLE
Add table—horizontal support to datatables

### DIFF
--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -49,7 +49,8 @@ PulsarUIComponent.prototype.initTables = function () {
 
 PulsarUIComponent.prototype.initDataTables = function () {
     var component = this,
-        datatables = component.$html.find('.datatable');
+        datatables = component.$html.find('.datatable:not(.table--horizontal)'),
+        datatablesHorizontal = component.$html.find('.datatable.table--horizontal');
 
     datatables.each(function() {
         var $this = $(this);
@@ -95,6 +96,51 @@ PulsarUIComponent.prototype.initDataTables = function () {
                 details: {
                     type: 'column'
                 }
+            },
+            select: select,
+            stateSave: false
+        });
+    });
+
+    datatablesHorizontal.each(function() {
+        var $this = $(this);
+
+        var select = {
+            className: 'dt-row-selected',
+            style:     'multi',
+            selector:  'td.table-selection'
+        }
+
+        var dom = '<"dataTables_top"Birf><"dataTables_actions"T><"table-container"t><"dataTables_bottom"lp>';
+
+        if (!$this.data('empty-table')) {
+            $this.data('empty-table', 'There are currently no items to display');
+        }
+
+        if ($this.data('select') === false) {
+            dom = '<"dataTables_top"irf><"dataTables_actions"T><"dt-disable-selection"<"table-container"t>><"dataTables_bottom"lp>';
+            select = false;
+        }
+
+        $this.DataTable({
+            dom: dom,
+            aaSorting: [],
+            bAutoWidth: false,
+            buttons: [
+                'selectAll',
+                'selectNone'
+            ],
+            columnDefs: [
+                { className: 'control', orderable: false, targets: 0 },
+                { "searchable": false, "targets": [0, 1] },
+                { "orderable": false, "targets": [0, 1] }
+            ],
+            language: {
+                "emptyTable": $this.data('empty-table'),
+                "info": "Showing _START_ to _END_ of _TOTAL_ items",
+                "infoEmpty": 'No items',
+                "infoFiltered": " (filtered from _MAX_ items)",
+                "zeroRecords": "No items matched your filter, please clear it and try again"
             },
             select: select,
             stateSave: false

--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -319,4 +319,15 @@ th.sorting_disabled:hover {
     }
 }
 
+.dataTables_wrapper > .table-container {
+    clear: both; // make sure container appears in correct place when used in datatable context
+    margin-bottom: 0; // make sure pagination sits directly underneath the table
+}
+
+// Hide the responsive column that usually contains the (+) control when using
+// horizontal version
+.datatable.table--horizontal .table-responsive {
+    display: none;
+}
+
 // scss-lint:enable SelectorFormat

--- a/views/lexicon/tables.html.twig
+++ b/views/lexicon/tables.html.twig
@@ -21,6 +21,9 @@
 {% set tab_sortable %}
     {% include 'lexicon/tables/sortable.html.twig' %}
 {% endset %}
+{% set tab_tablex %}
+    {% include 'lexicon/tables/tablex.html.twig' %}
+{% endset %}
 {% set tab_datatablex %}
     {% include 'lexicon/tables/datatablex.html.twig' %}
 {% endset %}
@@ -58,9 +61,15 @@
           "src"   : tab_sortable
         },
         {
+          "id"    : "tablex",
+          "label" : "Horizontal Table",
+          "src"   : tab_tablex
+        },
+        {
           "id"    : "datatablex",
-          "label" : "Horizontal Scroll",
-          "src"   : tab_datatablex
+          "label" : "Horizontal Datatable",
+          "src"   : tab_datatablex,
+          'active': 'true'
         }
     ]
 %}

--- a/views/lexicon/tables/tablex.html.twig
+++ b/views/lexicon/tables/tablex.html.twig
@@ -1,12 +1,11 @@
 {% extends '@pulsar/pulsar/components/tab.html.twig' %}
 
 {% block tab_content %}
-    <table class="table datatable table--full table--horizontal">
+
+    <table class="table table--full table--horizontal">
         <thead>
             <tr>
-                <td class="table-responsive"></td>
-                <td class="table-selection"></td>
-                <th><a href="#">Name datatable</a></th>
+                <th><a href="#">XName</a></th>
                 <th><a href="#">IP</a></th>
                 <th><a href="#">Status</a></th>
                 <th><a href="#">Uptime</a></th>
@@ -19,12 +18,6 @@
         <tbody>
             {% for i in 0..5 %}
             <tr>
-                <td class="table-responsive">
-                    {{ html.icon('plus-sign', { 'class': 'table-child-toggle' }) }}
-                </td>
-                <td class="table-selection">
-                    {{ html.icon('square-o', { 'class': 'table-row-select js-select' }) }}
-                </td>
                 <td><a href="#" class="table-link">Sysadmin - Ansible 1</a></td>
                 <td class="monospace"><a href="#" class="table-link">10.101.0.175</a></td>
                 <td>
@@ -49,12 +42,6 @@
             </tr>
 
             <tr class="table__tr">
-                <td class="table__td table-responsive">
-                    {{ html.icon('plus-sign', { 'class': 'table-child-toggle' }) }}
-                </td>
-                <td class="table__td table-selection">
-                    {{ html.icon('square-o', { 'class': 'table-row-select js-select' }) }}
-                </td>
                 <td><a href="#" class="table-link">Sysasdmin - WISP 1</a></td>
                 <td class="monospace"><a href="#" class="table-link">10.101.0.138</a></td>
                 <td>
@@ -81,12 +68,12 @@
 
 {% endblock tab_content %}
 {% block tab_sidebar %}
-    <h2>Horizontally Scrolling DataTable</h2>
+    <h2>Horizontally Scrolling Table</h2>
     <ul>
         <li>Addition of <code>table--horizontal</code> class adds scrolling behaviour</li>
         <li>Cells no longer collapse</li>
     </ul>
     <code class="hljs">
-        &lt;table class="table datatable table--horizontal table--full"&gt; &hellip; &lt;/table&gt;
+        &lt;table class="table table--horizontal table--full"&gt; &hellip; &lt;/table&gt;
     </code>
 {% endblock tab_sidebar %}


### PR DESCRIPTION
Add `.table--horizontal` to a datatable to switch the responsive mode from 'collapse' to 'scroll'.

There's a separate datatable loader for this case which wraps the `<table>` element with the `table-container` div in a different DOM position than regular tables to maintain the position of the datatable header and pagination when scrolling.

```
<table class="table datatable table--horizontal table--full"> ... </table>
```

![woo](https://user-images.githubusercontent.com/18653/28670150-48f05cb2-72cf-11e7-8d2c-24d60016c056.gif)