### PR TITLE
Remove double underline on abbreviations

### DIFF
--- a/stylesheets/_structure.type.scss
+++ b/stylesheets/_structure.type.scss
@@ -74,6 +74,11 @@ dt {
     }
 }
 
+// normalize-css needs updating to 7.0.0, for now we'll use this
+abbr[title] {
+    text-decoration: none;
+}
+
 .monospace {
     font-family: $font-family-monospace;
 

--- a/views/lexicon/tabs/message.html.twig
+++ b/views/lexicon/tabs/message.html.twig
@@ -2,9 +2,21 @@
 {% import 'pulsar/v2/helpers/form.html.twig' as form %}
 {% import 'pulsar/v2/helpers/flash.html.twig' as flash %}
 
-<h2 class="heading">Message</h2>
+<h2 class="heading">Text</h2>
 
 <div class="tab__inner tab--padded">
+
+    <ul>
+        <li>This is regular text</li>
+        <li><strong>This is bold text</strong></li>
+        <li><i>This is italic text</i></li>
+        <li><strong><i>This is bold, italic text</i></strong></li>
+        <li><a href="#" title="This is a link">This is a link</a></li>
+        <li><abbr title="This is the description">This is an abbreviation</abbr></li>
+        <li><a href="#" title="This is the link description">This is a link with an <abbr title="This is the abbreviation description">abbr</abbr> inside it</a></li>
+    </ul>
+
+    <h2>Messages</h2>
     <div class="message">
         <time class="message__time">16:32 <small>(2 days ago)</small></time>
         <span class="message__sender">Paul Stanton</span>


### PR DESCRIPTION
Issue was seen in Chrome and Firefox.

![screen shot 2017-10-06 at 14 43 55](https://user-images.githubusercontent.com/18653/31280632-de62b3fa-aaa4-11e7-922a-76906e3f81e0.png)

Closes #665