### PR TITLE
Add card component and documentation

### DIFF
--- a/docs/_components/card.md
+++ b/docs/_components/card.md
@@ -1,0 +1,188 @@
+---
+layout: page
+title: Card
+category: Components
+---
+
+Cards are a flexible container for standout content with a range of configurable options for headers and footers, images and calls to action.
+
+Cards can be sized and arranged using the common grid classes and respond well at small screen widths.
+
+## Example usage
+
+{% code_example html_helpers/card %}
+
+<div class="pulsar-example">
+    <div class="card">
+        <div class="card__body">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            <a href="#cta" class="btn btn--primary">Call to Action</a>
+        </div>
+    </div>
+</div>
+
+## Body
+
+At its most basic, a card can just contain a body.
+
+{% code_example html_helpers/card-body %}
+
+<div class="pulsar-example">
+    <div class="card">
+        <div class="card__body">
+            <p>This is the card body, it should be helpful and descriptive.</p>
+        </div>
+    </div>
+</div>
+
+## Titles, text, and links
+
+A card can contain a `.card__title` using a `<h*>` element within the body.
+
+Links using the `.card-link` class will be spaced apart slightly.
+
+{% code_example html_helpers/card-title-links %}
+
+<div class="pulsar-example">
+    <div class="card">
+        <div class="card__body">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            <a href="#cta-one" class="card-link">Card link</a>
+            <a href="#cta-two" class="card-link">Another link</a>
+        </div>
+    </div>
+</div>
+
+## Images
+
+Images can be added to the top of a card, they will be automatically made to respond to the card width.
+
+Use `.card--full-bleed` on the `.card` to make the image cover the default border of the card.
+
+<div class="pulsar-example">
+    <div class="card g-col g-col--6 g-col--first">
+        <img src="http://via.placeholder.com/600x250/ebebeb/000000?text=image" class="card-img" />
+        <div class="card__body">
+            <h3 class="card__title">Normal</h3>
+            <p>The image will be contained within the cards default border.</p>
+            <a href="#cta-one" class="card-link">Card link</a>
+            <a href="#cta-two" class="card-link">Another link</a>
+        </div>
+    </div>
+
+    <div class="card card--full-bleed g-col g-col--6">
+        <img src="http://via.placeholder.com/600x250/ebebeb/000000?text=image" class="card-img" />
+        <div class="card__body">
+            <h3 class="card__title">Full bleed</h3>
+            <p>This card uses <code>.card--full-bleed</code>, the difference is subtle.</p>
+            <a href="#cta-one" class="card-link">Card link</a>
+            <a href="#cta-two" class="card-link">Another link</a>
+        </div>
+    </div>
+</div>
+
+## Headers and footers
+
+Add an optional header and/or footer within a card. You can choose whether or not to also include a card title.
+
+{% code_example html_helpers/card-header-footer %}
+
+<div class="pulsar-example">
+    <div class="card">
+        <div class="card__header">
+            <p class="card__heading">Card Heading</p>
+        </div>
+        <div class="card__body">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            <a href="#cta-one" class="card-link">Card link</a>
+            <a href="#cta-two" class="card-link">Another link</a>
+        </div>
+        <div class="card__footer muted">
+            <p>Card footer</p>
+        </div>
+    </div>
+</div>
+
+<h2>Grid sizing</h2>
+
+Cards will be 100% width by default and can be modified using [grid classes](/layout/grid/). Use `.row` divs to organise cards into rows until we get fancier with flexbox.
+
+```html
+<div class="card g-col g-col--6 g-col--first">...</div>
+<div class="card g-col g-col--6">...</div>
+```
+
+<div class="pulsar-example">
+    <div class="card g-col g-col--6 g-col--first">
+        <div class="card__body">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            <a href="#cta" class="btn btn--primary">Call to Action</a>
+        </div>
+    </div>
+    <div class="card g-col g-col--6">
+        <div class="card__body">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            <a href="#cta" class="btn btn--primary">Call to Action</a>
+        </div>
+    </div>
+</div>
+
+```html
+<div class="card g-col g-col--4 g-col--first">...</div>
+<div class="card g-col g-col--4">...</div>
+<div class="card g-col g-col--4">...</div>
+```
+
+<div class="pulsar-example">
+    <div class="card g-col g-col--4 g-col--first">
+        <div class="card__body">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            <a href="#cta" class="btn btn--primary">Call to Action</a>
+        </div>
+    </div>
+    <div class="card g-col g-col--4">
+        <div class="card__body">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            <a href="#cta" class="btn btn--primary">Call to Action</a>
+        </div>
+    </div>
+    <div class="card g-col g-col--4">
+        <div class="card__body">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            <a href="#cta" class="btn btn--primary">Call to Action</a>
+        </div>
+    </div>
+</div>
+
+## Centered
+
+Use the `.u-text-align-center` utility class to make an entire card centered.
+
+```html
+<div class="card u-text-align-center">...</div>
+```
+
+<div class="pulsar-example">
+    <div class="card u-text-align-center">
+        <div class="card__header">
+            <p class="card__heading">Card Heading</p>
+        </div>
+        <div class="card__body">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            <a href="#cta-one" class="card-link">Card link</a>
+            <a href="#cta-two" class="card-link">Another link</a>
+        </div>
+        <div class="card__footer muted">
+            <p>Card footer</p>
+        </div>
+    </div>
+</div>

