### PR TITLE
Flash messages now use state colours

### DIFF
--- a/stylesheets/_component.flash.scss
+++ b/stylesheets/_component.flash.scss
@@ -34,9 +34,8 @@
 // Default
 .flash,
 .flash--default {
-    background: color(inverse, flash);
+    background: color(inverse);
     color: color(inverse, alt);
-    text-shadow: 0 0 2px rgba(0, 0, 0, .5);
 
     a {
         color: inherit;
@@ -45,29 +44,27 @@
 }
 
 // Variations
-.flash--success {
-    background: color(success, flash);
-    background: rgba(color(success, flash), .8);
-    color: color(success, alt);
+@each $state, $state-color, $state-color-alt in $state-colors {
+    // Exclude unneeded states
+    @if $state != base and $state != new and $state != white {
+        .flash--#{$state} {
+            background-color: $state-color;
+            color: $state-color-alt;
+
+            a,
+            a:link,
+            a:hover,
+            a:active,
+            a:visited {
+                color: $state-color-alt;
+            }
+        }
+    }
 }
 
-.flash--warning {
-    background: color(warning, flash);
-    background: rgba(color(warning, flash), .8);
-    color: color(warning, alt);
-    text-shadow: none;
-}
-
+// For backwards compatibility with old flash error class name
 .flash--error {
-    background: color(danger, flash);
-    background: rgba(color(danger, flash), .8);
-    color: color(danger, alt);
-}
-
-.flash--info {
-    background: color(info);
-    color: color(info, alt);
-    text-shadow: none;
+    @extend .flash--danger;
 }
 
 // Close buttons

--- a/stylesheets/_component.panels.scss
+++ b/stylesheets/_component.panels.scss
@@ -73,6 +73,8 @@
 }
 
 @each $state, $state-color, $state-color-alt in $state-colors {
+    // Exclude unneeded states
+    @if $state != base and $state != new and $state != white {
         .panel--#{$state} {
             background-color: $state-color;
             color: $state-color-alt;
@@ -86,6 +88,7 @@
             }
         }
     }
