### PR TITLE
Remove slider-container margin top on mobile

### DIFF
--- a/stylesheets/_component.slider.scss
+++ b/stylesheets/_component.slider.scss
@@ -1,8 +1,8 @@
 .slider-container {
-    margin: 5em auto 0;
     padding: $padding-base * 2;
 
     @include respond-min($screen-tablet) {
+        margin: 5em auto 0;
         padding: 0;
         width: 600px;
     }


### PR DESCRIPTION
Before fix:

![screen shot 2018-02-20 at 13 04 19](https://user-images.githubusercontent.com/756393/36425788-cb540604-163f-11e8-978b-a174de43399a.png)

After fix: 

![screen shot 2018-02-20 at 13 12 27](https://user-images.githubusercontent.com/756393/36425793-ced7d21a-163f-11e8-8a03-976bbc39acfd.png)
