### PR TITLE
Correct Datatable Selection Option Wording in Docs

### DIFF
--- a/docs/_components/datatable.md
+++ b/docs/_components/datatable.md
@@ -597,7 +597,7 @@ The `DataTable` plugin is called on any table containing the `datatable` class. 
 Datatables allow selection of rows by default, this behaviour can be disabled through the `data-selection` attribute. This will hide the related elements in the UI.
 
 ```html
-<table class="table datatable" data-selection="false">
+<table class="table datatable table--full" data-select="false">
  ...
 </table>
 ```


### PR DESCRIPTION
![datatables-selection](https://user-images.githubusercontent.com/1425876/33885353-0066667a-df3b-11e7-9300-8a7748175f4c.png)

Very simple and small change. The correct syntax is
`data-select="false"`