### PR TITLE
[CMS-5087] Button issue on Pulsar's data table

### DIFF
--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -47,14 +47,21 @@
 // scss-lint:enable SelectorFormat
 
 .dt-buttons {
+    border-right: 1px solid #ccc;
     float: left;
     margin-top: 11px;
     margin-right: 10px;
-    border-right: 1px solid #ccc;
+    padding-right: 6px;
 }
 
 .dt-button {
-    margin-right: 10px;
+    background-color: transparent;
+    border: 0;
+    color: color(jadu-blue, dark);
+
+    &:hover {
+        color: color(jadu-blue, darkest);
+    }
 }
 
 .datatable {


### PR DESCRIPTION
An update of the datatables package caused a change in the markup of the dt-buttons. It used to be links now it is buttons. This is the reason of those new styles.

![datatables-style correction](https://user-images.githubusercontent.com/1425876/34768247-46bf4ad8-f5f2-11e7-8440-1f144e0a74aa.png)
  