### PR TITLE
Make sure legends are consistently styled with underline

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -7,7 +7,7 @@ fieldset {
 .form {
     background-color: color(white);
 
-    > fieldset {
+    fieldset {
         padding: 22px 0;
 
         legend {


### PR DESCRIPTION
The descendent selector was breaking legend styling in stuations where fieldsets were contained in another element like a `<section>`.

Fixes #712