### PR TITLE
Add append/prepent support for select/select2 helpers

### DIFF
--- a/docs/_form-helpers/select.md
+++ b/docs/_form-helpers/select.md
@@ -15,15 +15,19 @@ Generates a select input.
 
 ## Options applied to parent wrapper
 
-Option      | Type    | Description
------------ | ------- | --------------------------------------------------------
-class       | string  | A space separated list of class names
-guidance    | string  | Text to be displayed in a popover, adds a (?) icon after the input
+Option       | Type    | Description
+------------ | ------- | --------------------------------------------------------
+append       | string  | Text or markup to include after the input element
+append_type  | string  | Use only when appending a button. `button` is the only valid value
+class        | string  | A space separated list of class names
+guidance     | string  | Text to be displayed in a popover, adds a (?) icon after the input
 guidance-container | string | Element to bind guidance popover scroll behaviour to (default `body`)
-help        | string  | Additional guidance information to be displayed next to the input
-label       | string  | Text for the `<label>` companion element
-required    | bool    | Visually indicates that the field must be completed
-show-label  | bool | Control visibility of the `<label>` element without affecting layout (default: true)
+help         | string  | Additional guidance information to be displayed next to the input
+label        | string  | Text for the `<label>` companion element
+prepend      | string  | Text or markup to include before the input element
+prepend_type | string  | Use only when prepending a button. `button`is the only valid value
+required     | bool    | Visually indicates that the field must be completed
+show-label   | bool    | Control visibility of the `<label>` element without affecting layout (default: true)
 
 ## Options applied to the input
 

