### PR TITLE
Prevent DropZone adding events to inputs in ie9

### DIFF
--- a/js/DropZone/DropZoneComponent.js
+++ b/js/DropZone/DropZoneComponent.js
@@ -98,7 +98,7 @@ class DropZoneComponent {
 
         // iterate over our DropZoneInstanceManagerInstances to process any input nodes & update help state
         this.instanceManager.getInstance().forEach(instance => {
-            if (instance.input) {
+            if (instance.input && this.instanceManager.getSupported(instance.id)) {
                 this.processInputNode(instance.input, instance.id, instance.options.showInputNode);
 
                 if (instance.browse) {

--- a/js/DropZone/DropZoneInstanceManager.js
+++ b/js/DropZone/DropZoneInstanceManager.js
@@ -116,7 +116,7 @@ class DropZoneInstanceManager {
      * @returns {Object} file
      */
     getFile (id, index) {
-         return _.find(this.instances, i => i.id === id).dropZone.getFile(index);
+        return _.find(this.instances, i => i.id === id).dropZone.getFile(index);
     }
 
     /**
@@ -126,6 +126,15 @@ class DropZoneInstanceManager {
      */
     getSupportsDataTransfer (id) {
         return _.find(this.instances, i => i.id === id).dropZone.getSupportsDataTransfer();
+    }
+
+    /**
+     * Get supported option
+     * @param {number} id
+     * @returns {boolean}
+     */
+    getSupported (id) {
+        return _.find(this.instances, i => i.id === id).options.supported;
     }
 
     /**

--- a/tests/js/web/DropZoneComponentTest.js
+++ b/tests/js/web/DropZoneComponentTest.js
@@ -76,6 +76,7 @@ describe('DropZoneComponent', () => {
             instanceManager.getInstance.returns([
                 { id: 0, input: {}, options: {}, browse: browseNodeInstance }
             ]);
+            instanceManager.getSupported.returns(true);
         });
 
         it('should build the base component options', () => {
@@ -102,6 +103,20 @@ describe('DropZoneComponent', () => {
             dropZoneComponent.init();
 
             expect(browseNodeInstance.addEvent).to.have.been.calledOnce;
+        });
+
+        it('should not process input node if the DropZone is not supported', () => {
+            instanceManager.getSupported.returns(false);
+            dropZoneComponent.init();
+
+            expect(inputStub).to.have.not.been.called;
+        });
+
+        it('should not process the browse node if the DropZone is not supported', () => {
+            instanceManager.getSupported.returns(false);
+            dropZoneComponent.init();
+
+            expect(browseNodeInstance.addEvent).to.have.not.been.called;
         });
     });
 

--- a/tests/js/web/DropZoneInstanceManagerTest.js
+++ b/tests/js/web/DropZoneInstanceManagerTest.js
@@ -255,6 +255,25 @@ describe('DropZoneInstanceManager', () => {
         });
     });
 
+    describe('getSupported()', () => {
+        let mockInstance;
+
+        beforeEach(() => {
+            mockInstance = {
+                id: 0,
+                options: {
+                    supported: true
+                }
+            };
+        });
+
+        it('should get support option for instance', () => {
+            instanceManager.instances.push(mockInstance);
+
+            expect(instanceManager.getSupported(0)).to.equal(true);
+        });
+    });
+
     describe('validateFiles()', () => {
         let mockInstance;
 


### PR DESCRIPTION
An issue has been identified in CXM where the DropZoneComponent is attaching events to an input node and implementing the File API, this is breaking on ie9 which does not support it.

The fix has added a condition to the DropZoneComponent which will avoid attaching any events to file input nodes if the DropZone supported option is false