### PR TITLE
Whitelist specific phrasing tags for the html.button helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,9 @@
   "scripts": {
     "start": "vagrant reload && grunt",
     "coverage": "mochify --transform [ babelify ] --plugin [ mochify-istanbul --exclude '**/+(tests|node_modules|libs)/**/*' --report lcov --dir ./coverage --instrumenter babel-istanbul] --reporter spec --recursive ./tests/js/web/index ./tests/js/web/*Test.js",
-    "test": "npm run web-test && npm run js-ext-test && npm run js-macro-test",
+    "test": "npm run web-test && npm run js-ext-test",
     "web-test": "mochify --reporter spec --transform [ babelify ] ./tests/js/web/index './tests/js/web/**/*Test.js'",
-    "js-ext-test": "mocha --reporter spec ./tests/js/twig/Extension/*Test.js",
-    "js-macro-test": "mocha --reporter spec ./tests/js/twig/Macro/*Test.js"
+    "js-ext-test": "mocha --reporter spec ./tests/js/twig/Extension/*Test.js"
   },
   "devDependencies": {
     "aliasify": "^1.9.0",

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/button-xss.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/button-xss.html
@@ -1,0 +1,1 @@
+<button class="btn"><i>icon</i>foo alert(1);</button>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/button-xss.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/button-xss.html.twig
@@ -1,0 +1,8 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    html.button({
+        'label': '<i>icon</i> foo <script>alert(1);</script>'
+    })
+}}
+{% endblock %}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -308,7 +308,7 @@ data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
                 })
             )
         }}>
-            {{- options.label|default|raw -}}
+            {{- options.label|default|striptags('<abbr><b><br><cite><code><dfn><em><i><img><kbd><q><small><span><strong><sub><sup>')|raw -}}
             {{- util.caret(options.caret|default) -}}
         </button>
 


### PR DESCRIPTION
Restrict the allowable HTML elements within a `<button>` to the common phrasing tags we're likely to use.