### PR TITLE
input-group support for new grid sizes

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -356,10 +356,19 @@ fieldset {
         width: auto;
     }
 
+    // input-groups default
     .form__group .input-group {
-        width: map-get($input-widths, regular);
+        @include col-span(4, false, false, 9);
     }
 
+    // input-groups column variations
+    @for $i from 1 through 9 {
+        .form__group.form__control-col--#{$i} .input-group {
+            @include col-span($i, false, false, 9);
+        }
+    }
+
+    // input-groups legacy sizes
     @each $variant, $width in $input-widths {
         .form__group.form__group--#{$variant} .input-group {
             width: #{$width};


### PR DESCRIPTION
Prior to this fix input groups default to a fixed width and used the legacy `form__group` width modifiers. See issue #649.

Now they default to the new grid and are able to use the new grid classes.

![input-groups](https://user-images.githubusercontent.com/756393/30639283-24d2881c-9df6-11e7-8eca-ad50bca4098d.gif)

Fixed #649 
