### PR TITLE
Address 'more' navigation issues

### DIFF
--- a/js/NavMainComponent.js
+++ b/js/NavMainComponent.js
@@ -77,7 +77,8 @@ NavMainComponent.prototype.init = function () {
         component.changeActiveQuaternaryNavLink($(this).attr('href'));
     });
 
-    component.$moreIcon.find('.nav-link').on('click', function () {
+    component.$moreIcon.find('.nav-link').on('click', function (e) {
+        e.preventDefault();
         component.$navSecondary.removeClass('is-open');
         component.$navTertiary.toggleClass('is-open');
         component.$navTertiary.find('.nav-list').addClass('is-active');

--- a/stylesheets/_component.nav-list.scss
+++ b/stylesheets/_component.nav-list.scss
@@ -17,6 +17,7 @@
 	border-bottom: 1px solid $nav-color-light;
 	color: #fff;
 	display: block;
+	font-family: $font-family-light;
 	font-size: 1.2em;
 	margin-bottom: 24px;
 

--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -207,6 +207,7 @@ $nav-color-darker: darken(color(jadu-blue, dark), 10%) !default;
 
 .nav-item {
     list-style-type: none;
+    font-family: $font-family-regular;
 }
 
 .nav-divider {


### PR DESCRIPTION
* Attempts to fix the intermittent unresponsiveness of the more link
* Fixes issue causing more nav items to use incorrect typeface

---

## Unresponsive issue

There's an intermittent issue where the more link doesn't open the tertiary menu, I've not been able to pin down precise steps to replicate but adding preventDefault() on the method targeting the more link seems to work locally. Only time will tell whether it solves it in products.

## Typeface issue 

This is an issue with products which add an ‘icon’ class to the nav-item, and cause FontAwesome to override Proxima Nova.

### Before

<img width="352" alt="screen shot 2018-03-01 at 15 49 34" src="https://user-images.githubusercontent.com/18653/36854153-2b90499a-1d68-11e8-9554-94be41acdccb.png">

### After

<img width="341" alt="screen shot 2018-03-01 at 15 50 47" src="https://user-images.githubusercontent.com/18653/36854221-5ce2aaf6-1d68-11e8-86b9-e4abb8e3753e.png">
