### PR TITLE
Responsive progress lists 📱

### DIFF
--- a/stylesheets/_component.progress-lists.scss
+++ b/stylesheets/_component.progress-lists.scss
@@ -1,41 +1,84 @@
 .progress-list {
-    display: table;
     margin-bottom: 1em;
     overflow: hidden;
-    table-layout: fixed;
     width: 100%;
+
+    @include respond-min($screen-tablet) {
+        display: table;
+        table-layout: fixed;
+    }
 }
 
 .progress-list__item {
     background-color: $progress-bg;
-    border-right: 3px solid color(white);
-    box-shadow: inset 2px 1px 2px rgba(0, 0, 0, .1);
+    border-bottom: 3px solid color(white);
+    box-shadow: inset 0 2px 2px 0 rgba(0, 0, 0, .1);
     color: color(black);
-    display: table-cell;
-    padding: .75em 0 .75em 40px;
+    display: block;
+    padding: 1.75em 0 .75em .75em;
     text-decoration: none;
     vertical-align: top;
 
+    @include respond-min($screen-tablet) {
+        border: 0;
+        box-shadow: inset 2px 1px 2px rgba(0, 0, 0, .1);
+        display: table-cell;
+        padding: .75em 0 .75em 40px;
+    }
+
+    // scss-lint:disable DeclarationOrder
     &:not(:last-child) {
-        @include css-arrow(23px, right, $progress-bg);
+        @include css-arrow(23px, bottom, $progress-bg);
 
         &::before {
-            border-left-color: color(white);
+            border-top-color: color(white);
             border-width: 27px;
-            margin-top: -27px;
+            margin-left: -27px;
+        }
+
+        @include respond-min($screen-tablet) {
+            @include css-arrow(23px, right, $progress-bg);
+            border-right: 3px solid color(white);
+
+            &::before {
+                border-left-color: color(white);
+                border-width: 27px;
+                margin-left: 0;
+                margin-top: -27px;
+            }
+
+            &::after {
+                border-top-color: transparent;
+                margin-left: 0;
+            }
         }
     }
+    // scss-lint:enable DeclarationOrder
 
     &:first-child {
         border-top-left-radius: $border-radius;
-        border-bottom-left-radius: $border-radius;
-        padding-left: 15px;
+        border-top-right-radius: $border-radius;
+
+        @include respond-min($screen-tablet) {
+            border-bottom-left-radius: $border-radius;
+            border-top-left-radius: $border-radius;
+            border-top-right-radius: 0;
+            padding-left: 15px;
+        }
     }
 
     &:last-child {
-        border-top-right-radius: $border-radius;
+        border-bottom: 0;
+        border-bottom-left-radius: $border-radius;
         border-bottom-right-radius: $border-radius;
         padding-right: 15px;
+
+        @include respond-min($screen-tablet) {
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: $border-radius;
+            border-top-right-radius: $border-radius;
+            padding-right: 15px;
+        }
     }
 
     &::before,
@@ -48,11 +91,15 @@
         color: color(black);
 
         &::after {
-            border-left-color: $progress-bg-hover;
+            border-top-color: $progress-bg-hover;
+
+            @include respond-min($screen-tablet) {
+                border-top-color: transparent;
+                border-left-color: $progress-bg-hover;
+            }
         }
     }
 }
-
 
 .progress-list__label {
     @include word-break-all;
@@ -73,24 +120,29 @@
     }
 }
 
-
-
 .progress-list__arrow {
     @extend %hide;
 }
 
-
 .progress-list__item--complete {
     background-color: color(success);
-    box-shadow: inset 0 -1px 0 rgba(0, 0, 0, .15);
     color: color(success, alt);
+
+    @include respond-min($screen-tablet) {
+        box-shadow: inset 0 -1px 0 rgba(0, 0, 0, .15);
+    }
 
     .badge {
         color: color(white) !important;
     }
 
     &:not(:last-child)::after {
-        border-left-color: color(success);
+        border-top-color: color(success);
+
+        @include respond-min($screen-tablet) {
+            border-top-color: transparent;
+            border-left-color: color(success);
+        }
     }
 
     &:hover {
@@ -98,23 +150,35 @@
         color: color(success, alt);
 
         &::after {
-            border-left-color: darken(color(success), 2);
+            border-top-color: darken(color(success), 2);
+
+            @include respond-min($screen-tablet) {
+                border-top-color: transparent;
+                border-left-color: darken(color(success), 2);
+            }
         }
     }
 }
 
-
 .progress-list__item--current {
     background-color: color(primary);
-    box-shadow: inset 0 -1px 0 rgba(0, 0, 0, .15);
     color: color(primary, alt);
+
+    @include respond-min($screen-tablet) {
+        box-shadow: inset 0 -1px 0 rgba(0, 0, 0, .15);
+    }
 
     .badge {
         color: color(white) !important;
     }
 
     &:not(:last-child)::after {
-        border-left-color: color(primary);
+        border-top-color: color(primary);
+
+        @include respond-min($screen-tablet) {
+            border-left-color: color(primary);
+            border-top-color: transparent;
+        }
     }
 
     &:hover {
@@ -122,7 +186,12 @@
         color: color(primary, alt);
 
         &::after {
-            border-left-color: darken(color(primary), 2);
+            border-top-color: darken(color(primary), 2);
+
+            @include respond-min($screen-tablet) {
+                border-left-color: darken(color(primary), 2);
+                border-top-color: transparent;
+            }
         }
     }
 }

--- a/stylesheets/_component.progress-lists.scss
+++ b/stylesheets/_component.progress-lists.scss
@@ -15,7 +15,7 @@
     box-shadow: inset 0 2px 2px 0 rgba(0, 0, 0, .1);
     color: color(black);
     display: block;
-    padding: 1.75em 0 .75em .75em;
+    padding: .7em 0 .5em .5em;
     text-decoration: none;
     vertical-align: top;
 
@@ -28,12 +28,12 @@
 
     // scss-lint:disable DeclarationOrder
     &:not(:last-child) {
-        @include css-arrow(23px, bottom, $progress-bg);
+        @include css-arrow(10px, bottom, $progress-bg);
 
         &::before {
             border-top-color: color(white);
-            border-width: 27px;
-            margin-left: -27px;
+            border-width: 15px;
+            margin-left: -15px;
         }
 
         @include respond-min($screen-tablet) {


### PR DESCRIPTION
Previously progress lists were not responsive. See #745

They are now 🎉

![responsive progress lists](https://user-images.githubusercontent.com/756393/35394459-bce6bb30-01df-11e8-848e-c6310eca8efb.gif)
