### PR TITLE
Responsive metadata list

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,6 +25,20 @@ module.exports = function(grunt) {
                     ]
                 }
             },
+            lexicon: {
+                files: {
+                    'dist/js/lexicon-bundle.js': ['js/lexicon/lexicon-index.js']
+                },
+                options: {
+                    browserifyOptions: {
+                        debug: true
+                    },
+                    transform: [
+                        ['babelify', { presets: ['es2015'] } ],
+                        ['aliasify', { global: true }]
+                    ]
+                }
+            },
             dist: {
                 files: {
                     'dist/js/bundle.js': ['js/index.js'],
@@ -560,6 +574,7 @@ module.exports = function(grunt) {
         'autoprefixer',
         'bless',
         'browserify:dev',
+        'browserify:lexicon',
         'browserSync',
         'watch'
     ]);

--- a/js/lexicon/lexicon-index.js
+++ b/js/lexicon/lexicon-index.js
@@ -1,2 +1,1 @@
-// Something is going to be added here soon
-console.log('Lexicon Specific Styles Bundle works!');
+// Coming soon

--- a/stylesheets/_component.metadata.scss
+++ b/stylesheets/_component.metadata.scss
@@ -1,59 +1,33 @@
-/* -------------------------------------------------------------------------- *\
-    Configuration
-\* -------------------------------------------------------------------------- */
-
-$metadata-padding-x: $padding-small-horizontal !default;
-$metadata-padding-y: $padding-small-vertical !default;
-
-
-
-
-
-/* -------------------------------------------------------------------------- *\
-    Default Presentation
-\* -------------------------------------------------------------------------- */
-
 .metadata {
-  margin-bottom: 0;
-  width: 100%;
-
-  &__key,
-  &__value {
-    display: inline-block;
-    padding: $metadata-padding-y 0;
-    vertical-align: top;
-  }
-
-  &__key {
-    width: 15%;
-  }
-
-  &__value {
     margin-bottom: 0;
-    margin-left: 0;
-    width: 85%;
-  }
-}
+    width: 100%;
 
+    &__key,
+    &__value {
+        display: block;
+        padding-bottom: $padding-small-vertical;
+        padding-top: $padding-small-vertical;
+        vertical-align: top;
+        word-break: break-word;
 
-
-
-/* -------------------------------------------------------------------------- *\
-    Variations
-\* -------------------------------------------------------------------------- */
-
-.metadata--bordered {
-  border: 1px solid color(gray, lighter);
-  border-radius: $border-radius;
-
-  .metadata__key,
-  .metadata__value {
-    padding: $metadata-padding-y $metadata-padding-x;
-    vertical-align: top;
-
-    &:not(:last-of-type) {
-      border-bottom: 1px solid color(gray, lighter);
+        @include respond-min($screen-phone) {
+            display: inline-block;
+        }
     }
-  }
+
+    &__key {
+        @include respond-min($screen-phone) {
+            padding-right: 2%;
+            width: 23%;
+        }
+    }
+
+    &__value {
+        margin-left: 0;
+
+        @include respond-min($screen-phone) {
+            width: 75%;
+        }
+    }
 }
 

--- a/views/lexicon/tabs/colours.html.twig
+++ b/views/lexicon/tabs/colours.html.twig
@@ -168,8 +168,7 @@
         set states_success = {
             "success-base": "success, base",
             "success-light": "success, light",
-            "success-dark": "success, dark",
-            "success-flash": "success, flash"
+            "success-dark": "success, dark"
         }
     %}
 
@@ -187,8 +186,7 @@
         set states_warning = {
             "warning-base": "warning, base",
             "warning-light": "warning, light",
-            "warning-dark": "warning, dark",
-            "warning-flash": "warning, flash"
+            "warning-dark": "warning, dark"
         }
     %}
 
@@ -206,8 +204,7 @@
         set states_danger = {
             "danger-base": "danger, base",
             "danger-light": "danger, light",
-            "danger-dark": "danger, dark",
-            "danger-flash": "danger, flash"
+            "danger-dark": "danger, dark"
         }
     %}
 
@@ -225,8 +222,7 @@
         set states_info = {
             "info-base": "info, base",
             "info-light": "info, light",
-            "info-dark": "info, dark",
-            "info-flash": "info, flash"
+            "info-dark": "info, dark"
         }
     %}
 
@@ -244,8 +240,7 @@
         set states_inverse = {
             "inverse-base": "inverse, base",
             "inverse-light": "inverse, light",
-            "inverse-dark": "inverse, dark",
-            "inverse-flash": "inverse, flash"
+            "inverse-dark": "inverse, dark"
         }
     %}
 

--- a/views/lexicon/tabs/metadata.html.twig
+++ b/views/lexicon/tabs/metadata.html.twig
@@ -9,6 +9,8 @@
 
     {%
         set data = {
+            "Example long title" : "true_lies.avi",
+            "Example very long title" : "true_lies.avi",
             "File" : "true_lies.avi",
             "Size" : "1.2Gb",
             "Type" : "Video"
@@ -16,14 +18,5 @@
     %}
 
     {{ html.metadata({ 'items': data }) }}
-
-    <h2 class="heading">Bordered variation</h2>
-
-    {{
-        html.metadata({
-            'items': data,
-            'class': 'metadata--bordered'
-        })
-    }}
 
 {% endblock tab_content %}


### PR DESCRIPTION
Metadata list now responds correctly at smaller VP widths. Removed unused bordered variation.

![metadata list](https://user-images.githubusercontent.com/756393/35400824-c529df38-01ef-11e8-98b5-aa6c6e20b2ba.gif)

fixes #747 


