### PR TITLE
Restrict textarea resizing to vertical axis only

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -103,6 +103,7 @@ fieldset {
         min-height: 68px;
         padding-top: 11px;
         padding-bottom: 11px;
+        resize: vertical;
     }
 
     &.select {


### PR DESCRIPTION
This prevents an issue where textareas can be expanded to break the containing layout.

The width of textareas should be defined by the documented form width modifiers and grid classes.

Closes #609