### PR TITLE
Fix issue causing secondary navigation to close when switching

### DIFF
--- a/js/NavMainComponent.js
+++ b/js/NavMainComponent.js
@@ -110,10 +110,10 @@ NavMainComponent.prototype.switchPrimaryNav = function (target) {
 
 NavMainComponent.prototype.switchSecondaryNav = function (target) {
     var component = this;
-
     component.closeSubNavs();
+
     if (target.indexOf('#') !== -1) {
-        component.$navSecondary.toggleClass('is-open');
+        component.$navSecondary.addClass('is-open');
         component.$navSecondary.find('.nav-list.is-active').removeClass('is-active');
         component.$navSecondary.find('[data-nav="' + target + '"]').addClass('is-active');
     }
@@ -155,7 +155,6 @@ NavMainComponent.prototype.changeActiveQuaternaryNavLink = function (target) {
 
 NavMainComponent.prototype.closeNavs = function () {
     var component = this;
-
     component.$navMain.removeClass('is-open');
 
     if (component.$navSecondary.hasClass('is-open')) {


### PR DESCRIPTION
Fixes an issue where secondary navigation would be closed when opening a second menu item.

#### Before
![nav-pre](https://user-images.githubusercontent.com/18653/36725844-87bb1368-1baf-11e8-8a1b-85055102de2c.gif)

#### After
![nav-post](https://user-images.githubusercontent.com/18653/36725853-8cdd7d2c-1baf-11e8-9044-3e85b89082a0.gif)
