### PR TITLE
Add a box shadow to the select2 dropdown to offset against the background UI

### DIFF
--- a/stylesheets/_component.select2.scss
+++ b/stylesheets/_component.select2.scss
@@ -690,6 +690,7 @@ span.select2-selection.select2-selection--single {
 }
 
 .select2-dropdown {
+    box-shadow: 0 5px 10px rgba(0,0,0,.4);
     z-index: $zindex-modal;
 }
 


### PR DESCRIPTION
## Before

![screen shot 2018-01-10 at 11 39 31](https://user-images.githubusercontent.com/18653/34771015-f6a82c64-f5fa-11e7-95b8-1cd7d1069d68.png)

## After

**Safari**
![screen shot 2018-01-10 at 11 38 48](https://user-images.githubusercontent.com/18653/34770990-dd19df04-f5fa-11e7-9571-d1c3d57c7492.png)

**Chrome**
![screen shot 2018-01-10 at 11 37 04](https://user-images.githubusercontent.com/18653/34770921-a05d9100-f5fa-11e7-98f2-2714ebfe49f6.png)

**Firefox**
![screen shot 2018-01-10 at 11 37 57](https://user-images.githubusercontent.com/18653/34770955-bdd24e6a-f5fa-11e7-9889-41c89783a11d.png)

**IE9**
![screen shot 2018-01-10 at 11 22 03](https://user-images.githubusercontent.com/18653/34770810-2d4cfa02-f5fa-11e7-949d-fbada8801e68.png)

**IE10**
![screen shot 2018-01-10 at 11 23 45](https://user-images.githubusercontent.com/18653/34770805-26f96870-f5fa-11e7-9bfc-35df8b8c1551.png)

**IE11**
![screen shot 2018-01-10 at 11 28 28](https://user-images.githubusercontent.com/18653/34770795-22a81bb8-f5fa-11e7-962d-e9e05f6c75c9.png)

Closes #702