### PR TITLE
599 select2 elements have wrong default width

### DIFF
--- a/stylesheets/_component.select2.scss
+++ b/stylesheets/_component.select2.scss
@@ -5,6 +5,11 @@
     margin: 0;
     position: relative;
     vertical-align: middle;
+    width: 100% !important;
+
+    @include respond-min($screen-smaller) {
+        @include span(4, false, true, 9, true);
+    }
 }
 
 .select2-container .select2-selection--single {

--- a/stylesheets/_structure.grid.scss
+++ b/stylesheets/_structure.grid.scss
@@ -28,8 +28,9 @@ $gutter_pc:     1;
  * @param  {int}  $num                   The number of columns the width should span
  * @param  {bool} $force:  false         If true, prevents the width from becoming 100% at smaller screen sizes
  * @param  {bool} $first:  false         If true, removes the left hand column margin
+ * @param  {bool} $important:  false     If true, adds the !important declaration
  */
-@mixin span($num, $force: false, $gutter: false, $columns: $columns) {
+@mixin span($num, $force: false, $gutter: false, $columns: $columns, $important: false) {
     $one_col: (100% - ($gutter_pc * ($columns - 1))) / $columns;
     $span_width: ($one_col * ($num)) + ($gutter_pc * ($num - 1));
 
@@ -43,15 +44,30 @@ $gutter_pc:     1;
         }
     }
     @else {
-        width: $span_width;
+        @if $important == false {
+            width: $span_width;
+        }
+        @else {
+            width: $span_width !important;
+        }
     }
 
     @include respond-min($screen-tablet) {
-        width: $span_width;
+        @if $important == false {
+            width: $span_width;
+        }
+        @else {
+            width: $span_width !important;
+        }
     }
 
     @include respond-min($screen-desktop) {
-        width: $span_width;
+        @if $important == false {
+            width: $span_width;
+        }
+        @else {
+            width: $span_width !important;
+        }
     }
 }
 


### PR DESCRIPTION
The recent changes to `form__control` (it now uses the grid by default) resulted in select2 widths being miscalculated. This is down to select2 grabbing the width, which is a percentage and applying the same value as pixels.

As a fix, `.select2-container` now also uses the grid to ensure proper width at various vp widths. As select2 sets an inline width, I've added an option to the grid `span` mixin for adding `!important` to grid span widths (currently only used to fix the select2 issue).

Fixes #599 

![fixed](https://user-images.githubusercontent.com/756393/28726841-b39b2f4c-73ba-11e7-80b7-f868b7d2d440.gif)