--- a/docs/_form-helpers/select2.md
+++ b/docs/_form-helpers/select2.md
@@ -47,15 +47,19 @@ This will then affect all select elements with the `js-select2` class (which wil
 
 ## Options applied to parent wrapper
 
-Option      | Type    | Description
------------ | ------- | --------------------------------------------------------
-class       | string  | A space separated list of class names
-guidance    | string  | Text to be displayed in a popover, adds a (?) icon after the input
+Option       | Type    | Description
+------------ | ------- | --------------------------------------------------------
+append       | string | Text or markup to include after the input element
+append_type  | string | Use only when appending a button. `button` is the only valid value
+class        | string  | A space separated list of class names
+guidance     | string  | Text to be displayed in a popover, adds a (?) icon after the input
 guidance-container | string | Element to bind guidance popover scroll behaviour to (default `body`)
-help        | string  | Additional guidance information to be displayed next to the input
-label       | string  | Text for the `<label>` companion element
-required    | bool    | Visually indicates that the field must be completed
-show-label  | bool    | Control visibility of the `<label>` element without affecting layout (default: true)
+help         | string  | Additional guidance information to be displayed next to the input
+label        | string  | Text for the `<label>` companion element
+prepend      | string | Text or markup to include before the input element
+prepend_type | string | Use only when prepending a button. `button`is the only valid value
+required     | bool    | Visually indicates that the field must be completed
+show-label   | bool    | Control visibility of the `<label>` element without affecting layout (default: true)
 
 ## Options applied to the input
 

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-append-prepend.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-append-prepend.html
@@ -1,0 +1,11 @@
+<div class="form__group">
+    <div class="controls">
+        <div class="input-group">
+            <select prepended="prepended" class="form__control select">
+                <option value="foo">bar</option>
+                <option value="bar">baz</option>
+            </select>
+            <span class="input-group-addon">appended</span>
+        </div>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-append-prepend.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-append-prepend.html.twig
@@ -1,0 +1,13 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.select({
+        'append': 'appended',
+        'prepended': 'prepended',
+        'options': {
+            'foo': 'bar',
+            'bar': 'baz'
+        }
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-append.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-append.html
@@ -1,0 +1,11 @@
+<div class="form__group">
+    <div class="controls">
+        <div class="input-group">
+            <select class="form__control select">
+                <option value="foo">bar</option>
+                <option value="bar">baz</option>
+            </select>
+            <span class="input-group-addon">appended</span>
+        </div>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-append.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-append.html.twig
@@ -1,0 +1,12 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.select({
+        'append': 'appended',
+        'options': {
+            'foo': 'bar',
+            'bar': 'baz'
+        }
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-prepend.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-prepend.html
@@ -1,0 +1,11 @@
+<div class="form__group">
+    <div class="controls">
+        <div class="input-group">
+            <span class="input-group-addon">prepended</span>
+            <select class="form__control select">
+                <option value="foo">bar</option>
+                <option value="bar">baz</option>
+            </select>
+        </div>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-prepend.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-prepend.html.twig
@@ -1,0 +1,12 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.select({
+        'prepend': 'prepended',
+        'options': {
+            'foo': 'bar',
+            'bar': 'baz'
+        }
+    })
+}}
+{% endblock %}

--- a/views/lexicon/forms.html.twig
+++ b/views/lexicon/forms.html.twig
@@ -49,8 +49,7 @@
         {
           "id"    : "dropzone",
           "label" : "Dropzone",
-          "src"   : tab_dropzone,
-          "active": true
+          "src"   : tab_dropzone
         },
         {
           "id"    : "date",
@@ -80,7 +79,8 @@
         {
           "id"    : "select",
           "label" : "Select",
-          "src"   : tab_select
+          "src"   : tab_select,
+          "active": true
         },
         {
           "id"    : "select2",

--- a/views/lexicon/forms/select.html.twig
+++ b/views/lexicon/forms/select.html.twig
@@ -6,6 +6,8 @@
         form.create()
     }}
 
+    {{ form.fieldset_start({ 'legend': 'Appended &amp; Prepended' }) }}
+
     {{
         form.select({
             'id': 'select-1',
@@ -781,6 +783,44 @@
             'label': 'Prepended &amp; Appended',
             'append': '.00',
             'prepend': '£',
+            'options': [
+                {
+                    'label': 'Value one',
+                    'value': 'value1'
+                },
+                {
+                    'label': 'Value two',
+                    'value': 'value2'
+                }
+            ]
+        })
+    }}
+
+    {{
+        form.select({
+            'id': 'select-30',
+            'label': 'Prepended button',
+            'prepend': html.button({ 'label': 'foo' }),
+            'prepend_type': 'button',
+            'options': [
+                {
+                    'label': 'Value one',
+                    'value': 'value1'
+                },
+                {
+                    'label': 'Value two',
+                    'value': 'value2'
+                }
+            ]
+        })
+    }}
+
+    {{
+        form.select({
+            'id': 'select-31',
+            'label': 'Appended button',
+            'append': html.button({ 'label': 'foo' }),
+            'append_type': 'button',
             'options': [
                 {
                     'label': 'Value one',

--- a/views/lexicon/forms/select2.html.twig
+++ b/views/lexicon/forms/select2.html.twig
@@ -846,11 +846,49 @@
         })
     }}
 
+    {{
+        form.select({
+            'id': 'select2-30',
+            'label': 'Prepended button',
+            'prepend': html.button({ 'label': 'foo' }),
+            'prepend_type': 'button',
+            'options': [
+                {
+                    'label': 'Value one',
+                    'value': 'value1'
+                },
+                {
+                    'label': 'Value two',
+                    'value': 'value2'
+                }
+            ]
+        })
+    }}
+
+    {{
+        form.select({
+            'id': 'select2-31',
+            'label': 'Appended button',
+            'append': html.button({ 'label': 'foo' }),
+            'append_type': 'button',
+            'options': [
+                {
+                    'label': 'Value one',
+                    'value': 'value1'
+                },
+                {
+                    'label': 'Value two',
+                    'value': 'value2'
+                }
+            ]
+        })
+    }}
+
     {{ form.fieldset_end() }}
 
     {{
         form.select2({
-            'id': 'select2-30',
+            'id': 'select2-32',
             'label': 'data-init="false"',
             'class': 'foo',
             'data-init': 'false',

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -1638,7 +1638,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {{
         form.group({
-            'parent': options|only('bare class error guidance guidance-container help id label required show-label'),
+            'parent': options|only('append append_type bare class error guidance guidance-container help id label prepend prepend_type required show-label'),
             'inputs': [
                 elem.select(
                     options
@@ -1713,7 +1713,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {{
         form.group({
-            'parent': options|only('bare class error guidance guidance-container help id label required show-label'),
+            'parent': options|only('append append_type bare class error guidance guidance-container help id prepend prepend_type label required show-label'),
             'inputs': [
                 elem.select2(options
                     |exclude('bare class error guidance guidance-container help label show-label')


### PR DESCRIPTION
Adds the same functionality as other form helpers.

### New helper options

Option       | Type    | Description
------------ | ------- | --------------------------------------------------------
append       | string  | Text or markup to include after the input element
append_type  | string  | Use only when appending a button. `button` is the only valid value
prepend      | string  | Text or markup to include before the input element
prepend_type | string  | Use only when prepending a button. `button`is the only valid value

### Example usage:
```
{{
    form.select({
        'label': 'Appended',
        'append': '.00',
        'options': {
            'foo': 'bar',
            'bar': 'baz'
        }
    })
}}
```

### Expected visuals
<img width="668" alt="screen shot 2017-09-07 at 15 54 13" src="https://user-images.githubusercontent.com/18653/30208122-fe9d3f68-9489-11e7-9425-e617b59fca98.png">


Closes #636 