+}
 
 .form-v2 > .panel:first-of-type {
     margin-top: 0;

--- a/stylesheets/_palette.base.scss
+++ b/stylesheets/_palette.base.scss
@@ -72,8 +72,7 @@ $palette-states: (
         base:  map-get(map-get($palette-monochromes, gray), lightest),
         alt:   pick_best_color(map-get(map-get($palette-monochromes, gray), lighter), (#fff, #000)),
         light: lighten(map-get(map-get($palette-monochromes, gray), lightest), 5),
-        dark:  map-get(map-get($palette-monochromes, gray), darker),
-        flash: map-get(map-get($palette-monochromes, gray), black),
+        dark:  map-get(map-get($palette-monochromes, gray), darker)
     ),
     primary: (
         base:  #2575b0,
@@ -85,36 +84,31 @@ $palette-states: (
         base:  #297c46,
         alt:   pick_best_color(#297c46, (#fff, #000)),
         light: lighten(#297c46, 55),
-        dark:  darken(#297c46, 5),
-        flash: rgb(0, 153, 51),
+        dark:  darken(#297c46, 5)
     ),
     warning: (
         base:  #eaa96a,
         alt:   pick_best_color(#eaa96a, (#fff, #000)),
         light: lighten(#eaa96a, 25),
-        dark:  darken(#eaa96a, 35),
-        flash: rgb(255, 137, 9)
+        dark:  darken(#eaa96a, 35)
     ),
     danger: (
         base:  #c84d40,
         alt:   pick_best_color(#c84d40, (#fff, #000)),
         light: lighten(#c84d40, 40),
-        dark:  darken(#c84d40, 5),
-        flash: rgb(204, 51, 51)
+        dark:  darken(#c84d40, 5)
     ),
     info: (
         base:  map-get(map-get($palette-branding, jadu-blue), pale),
         alt:   pick_best_color(map-get(map-get($palette-branding, jadu-blue), pale), (#fff, #000)),
         light: lighten(map-get(map-get($palette-branding, jadu-blue), pale), 15),
-        dark:  darken(map-get(map-get($palette-branding, jadu-blue), pale), 40),
-        flash: map-get(map-get($palette-branding, jadu-blue), pale)
+        dark:  darken(map-get(map-get($palette-branding, jadu-blue), pale), 40)
     ),
     inverse: (
         base:  map-get(map-get($palette-monochromes, gray), darker),
         alt:   pick_best_color(map-get(map-get($palette-monochromes, gray), darker), (#fff, #000)),
         light: lighten(map-get(map-get($palette-monochromes, gray), darker), 60),
-        dark:  map-get(map-get($palette-monochromes, gray), darker),
-        flash: map-get(map-get($palette-monochromes, gray), darker)
+        dark:  map-get(map-get($palette-monochromes, gray), darker)
     ),
     white: (
         base:  #fff,

--- a/stylesheets/_palette.projector.scss
+++ b/stylesheets/_palette.projector.scss
@@ -77,8 +77,7 @@ $palette-states: (
         base:  map-get(map-get($palette-monochromes, gray), lightest),
         alt:   pick_best_color(map-get(map-get($palette-monochromes, gray), lighter), (#fff, #000)),
         light: lighten(map-get(map-get($palette-monochromes, gray), lightest), 5),
-        dark:  map-get(map-get($palette-monochromes, gray), darker),
-        flash: map-get(map-get($palette-monochromes, gray), black),
+        dark:  map-get(map-get($palette-monochromes, gray), darker)
     ),
     primary: (
         base:  #2575b0,
@@ -90,36 +89,31 @@ $palette-states: (
         base:  #297c46,
         alt:   pick_best_color(#297c46, (#fff, #000)),
         light: lighten(#297c46, 55 - $darken-factor),
-        dark:  darken(#297c46, 5),
-        flash: rgb(0, 153, 51),
+        dark:  darken(#297c46, 5)
     ),
     warning: (
         base:  #eaa96a,
         alt:   pick_best_color(#eaa96a, (#fff, #000)),
         light: lighten(#eaa96a, 25 - $darken-factor),
-        dark:  darken(#eaa96a, 35),
-        flash: rgb(255, 137, 9)
+        dark:  darken(#eaa96a, 35)
     ),
     danger: (
         base:  #c84d40,
         alt:   pick_best_color(#c84d40, (#fff, #000)),
         light: lighten(#c84d40, 40 - $darken-factor),
-        dark:  darken(#c84d40, 5),
-        flash: rgb(204, 51, 51)
+        dark:  darken(#c84d40, 5)
     ),
     info: (
         base:  map-get(map-get($palette-branding, jadu-blue), pale),
         alt:   pick_best_color(map-get(map-get($palette-branding, jadu-blue), pale), (#fff, #000)),
         light: lighten(map-get(map-get($palette-branding, jadu-blue), pale), 5),
-        dark:  darken(map-get(map-get($palette-branding, jadu-blue), pale), 40),
-        flash: map-get(map-get($palette-branding, jadu-blue), pale)
+        dark:  darken(map-get(map-get($palette-branding, jadu-blue), pale), 40)
     ),
     inverse: (
         base:  map-get(map-get($palette-monochromes, gray), darker),
         alt:   pick_best_color(map-get(map-get($palette-monochromes, gray), darker), (#fff, #000)),
         light: lighten(map-get(map-get($palette-monochromes, gray), darker), 60 - $darken-factor),
-        dark:  map-get(map-get($palette-monochromes, gray), darker),
-        flash: map-get(map-get($palette-monochromes, gray), darker)
+        dark:  map-get(map-get($palette-monochromes, gray), darker)
     ),
     white: (
         base:  #fff,


### PR DESCRIPTION
Previously flash messages had different colours to states colours and therefore didn't match elements such as panels - see #727.

Flash messages now use state colours. Also I noticed flash message and panels were outputting some unneeded CSS for a handful of states that weren't applicable to them, these have now been filtered out from the respective loops. Therefore: 

- `panel--base`
- `panel--white`
- `panel--new`

No longer exist. These don't seem to have been used anywhere and were visually broken. Suspect these were created by mistake and as a by-product of adding `base`, `white` and `new` to `$state-colors`. Note the colours have not been removed from `$state-colors` as they are used elsewhere.

I've also removed the old flash colours form the palettes.

New colours (All meet AA due to state colour usage):
![new](https://user-images.githubusercontent.com/756393/34942495-d0e779dc-f9ef-11e7-9104-bf4670684729.png)

Old colours (some didn't meet AA):
![old](https://user-images.githubusercontent.com/756393/34942545-f7e706ce-f9ef-11e7-9ce7-503e097e92c5.png)
