### PR TITLE
Fix console error when closing filterbar filter containing uninitialised select2

### DIFF
--- a/js/FilterBarComponent.js
+++ b/js/FilterBarComponent.js
@@ -322,7 +322,7 @@ function removeFilter ($filterbar) {
         }
 
         // Destroy select2
-        if ($field.hasClass('js-select2')) {
+        if ($field.hasClass('select2-hidden-accessible')) {
             $field.select2('destroy');
         }
 

--- a/tests/js/web/FilterBarComponentTest.js
+++ b/tests/js/web/FilterBarComponentTest.js
@@ -16,7 +16,7 @@ describe('FilterBar component', function () {
 			'			<div class="form__group">' +
 			'				<label for="colour" class="control__label">Colour</label>' +
 			'				<div class="controls">' +
-			'					<select id="colour" multiple="" placeholder="Choose one or more" class="form__control js-select2">' +
+			'					<select id="colour" multiple="" placeholder="Choose one or more" class="form__control js-select2 select2-hidden-accessible">' +
 			'						<option value="colour_red">Red</option>' +
 			'						<option value="colour_blue">Blue</option>' +
 			'					</select>' +
@@ -25,7 +25,7 @@ describe('FilterBar component', function () {
 			'			<div class="form__group">' +
 			'				<label for="size" class="control__label">Size</label>' +
 			'				<div class="controls">' +
-			'					<select id="size" placeholder="Choose one" class="form__control select  js-select2">' +
+			'					<select id="size" placeholder="Choose one" class="form__control select js-select2 select2-hidden-accessible">' +
 			'						<option value=""></option>' +
 			'						<option value="small">Small</option>' +
 			'						<option value="medium">Medium</option>' +


### PR DESCRIPTION
**Problem**

Console error when trying to call the `select2.destroy()` method on a select2 that uses `data-init="false"

**Solution**

Use `.select2-hidden-accessible` which is added by select2 instead of our `.js-select2`, which we can't rely on to be honest about whether the select2 has been properly initialised.