--- a/docs/_sass/_base.scss
+++ b/docs/_sass/_base.scss
@@ -47,8 +47,6 @@ a {
 img {
   display: block;
   max-width: 100%;
-  margin: 0 0 1rem;
-  border-radius: 5px;
 }
 
 table:not(.table) {

--- a/docs/assets/code_examples/html_helpers/html/card
+++ b/docs/assets/code_examples/html_helpers/html/card
@@ -1,0 +1,7 @@
+<div class="card">
+    <div class="card__body">
+        <h3 class="card__title">Card Title</h3>
+        <p>This is the card body, it should be helpful and descriptive.</p>
+        <a href="#cta" class="btn btn--primary">Call to Action</a>
+    </div>
+</div>

--- a/docs/assets/code_examples/html_helpers/html/card-body
+++ b/docs/assets/code_examples/html_helpers/html/card-body
@@ -1,0 +1,5 @@
+<div class="card">
+    <div class="card__body">
+        <p>This is the card body, it should be helpful and descriptive.</p>
+    </div>
+</div>

--- a/docs/assets/code_examples/html_helpers/html/card-header-footer
+++ b/docs/assets/code_examples/html_helpers/html/card-header-footer
@@ -1,0 +1,13 @@
+<div class="card">
+    <div class="card__header">
+        <h3 class="card__heading">Card Heading</h3>
+    </div>
+    <div class="card__body">
+        <p>This is the card body, it should be helpful and descriptive.</p>
+        <a href="#cta-one" class="card-link">Card link</a>
+        <a href="#cta-two" class="card-link">Another link</a>
+    </div>
+    <div class="card__footer muted">
+        <p>Card footer</p>
+    </div>
+</div>

--- a/docs/assets/code_examples/html_helpers/html/card-title-links
+++ b/docs/assets/code_examples/html_helpers/html/card-title-links
@@ -1,0 +1,10 @@
+<div class="pulsar-example">
+    <div class="card">
+        <div class="card__body">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            <a href="#cta-one" class="card-link">Card link</a>
+            <a href="#cta-two" class="card-link">Another link</a>
+        </div>
+    </div>
+</div>

--- a/stylesheets/_component.cards.scss
+++ b/stylesheets/_component.cards.scss
@@ -1,0 +1,67 @@
+.card {
+    border: 1px solid color(border);
+    border-radius: $border-radius;
+    margin-bottom: $line-height-base;
+
+    @include respond-min($screen-small) {
+        margin-bottom: 0;
+    }
+}
+
+.card__header {
+    background: color(gray, off-white);
+    border-bottom: 1px solid color(border);
+    border-top-left-radius: $border-radius;
+    border-top-right-radius: $border-radius;
+    font-family: $font-family-regular;
+    padding: .75em;
+}
+
+.card__heading {
+    margin: 0;
+}
+
+.card__title {
+    font-family: $font-family-regular;
+}
+
+.card__body {
+    padding: .75em;
+
+    li:last-child {
+        border-bottom: 0;
+    }
+}
+
+.card__footer {
+    background: color(gray, off-white);
+    border-bottom-left-radius: $border-radius;
+    border-bottom-right-radius: $border-radius;
+    border-top: 1px solid color(border);
+    padding: .25em .75em;
+}
+
+.card-link + .card-link {
+    margin-left: $padding-base;
+}
+
+.card-img {
+    border-top-left-radius: $border-radius;
+    border-top-right-radius: $border-radius;
+    display: block;
+    max-width: 100%;
+}
+
+.card-img + .card__body {
+    border-top: 1px solid color(border);
+}
+
+.card--full-bleed {
+    border: 0;
+
+    .card__body {
+        border: 1px solid color(border);
+        border-bottom-left-radius: $border-radius;
+        border-bottom-right-radius: $border-radius;
+    }
+}

--- a/stylesheets/_component.cards.scss
+++ b/stylesheets/_component.cards.scss
@@ -50,6 +50,7 @@
     border-top-right-radius: $border-radius;
     display: block;
     max-width: 100%;
+    width: 100%;
 }
 
 .card-img + .card__body {

--- a/stylesheets/pulsar.scss
+++ b/stylesheets/pulsar.scss
@@ -96,6 +96,7 @@ $fa-css-prefix: 'icon';
 @import 'component.button-groups';
 @import 'component.buttons';
 @import 'component.calendar';
+@import 'component.cards';
 @import 'component.colorpicker';
 @import 'component.close';
 @import 'component.datepicker';

--- a/views/lexicon/index.html.twig
+++ b/views/lexicon/index.html.twig
@@ -11,6 +11,9 @@
 {% set tab_block_list %}
     {% include 'lexicon/tabs/block-list.html.twig' %}
 {% endset %}
+{% set tab_cards %}
+    {% include 'lexicon/tabs/cards.html.twig' %}
+{% endset %}
 {% set tab_colours %}
     {% include 'lexicon/tabs/colours.html.twig' %}
 {% endset %}
@@ -57,14 +60,20 @@
           "id"    : "grid",
           "label" : "Grid",
           "href"  : "?tab=grid",
-          "src"   : tab_grid
+          "src"   : tab_grid,
+        },
+        {
+          "id"    : "cards",
+          "label" : "Cards",
+          "href"  : "?tab=cards",
+          "src"   : tab_cards,
+          "active": true
         },
         {
           "id"    : "colours",
           "label" : "Colours",
           "href"  : "?tab=colours",
           "src"   : tab_colours,
-          "active": true
         },
         {
           "id"    : "buttons",

--- a/views/lexicon/tabs/cards.html.twig
+++ b/views/lexicon/tabs/cards.html.twig
@@ -1,0 +1,118 @@
+{% extends "@pulsar/pulsar/components/tab.html.twig" %}
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
+{% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
+
+{% block tab_content %}
+
+    <div class="card g-col g-col--3 g-col--first">
+        <div class="card__body card__body--light">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            {{
+                html.button({
+                    'label': 'Call to Action',
+                    'class': 'btn--primary'
+                })
+            }}
+        </div>
+    </div>
+
+    <div class="card g-col g-col--3">
+        <div class="card__body card__body--light">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            {{
+                html.link({
+                    'label': 'Card link',
+                    'class': 'card-link'
+                })
+            }}
+            {{
+                html.link({
+                    'label': 'Card link',
+                    'class': 'card-link'
+                })
+            }}
+        </div>
+    </div>
+
+    <div class="card g-col g-col--3">
+        <div class="card__header">
+            <h3 class="card__heading">Card Heading</h3>
+        </div>
+        <div class="card__body card__body--light">
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            {{
+                html.button({
+                    'label': 'Call to Action',
+                    'class': 'btn--primary'
+                })
+            }}
+        </div>
+    </div>
+
+    <div class="card g-col g-col--3 u-text-align-center">
+        <div class="card__header">
+            <h3 class="card__heading">Card Heading</h3>
+        </div>
+        <div class="card__body card__body--light">
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            {{
+                html.button({
+                    'label': 'Call to Action',
+                    'class': 'btn--primary'
+                })
+            }}
+        </div>
+        <div class="card__footer">
+            This is the card footer
+        </div>
+    </div>
+
+    <div class="card g-col g-col--3 g-col--first">
+        <div class="card__header">
+            <h3 class="card__heading">Card Heading</h3>
+        </div>
+        <div class="card__body card__body--light">
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            {{
+                html.button({
+                    'label': 'Call to Action',
+                    'class': 'btn--primary'
+                })
+            }}
+        </div>
+        <div class="card__footer">
+            This is the card footer
+        </div>
+    </div>
+
+    <div class="card g-col g-col--3">
+        <img src="http://via.placeholder.com/1000x700/cccccc/000000" class="card-img" />
+        <div class="card__body card__body--light">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            {{
+                html.button({
+                    'label': 'Call to Action',
+                    'class': 'btn--primary'
+                })
+            }}
+        </div>
+    </div>
+
+    <div class="card g-col g-col--3 card--full-bleed">
+        <img src="http://via.placeholder.com/1000x700/cccccc/000000" class="card-img" />
+        <div class="card__body card__body--light">
+            <h3 class="card__title">Card Title</h3>
+            <p>This is the card body, it should be helpful and descriptive.</p>
+            {{
+                html.button({
+                    'label': 'Call to Action',
+                    'class': 'btn--primary'
+                })
+            }}
+        </div>
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
![screen shot 2017-11-07 at 15 31 51](https://user-images.githubusercontent.com/18653/32501777-d3904c18-c3d0-11e7-81c0-a86b32c97e0f.png)

Cards are a flexible container for standout content with a range of configurable options for headers and footers, images and calls to action.

Cards can be sized and arranged using the common grid classes and respond well at small screen widths.

## Example usage

```
<div class="card">
    <div class="card__body">
        <h3 class="card__title">Card Title</h3>
        <p>This is the card body, it should be helpful and descriptive.</p>
        <a href="#cta" class="btn btn--primary">Call to Action</a>
    </div>
</div>
```

Detailed examples in [card.md](https://github.com/jadu/pulsar/pull/690/files#diff-a5aff9c6f591a7ec91cfa32c67e27e96), helper will follow as a separate ticket once any issues here have been sweated out.

Closes #687