### PR TITLE
Update UglifyJS2 version

### DIFF
--- a/libs/store.js/package.json
+++ b/libs/store.js/package.json
@@ -22,7 +22,7 @@
     "ngrok": "^0.2.2",
     "node-localstorage": "^0.6.0",
     "request": "^2.67.0",
-    "uglify-js": "v1.3.4"
+    "uglify-js": "2.6.0"
   },
   "engines": {
     "browser": "*",

--- a/libs/store.js/package.json
+++ b/libs/store.js/package.json
@@ -22,7 +22,7 @@
     "ngrok": "^0.2.2",
     "node-localstorage": "^0.6.0",
     "request": "^2.67.0",
-    "uglify-js": "2.6.0"
+    "uglify-js": "v2.6.0"
   },
   "engines": {
     "browser": "*",


### PR DESCRIPTION
This was suggested by Github. There is not much available and this specific dependency doesn't have a changelog. Searched every source available and at least there is no issue mentioned for the version 2. When it will be time to update to 3 there we will probably have to change because there is no backwards compatibility.
  