### PR TITLE
Improve visual presentation of focused form fields

### DIFF
--- a/stylesheets/_component.choice.scss
+++ b/stylesheets/_component.choice.scss
@@ -14,8 +14,8 @@
 .form-choice .form__control {
     &.checkbox,
     &.radio {
-        vertical-align: baseline;
-        width: auto; // suppress default grid width
+        vertical-align: text-bottom;
+        // width: auto; // suppress default grid width
     }
 
     &.select,
@@ -55,6 +55,11 @@
         @include ie-lte(8) {
             border: 1px solid color(black);
         }
+    }
+
+    .control__label:focus,
+    .control__label.is-selected:focus {
+        box-shadow: inset 0 0 0 2px color(primary);
     }
 }
 

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -527,8 +527,8 @@ fieldset {
 .form__control.radio {
     appearance: none;
     background-color: #fafafa;
-    border: 1px solid color(border);
-    box-shadow: none;
+    border: 0;
+    box-shadow: inset 0 0 0 1px color(border);
     height: 20px;
     position: relative;
     width: 20px;
@@ -539,24 +539,16 @@ fieldset {
 
     &:focus {
         border-color: color(primary);
-        box-shadow: 0 0 0 1px color(primary);
-    }
-
-    &:checked {
-        border-color: color(grey, light);
-    }
-
-    &:focus:checked {
-        border-color: color(primary);
+        box-shadow: 0 0 0 2px color(primary);
     }
 
     &::before {
         content: '';
         font-family: 'FontAwesome';
         height: 20px;
-        left: 1px;
+        left: 2px;
         position: absolute;
-        top: -15px;
+        top: -14px;
     }
 
     &:focus:checked::before {
@@ -574,8 +566,8 @@ fieldset {
 
     &:checked::before {
         content: '\f111';
-        font-size: 14px;
-        left: 3px;
+        font-size: 13.5px;
+        left: 3.9px;
     }
 }
 

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -140,12 +140,17 @@ fieldset {
         padding: 0;
 
         @include respond-min($screen-tablet) {
-            padding: 14px 0 0;
+            padding: 8px 0;
         }
 
         @include ie-lte(9) {
             border: 1px solid $input-border;
             border-radius: 0;
+        }
+
+        &:focus {
+            border: 0;
+            box-shadow: 0 0 0 2px color(primary);
         }
 
         &.is-disabled {
@@ -230,6 +235,13 @@ fieldset {
     fieldset[disabled] & {
         cursor: not-allowed;
         background-color: $input-bg-disabled;
+    }
+
+    &:focus {
+        border: 1px solid color(primary);
+        box-shadow: 0 0 0 1px color(primary);
+        outline: none;
+        overflow: visible; // stop chrome clipping the box shadow
     }
 }
 
@@ -333,8 +345,8 @@ fieldset {
 // based on the remaining 9 column grid
 
     // default width
-    .control__label + .controls > .form__control:not(.checkbox),
-    .control__label + .controls > .form__control:not(.checkbox) + .select2 {
+    .control__label + .controls > .form__control:not(.checkbox):not(.radio),
+    .control__label + .controls > .form__control:not(.checkbox):not(.radio) + .select2 {
         @include col-span-width(4, 9);
     }
 
@@ -508,8 +520,63 @@ fieldset {
 
 .form__group.form-checkbox .form__control.checkbox,
 .form__group.form-radio .form__control.radio {
-    margin-top: 17px;
-    width: auto;
+    // margin-top: 17px;
+}
+
+.form__control.checkbox,
+.form__control.radio {
+    appearance: none;
+    background-color: #fafafa;
+    border: 1px solid color(border);
+    box-shadow: none;
+    height: 20px;
+    position: relative;
+    width: 20px;
+
+    .controls {
+        padding: 12px 0 16px;
+    }
+
+    &:focus {
+        border-color: color(primary);
+        box-shadow: 0 0 0 1px color(primary);
+    }
+
+    &:checked {
+        border-color: color(grey, light);
+    }
+
+    &:focus:checked {
+        border-color: color(primary);
+    }
+
+    &::before {
+        content: '';
+        font-family: 'FontAwesome';
+        height: 20px;
+        left: 1px;
+        position: absolute;
+        top: -15px;
+    }
+
+    &:focus:checked::before {
+        color: color(primary);
+    }
+
+    &:checked::before {
+        color: color(text);
+        content: '\f00c';
+    }
+}
+
+.form__control.radio {
+    border-radius: 20px;
+
+    &:checked::before {
+        content: '\f111';
+        font-size: 14px;
+        left: 3px;
+    }
 }
 
 // Make sure checkboxes and radios reduce the label's clickable area to the
@@ -526,9 +593,9 @@ fieldset {
         width: 100%;
     }
 
-    .control__label > .form__control {
-        width: auto;
-    }
+    // .control__label > .form__control {
+    //     width: auto;
+    // }
 }
 
 .form-choice {

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -571,6 +571,11 @@ fieldset {
     }
 }
 
+.form-radio .radio,
+.form-checkbox .checkbox {
+    top: 11px;
+}
+
 // Make sure checkboxes and radios reduce the label's clickable area to the
 // width of the label only
 .form-checkbox-inline,

--- a/stylesheets/_component.range-slider.scss
+++ b/stylesheets/_component.range-slider.scss
@@ -120,6 +120,7 @@
     }
 
     &:focus {
-        box-shadow: 0 0 0 2px white, 0 0 2px 5px highlight;
+        border: 0;
+        box-shadow: 0 0 0 2px white, 0 0 0 4px color(primary);
     }
 }

--- a/stylesheets/_component.select2.scss
+++ b/stylesheets/_component.select2.scss
@@ -711,4 +711,11 @@ span.select2-selection.select2-selection--single {
 .select2-selection__choice {
     line-height: 34px;
 }
+
+.select2-container--default.select2-container--focus .select2-selection--single,
+.select2-container--default.select2-container--focus:focus .select2-selection--single {
+    border: 1px solid color(primary);
+    box-shadow: 0 0 0 1px color(primary);
+    outline: none;
+}
 // scss-lint:enable all

--- a/stylesheets/_component.toggle-switch.scss
+++ b/stylesheets/_component.toggle-switch.scss
@@ -31,7 +31,7 @@
     }
 
     &:focus + .toggle-switch-label {
-        box-shadow: 0 0 0 2px white, 0 0 2px 5px highlight;
+        box-shadow: 0 0 0 2px white, 0 0 0 4px color(primary);
     }
 
     &.toggle-switch--large + .toggle-switch-label {
@@ -57,7 +57,7 @@
     font-size: 2em;
     height: 1em;
     position: relative;
-    transition: .4s;
+    transition: left .4s, right .4s;
     vertical-align: middle;
     width: 2em;
 

--- a/views/lexicon/forms.html.twig
+++ b/views/lexicon/forms.html.twig
@@ -2,6 +2,7 @@
 
 {% set heading = 'Form Helpers' %}
 
+{% set tab_all %}{% include 'lexicon/forms/all.html.twig' %}{% endset %}
 {% set tab_buttongroup %}{% include 'lexicon/forms/button-group.html.twig' %}{% endset %}
 {% set tab_colour %}{% include 'lexicon/forms/colour.html.twig' %}{% endset %}
 {% set tab_content %}{% include 'lexicon/forms/content.html.twig' %}{% endset %}
@@ -25,6 +26,11 @@
 
 {%
     set tabs_content = [
+        {
+          "id"    : "all",
+          "label" : "All fields",
+          "src"   : tab_all
+        },
         {
           "id"    : "buttongroup",
           "label" : "Button Group",

--- a/views/lexicon/forms/all.html.twig
+++ b/views/lexicon/forms/all.html.twig
@@ -1,0 +1,345 @@
+{% extends '@pulsar/pulsar/components/tab.html.twig' %}
+{% set i = 1 %}
+
+{% block tab_content %}
+
+    {{
+        form.create()
+    }}
+
+    {{
+        form.text({
+            'label': 'Text',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.textarea({
+            'label': 'Textarea',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.password({
+            'label': 'Password',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.date({
+            'label': 'Date',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.time({
+            'label': 'Time',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.file({
+            'label': 'File',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.color({
+            'label': 'Color',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.select({
+            'label': 'Select',
+            'id': i,
+            'options': [
+                {
+                    'label': 'Value one',
+                    'value': 'value1'
+                },
+                {
+                    'label': 'Value two',
+                    'value': 'value2'
+                }
+            ]
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.select2({
+            'label': 'Select2',
+            'id': i,
+            'options': [
+                {
+                    'label': 'Value one',
+                    'value': 'value1'
+                },
+                {
+                    'label': 'Value two',
+                    'value': 'value2'
+                }
+            ]
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.compound({
+            'label': 'Compound',
+            'id': i,
+            'inputs': [
+                {
+                    'class': 'form__control-col--1',
+                    'label': 'Value',
+                    'id': 'value-1',
+                    'maxlength': '3',
+                    'show-label': false,
+                    'type': 'text'
+                },
+                {
+                    'class': 'u-width-auto',
+                    'label': 'Unit of time',
+                    'id': 'Unit-1',
+                    'show-label': false,
+                    'type': 'select',
+                    'options': [
+                        {
+                            'label': 'Seconds',
+                            'value': 'sec'
+                        },
+                        {
+                            'label': 'Minutes',
+                            'value': 'min'
+                        }
+                    ]
+                }
+            ]
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.toggle_switch({
+            'label': 'Toggle switch',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.range({
+            'label': 'Range',
+            'id': i,
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{ form.fieldset_start({ 'legend': 'Checkboxes and radios' }) }}
+
+    {{
+        form.checkbox({
+            'label': 'Checkbox',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.radio({
+            'label': 'Radio',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.checkbox_inline({
+            'label': 'Checkbox inline',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.radio_inline({
+            'label': 'Radio inline',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.checkbox_inline({
+            'label': 'Checkbox inline indented',
+            'class': 'form__group--indent',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.radio_inline({
+            'label': 'Radio inline indented',
+            'class': 'form__group--indent',
+            'id': i
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.choice({
+            'label': 'Choice checkbox',
+            'id': i,
+            'options': [
+                {
+                    'label': 'One',
+                    'value': 'one',
+                    'name': 'one',
+                    'checked': true
+                },
+                {
+                    'label': 'Two',
+                    'value': 'two',
+                    'name': 'one'
+                },
+                {
+                    'label': 'Three',
+                    'value': 'three',
+                    'name': 'one'
+                }
+            ]
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.choice({
+            'label': 'Choice radio',
+            'multiple': true,
+            'id': i,
+            'options': [
+                {
+                    'label': 'One',
+                    'value': 'one',
+                    'name': 'one'
+                },
+                {
+                    'label': 'Two',
+                    'value': 'two',
+                    'name': 'one'
+                },
+                {
+                    'label': 'Three',
+                    'value': 'three',
+                    'name': 'one'
+                }
+            ]
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.choice({
+            'label': 'Choice as select2',
+            'id': i,
+            'options': [
+                {
+                    'label': 'One',
+                    'value': 'one',
+                    'name': 'three'
+                },
+                {
+                    'label': 'Two',
+                    'value': 'two',
+                    'name': 'three'
+                },
+                {
+                    'label': 'Three',
+                    'value': 'three',
+                    'name': 'three'
+                },
+                {
+                    'label': 'Four',
+                    'value': 'four',
+                    'name': 'three'
+                },
+                {
+                    'label': 'Five',
+                    'value': 'five',
+                    'name': 'three'
+                },
+                {
+                    'label': 'Six',
+                    'value': 'six',
+                    'name': 'three'
+                }
+            ]
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{
+        form.choice({
+            'class': 'choice--block',
+            'label': 'Choice block radios',
+            'id': i,
+            'options': [
+                {
+                    'label': html.icon('bold') ~ ' Bold',
+                    'value': 'bold',
+                    'name': 'five'
+                },
+                {
+                    'label': html.icon('italic') ~ ' Italic',
+                    'value': 'italic',
+                    'name': 'five',
+                    'checked': true
+                },
+                {
+                    'label': html.icon('underline') ~ ' Underline',
+                    'value': 'underline',
+                    'name': 'five'
+                },
+            ]
+        })
+    }}
+    {% set i = i + 1 %}
+
+    {{ form.fieldset_end() }}
+
+    {{
+        form.end()
+    }}
+
+{% endblock tab_content %}
+
+{% block tab_sidebar %}
+    <a href="https://jadu.gitbooks.io/pulsar/content/text.html">
+        <img src="../../../images/cover.png" alt="Pulsar documentation front cover" width="157" />
+    </a>
+    <br />
+    {{
+        html.button({
+            'label': 'View Documentation',
+            'type': 'link',
+            'href': 'https://jadu.gitbooks.io/pulsar/content/text.html'
+        })
+    }}
+
+{% endblock tab_sidebar %}

--- a/views/lexicon/index.html.twig
+++ b/views/lexicon/index.html.twig
@@ -76,7 +76,7 @@
           "id"    : "colours",
           "label" : "Colours",
           "href"  : "?tab=colours",
-          "src"   : tab_colours,
+          "src"   : tab_colours
         },
         {
           "id"    : "buttons",


### PR DESCRIPTION
This improves the general obviousness of the user interface as well as improving keyboard navigation.
Also adds a new lexicon page with a sample of all form elements on.

## Before
![focus-before](https://user-images.githubusercontent.com/18653/35797847-f14834ea-0a58-11e8-9211-4f69a1096bfc.gif)

## After
(note alignment issues with checlbox/radios have been sorted since the gif was recorded)
![focus-after](https://user-images.githubusercontent.com/18653/35797855-f6a85d02-0a58-11e8-8f0e-0da6b8a3097c.gif)
