### PR TITLE
Make sure unhidden primary nav items don’t use inline-block

### DIFF
--- a/js/NavMainComponent.js
+++ b/js/NavMainComponent.js
@@ -232,7 +232,9 @@ NavMainComponent.prototype.unhidePrimaryNavItems = function () {
         firstHiddenPrimaryNavItem = navItems.find('li:hidden').first();
 
         if ((firstHiddenPrimaryNavItem.length > 0) && (navItemMore.is(':visible'))) {
-            firstHiddenPrimaryNavItem.show();
+
+            // Reset display type to list-item rather than show() to make sure they don't get recreated as inline-block
+            firstHiddenPrimaryNavItem.css({display: 'list-item'});
         }
 };
 


### PR DESCRIPTION
This fixes an odd edge case identified in XFP where items unhidden through `show()` were being assigned `inline-block` rather than `list-type`.

To resolve this we now explicitly set that as the inline style rather than use `show()`.

Fixes #719