### PR TITLE
Fixed checkbox bg and width issue in FF and IE

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -90,6 +90,7 @@ fieldset {
         height: auto;
         padding: 0;
         vertical-align: baseline;
+        width: auto;
 
         @include ie-lte(9) {
             border: 0;
@@ -327,7 +328,7 @@ fieldset {
 // based on the remaining 9 column grid
 
     // default width
-    .control__label + .controls > .form__control {
+    .control__label + .controls > .form__control:not(.checkbox) {
         @include col-span(4, false, false, 9);
     }
 
@@ -346,14 +347,6 @@ fieldset {
         .form__group--#{$variant}.form__group--#{$variant} .control__label + .controls > .form__control {
             width: #{$width};
         }
-    }
-
-    // Checkboxes and radios don't need to use the grid widths, but we avoid
-    // using :not() because it makes things overly specific and is a pain to
-    // override (trust me ;)
-    .form__control.checkbox,
-    .form__control.radio {
-        width: auto;
     }
 
     // input-groups default


### PR DESCRIPTION
Fixed the width issue in FF and IE (along with the bg colour issue).

Unfortunately due to the nested MQ generated by using the `col-span` mixin [here](https://github.com/jadu/pulsar/blob/662_checkbox-issues/stylesheets/_component.forms.scss#L332) when already inside [this MQ](https://github.com/jadu/pulsar/blob/662_checkbox-issues/stylesheets/_component.forms.scss#L307) the only option was to use a `not(.checkbox)` [here](https://github.com/jadu/pulsar/blob/662_checkbox-issues/stylesheets/_component.forms.scss#L331).

Previously this was generating this CSS
```
@media screen and (min-width: 600px) and (min-width: 480px) {
  .control__label + .controls > .form__control {
    width: 100%; } }
```

Which was more specific (by 1 MQ) than the width overrides (now removed).

Example of FF fix:
![checkbox fix](https://user-images.githubusercontent.com/756393/31122351-5eff43c6-a833-11e7-9105-61ca64092724.gif)

The previous (non-working) overrides mentioned not using `not()` due to specificity so this fix may need testing in product.

Fixes #662 