### PR TITLE
Moved navigation color definitions in theme

### DIFF
--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -1,7 +1,3 @@
-$nav-color-light: color(jadu-blue, dark) !default;
-$nav-color-dark: darken(color(jadu-blue, dark), 5%) !default;
-$nav-color-darker: darken(color(jadu-blue, dark), 10%) !default;
-
 .nav-main {
     -webkit-backface-visibility: hidden;
     -webkit-transform: translate3d(-100%, 0, 0);

--- a/stylesheets/_config.theme.scss
+++ b/stylesheets/_config.theme.scss
@@ -126,7 +126,7 @@ $state-info-bg:                  #d9edf7 !default;
 $state-info-border:              darken($state-info-bg, 10%) !default;
 
 // -----------------------------------------------------------------------------
-//  Forms
+//  Navigation
 // -----------------------------------------------------------------------------
 
 $nav-color-light: color(jadu-blue, dark) !default;

--- a/stylesheets/_config.theme.scss
+++ b/stylesheets/_config.theme.scss
@@ -124,3 +124,11 @@ $state-success-border:           darken($state-success-bg, 10%) !default;
 $state-info-text:                #3a87ad !default;
 $state-info-bg:                  #d9edf7 !default;
 $state-info-border:              darken($state-info-bg, 10%) !default;
+
+// -----------------------------------------------------------------------------
+//  Forms
+// -----------------------------------------------------------------------------
+
+$nav-color-light: color(jadu-blue, dark) !default;
+$nav-color-dark: darken(color(jadu-blue, dark), 5%) !default;
+$nav-color-darker: darken(color(jadu-blue, dark), 10%) !default;


### PR DESCRIPTION
The navigation colors are defined directly in the component. I think they should be defined in `config.theme` so they can be more easily overridden.

# Breaking change quick checklist

**This is not an exhaustive list of what constitutes a breaking change**

| Does this pull request... | Yes / No |
| ---- | ---- |
| require changes to `main.js` | No |
| require changes to `index.js` | No |
| require changes to `pulsar.scss` | No |
| require changes to `gruntfile.js` | No |
| require changes to `package.json` (not including dev dependencies) | No |
| require changes to `base.html.twig` (or other core views like header/footer) | No |
| require new arguments to be passed to a js component | No |
| require markup changes to maintain functionality | No |

## Do Continuum products use `_config.theme.scss`?

- [x] CMS
- [x] CXM