### PR TITLE
Masterswitch now uses DisableUIComponent to disable the masterswitch contents

### DIFF
--- a/js/DisableUiComponent.js
+++ b/js/DisableUiComponent.js
@@ -40,7 +40,6 @@ DisableUiComponent.prototype.disable = function (target) {
             .addClass('js-disabled u-cursor-not-allowed');
 
         // Wrap with disabled wrapper to visually disable
-        console.log('1');
         $this.wrap('<div class="u-ui-disabled"></div>');
     });
 };

--- a/js/DisableUiComponent.js
+++ b/js/DisableUiComponent.js
@@ -14,14 +14,17 @@ function preventDefaultAndStopPropagation(e) {
 DisableUiComponent.prototype.init = function () {
     var component = this;
 
-    component.$container = this.$html.find('[data-disable-ui="true"]');
+    component.disable(component.$html.find('[data-disable-ui="true"]'));
+};
 
-    component.$container.each(function() {
+DisableUiComponent.prototype.disable = function (target) {
+    var component = this,
+        FORM_ELEMENTS = 'button:not(.disabled), input:not(.disabled), select:not(.disabled)',
+        LINK_ELEMENTS = 'a:not(.disabled)',
+        LABEL_ELEMENTS = 'label';
 
-        var $this = $(this),
-            FORM_ELEMENTS = 'button:not(.disabled), input:not(.disabled), select:not(.disabled)',
-            LINK_ELEMENTS = 'a:not(.disabled)',
-            LABEL_ELEMENTS = 'label';
+    target.each(function() {
+        var $this = $(this);
 
         // Disable form elements
         $this.find(FORM_ELEMENTS)
@@ -35,10 +38,42 @@ DisableUiComponent.prototype.init = function () {
         // Disable links
         $this.find(LINK_ELEMENTS)
             .on('click', preventDefaultAndStopPropagation)
-            .addClass('u-cursor-not-allowed');
+            .addClass('js-disabled u-cursor-not-allowed');
 
         // Wrap with disabled wrapper to visually disable
+        console.log('1');
         $this.wrap('<div class="u-ui-disabled"></div>');
+    });
+};
+
+DisableUiComponent.prototype.enable = function (target) {
+    var component = this,
+        FORM_ELEMENTS = 'button.disabled, input.disabled, select.disabled',
+        LINK_ELEMENTS = 'a.js-disabled',
+        LABEL_ELEMENTS = 'label';
+
+    target.each(function() {
+        var $this = $(this);
+
+        // Remove attribute used to disable a UI on load
+        $this.removeAttr('data-disable-ui');
+
+        // Enable form elements
+        $this.find(FORM_ELEMENTS)
+            .unbind('click', preventDefaultAndStopPropagation)
+            .removeClass('disabled')
+            .removeAttr('disabled');
+
+        // Enable labels
+        $this.find(LABEL_ELEMENTS).removeClass('u-cursor-not-allowed');
+
+        // Enable links
+        $this.find(LINK_ELEMENTS)
+            .unbind('click', preventDefaultAndStopPropagation)
+            .removeClass('u-cursor-not-allowed');
+
+        // Remove wrapper which provides visually disabled styling
+        $this.unwrap('<div class="u-ui-disabled"></div>');
     });
 };
 

--- a/js/DisableUiComponent.js
+++ b/js/DisableUiComponent.js
@@ -34,7 +34,7 @@ DisableUiComponent.prototype.disable = function (target) {
         // Disable labels
         $this.find(LABEL_ELEMENTS).addClass('u-cursor-not-allowed');
 
-        // Disable links
+        // Disable links (uses .js-disable as any existing disabled)
         $this.find(LINK_ELEMENTS)
             .on('click', preventDefaultAndStopPropagation)
             .addClass('js-disabled u-cursor-not-allowed');
@@ -67,7 +67,7 @@ DisableUiComponent.prototype.enable = function (target) {
         // Enable links
         $this.find(LINK_ELEMENTS)
             .unbind('click', preventDefaultAndStopPropagation)
-            .removeClass('u-cursor-not-allowed');
+            .removeClass('js-disabled u-cursor-not-allowed');
 
         // Remove wrapper which provides visually disabled styling
         $this.unwrap('<div class="u-ui-disabled"></div>');

--- a/js/DisableUiComponent.js
+++ b/js/DisableUiComponent.js
@@ -18,8 +18,7 @@ DisableUiComponent.prototype.init = function () {
 };
 
 DisableUiComponent.prototype.disable = function (target) {
-    var component = this,
-        FORM_ELEMENTS = 'button:not(.disabled), input:not(.disabled), select:not(.disabled)',
+    var FORM_ELEMENTS = 'button:not(.disabled), input:not(.disabled), select:not(.disabled)',
         LINK_ELEMENTS = 'a:not(.disabled)',
         LABEL_ELEMENTS = 'label';
 
@@ -47,8 +46,7 @@ DisableUiComponent.prototype.disable = function (target) {
 };
 
 DisableUiComponent.prototype.enable = function (target) {
-    var component = this,
-        FORM_ELEMENTS = 'button.disabled, input.disabled, select.disabled',
+    var FORM_ELEMENTS = 'button.disabled, input.disabled, select.disabled',
         LINK_ELEMENTS = 'a.js-disabled',
         LABEL_ELEMENTS = 'label';
 

--- a/js/MasterSwitchComponent.js
+++ b/js/MasterSwitchComponent.js
@@ -24,7 +24,7 @@ MasterSwitchComponent.prototype.init = function () {
             component.switchOn(this.$control);
         }
 
-        this.$control.on('change', function (e, active) {
+        this.$control.on('change', function (e) {
             if ($(this).prop('checked')) {
                 component.switchOn(e.target);
             } else {

--- a/js/MasterSwitchComponent.js
+++ b/js/MasterSwitchComponent.js
@@ -52,8 +52,4 @@ MasterSwitchComponent.prototype.switchOff = function (target) {
     component.disableUi.disable(component.$target);
 };
 
-function preventDefault(e) {
-    e.preventDefault();
-}
-
 module.exports = MasterSwitchComponent;

--- a/js/MasterSwitchComponent.js
+++ b/js/MasterSwitchComponent.js
@@ -2,33 +2,29 @@
 
 var $ = require('jquery');
 
-function MasterSwitchComponent(html) {
-
-    this.$html = html;
-
+function MasterSwitchComponent(html, disableUi) {
+    this.$html = html,
+    this.disableUi = disableUi;
 };
 
 MasterSwitchComponent.prototype.init = function () {
-
     var component = this;
 
     component.$container = this.$html.find('.masterswitch');
 
     component.$container.each(function() {
-
         var $this = $(this);
 
         this.$control = $this.find('.masterswitch-control input');
         this.$content = $this.find('.masterswitch-content');
 
         if (!this.$control.prop('checked')) {
-            component.disableElements(this.$content);
+            component.switchOff(this.$control);
         } else {
             component.switchOn(this.$control);
-            component.enableElements(this.$content);
         }
 
-        this.$control.on('click change', function (e, active) {
+        this.$control.on('change', function (e, active) {
             if ($(this).prop('checked')) {
                 component.switchOn(e.target);
             } else {
@@ -39,47 +35,21 @@ MasterSwitchComponent.prototype.init = function () {
 };
 
 MasterSwitchComponent.prototype.switchOn = function (target) {
-
     var component = this;
 
     component.$target = $(target).closest('.masterswitch').find('.masterswitch-content');
 
     component.$target.removeClass('is-disabled');
-    component.enableElements(component.$target);
+    component.disableUi.enable(component.$target);
 };
 
 MasterSwitchComponent.prototype.switchOff = function (target) {
-
     var component = this;
 
     component.$target = $(target).closest('.masterswitch').find('.masterswitch-content');
 
     component.$target.addClass('is-disabled');
-    component.disableElements(component.$target);
-};
-
-MasterSwitchComponent.prototype.disableElements = function (target) {
-
-    var component = this,
-        CLICKABLES_SELECTOR = 'a:not(.is-disabled), button:not(.is-disabled), input:not(.is-disabled), select:not(.is-disabled)';
-
-    $(target)
-        .on('click', CLICKABLES_SELECTOR, preventDefault)
-        .find(CLICKABLES_SELECTOR)
-            .addClass('disabled')
-            .attr('disabled', 'disabled');
-};
-
-MasterSwitchComponent.prototype.enableElements = function (target) {
-
-    var component = this,
-        CLICKABLES_SELECTOR = 'a:not(.is-disabled), button:not(.is-disabled), input:not(.is-disabled), select:not(.is-disabled)';
-
-    $(target)
-        .off('click', CLICKABLES_SELECTOR, preventDefault)
-        .find(CLICKABLES_SELECTOR)
-            .removeClass('disabled')
-            .removeAttr('disabled');
+    component.disableUi.disable(component.$target);
 };
 
 function preventDefault(e) {

--- a/js/main.js
+++ b/js/main.js
@@ -18,7 +18,7 @@
     pulsar.pulsarUI = new pulsar.PulsarUIComponent($html, pulsar.history);
     pulsar.pulsarSortable = new pulsar.PulsarSortableComponent($html, window);
     pulsar.signIn = new pulsar.SignInComponent($html);
-    pulsar.masterSwitch = new pulsar.MasterSwitchComponent($html);
+    pulsar.masterSwitch = new pulsar.MasterSwitchComponent($html, pulsar.disableUi);
 	pulsar.modulePermissions = new pulsar.ModulePermissionsComponent($html);
     pulsar.navMain = new pulsar.NavMainComponent($html);
     pulsar.filterBar = new pulsar.FilterBarComponent($html);

--- a/tests/js/web/DisableUiComponentTest.js
+++ b/tests/js/web/DisableUiComponentTest.js
@@ -11,7 +11,7 @@ describe('DisableUi component', function() {
 		this.$html = $('<html></html>');
 		this.$body = $('<body></body>').appendTo(this.$html);
 		this.$standardForm = $(
-			'<div data-disable-ui="true">' +
+			'<div class="qa-container" data-disable-ui="true">' +
 			'	<label for="inputText" class="control__label text-label">Text input</label>' +
 			'	<input id="inputText" type="text" class="form__control">' +
 			'	<a href="http://google.com">External link</a>' +
@@ -20,6 +20,7 @@ describe('DisableUi component', function() {
 	        '</div>'
         ).appendTo(this.$body);
 
+		this.$target = this.$body.find('.qa-container');
 		this.$link = this.$body.find('a');
 		this.$label = this.$body.find('.text-label');
 		this.$button = this.$body.find('.btn--primary');
@@ -31,7 +32,52 @@ describe('DisableUi component', function() {
 	describe('on init', function() {
 
 		beforeEach(function() {
+			sinon.spy(this.disableUi, 'disable');
+		});
+
+		it('should call the disable method', function() {
 			this.disableUi.init();
+			expect(this.disableUi.disable).to.have.been.calledOnce;
+		});
+	});
+
+	describe('the ‘enable’ method', function() {
+
+		beforeEach(function() {
+			this.disableUi.init();
+			this.disableUi.enable(this.$target);
+		});
+
+		it('should unwrap the div.u-ui-disabled from the container', function() {
+			expect(this.$standardForm.parent().hasClass('u-ui-disabled')).to.be.false;
+		});
+
+		it('should remove the u-cursor-not-allowed class from form labels', function() {
+			expect(this.$label.hasClass('u-cursor-not-allowed')).to.be.false;
+		});
+
+		it('should remove the disabled attribute from buttons', function() {
+			expect(this.$button.attr('disabled')).to.be.undefined;
+		});
+
+		it('should remove the disabled attribute from inputs', function() {
+			expect(this.$textInput.attr('disabled')).to.be.undefined;
+		});
+
+		it('should remove the disabled attribute from selects', function() {
+			expect(this.$select.attr('disabled')).to.be.undefined;
+		});
+
+		it('should remove the disabled class from form inputs', function() {
+			expect(this.$textInput.hasClass('disabled')).to.be.false;
+		});
+	});
+
+	describe('the ‘disable’ method', function() {
+
+		beforeEach(function() {
+			this.disableUi.init();
+			this.disableUi.disable(this.$target);
 		});
 
 		it('should prevent default on links', function() {
@@ -82,4 +128,5 @@ describe('DisableUi component', function() {
 			expect(this.$standardForm.parent().hasClass('u-ui-disabled')).to.be.true;
 		});
 	});
+
 });

--- a/tests/js/web/MasterSwitchComponentTest.js
+++ b/tests/js/web/MasterSwitchComponentTest.js
@@ -37,7 +37,12 @@ describe('MasterSwitch component', function() {
 		this.$contentInput = this.$html.find('.masterswitch-content input');
 		this.$contentSelect = this.$html.find('.masterswitch-content select');
 
-		this.masterSwitch = new MasterSwitchComponent(this.$html);
+		this.disableUi = {
+            enable: sinon.stub(),
+            disable: sinon.stub()
+        };
+
+		this.masterSwitch = new MasterSwitchComponent(this.$html, this.disableUi);
 
 	});
 
@@ -55,24 +60,8 @@ describe('MasterSwitch component', function() {
 			expect(this.$content.hasClass('is-disabled')).to.be.true;
 		});
 
-		it('should prevent any links from being clicked', function() {
-			var clickEvent = $.Event('click');
-
-			this.$contentLink.trigger(clickEvent);
-
-			expect(clickEvent.isDefaultPrevented()).to.be.true;
-		});
-
-		it('should add the disabled attribute to buttons', function() {
-			expect(this.$contentButton.attr('disabled')).to.equal('disabled');
-		});
-
-		it('should add the disabled attribute to inputs', function() {
-			expect(this.$contentInput.attr('disabled')).to.equal('disabled');
-		});
-
-		it('should add the disabled attribute to selects', function() {
-			expect(this.$contentSelect.attr('disabled')).to.equal('disabled');
+		it('should call the ‘disable ui’ method', function() {
+			expect(this.disableUi.disable).to.have.been.calledOnce;
 		});
 
 	});
@@ -114,31 +103,15 @@ describe('MasterSwitch component', function() {
 
 		beforeEach(function() {
 			this.masterSwitch.init();
-			this.$control.click();
+			this.$control.click().trigger('change');
 		});
 
 		it('should enable the content container', function() {
 			expect(this.$html.find('.masterswitch-content').hasClass('is-disabled')).to.be.false;
 		});
 
-		it('should allow any links to be clicked', function() {
-			var clickEvent = $.Event('click');
-
-			this.$contentLink.trigger(clickEvent);
-
-			expect(clickEvent.isDefaultPrevented()).to.be.false;
-		});
-
-		it('should remove the disabled attribute from buttons', function() {
-			expect(this.$contentButton.attr('disabled')).to.be.undefined;
-		});
-
-		it('should remove the disabled attribute from inputs', function() {
-			expect(this.$contentInput.attr('disabled')).to.be.undefined;
-		});
-
-		it('should remove the disabled attribute from selects', function() {
-			expect(this.$contentSelect.attr('disabled')).to.be.undefined;
+		it('should call the ‘enable ui’ method', function() {
+			expect(this.disableUi.enable).to.have.been.calledOnce;
 		});
 
 	});
@@ -148,23 +121,15 @@ describe('MasterSwitch component', function() {
 		beforeEach(function() {
 			this.masterSwitch.init();
 			this.$control.click();
-			this.$control.click();
+			this.$control.click().trigger('change');
 		});
 
 		it('should disable the content container', function() {
 			expect(this.$html.find('.masterswitch-content').hasClass('is-disabled')).to.be.true;
 		});
 
-		it('should add the disabled attribute to buttons', function() {
-			expect(this.$contentButton.attr('disabled')).to.equal('disabled');
-		});
-
-		it('should add the disabled attribute to inputs', function() {
-			expect(this.$contentInput.attr('disabled')).to.equal('disabled');
-		});
-
-		it('should add the disabled attribute to selects', function() {
-			expect(this.$contentSelect.attr('disabled')).to.equal('disabled');
+		it('should call the ‘disable ui’ method', function() {
+			expect(this.disableUi.disable).to.have.been.called;
 		});
 
 	});


### PR DESCRIPTION
This allows us to use a common method of disabling different interactive elements within Puslar.

* Creates new `enable()` and `disable()` methods in DisableUIComponent
* Refactors `MasterSwitchComponent` to use the new methods
* Fixes an issue where the `switchOn/Off` methods were being called on both `click` and `change`
* Removes some tests from `MasterSwitchComponentTest` and assumes they methods called are (or will be) tested within `DisabledUIComponentTest`

- [x] Add tests for new DisableUiComponent methods

Addresses #525