### PR TITLE
Focus first input field after opening a modal

### DIFF
--- a/js/libs/modal.js
+++ b/js/libs/modal.js
@@ -248,9 +248,12 @@ var $ = require('jquery');
   $(document)
     .on('show.bs.modal',  '.modal', function () { $(document.body).addClass('modal-open') })
     .on('hidden.bs.modal', '.modal', function () {
-      // $(this).removeData('bs.modal').empty()
       $(document.body).removeClass('modal-open');
+    });
 
-    })
-
+  // Focus the first input in a modal when the modal has been opened
+  $(document).on('shown.bs.modal', '.modal', function() {
+    $(':input:not(input[type=button], input[type=submit], button):visible:first', $(this)).focus();
+  });
+  
 module.exports = Modal;

--- a/tests/js/web/ModalTest.js
+++ b/tests/js/web/ModalTest.js
@@ -11,22 +11,22 @@ describe('Test extra functionality added to Bootstrap modals', function() {
     beforeEach(function() {
         this.$html = $('<div id="html"></div>').appendTo('html');
         this.$body = $('<div id="body"></div>').appendTo(this.$html);
-        this.$code = $('\
-            <a href="#theModal">\
-            <div class="modal fade" id="theModal" tabindex="-1" role="dialog" aria-hidden="true">\
-                <div class="modal__dialog">\
-                    <div class="modal__content">\
-                        <div class="modal__header">\
-                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>\
-                            <h4 class="modal__title">Standard modal</h4>\
-                        </div>\
-                        <div class="modal__body">\
-                            <input type="text" id="textField" />\
-                        </div>\
-                    </div>\
-                </div>\
-            </div>\
-').appendTo(this.$body);
+        this.$code = $(`
+            <a href="#theModal">
+            <div class="modal fade" id="theModal" tabindex="-1" role="dialog" aria-hidden="true">
+                <div class="modal__dialog">
+                    <div class="modal__content">
+                        <div class="modal__header">
+                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                            <h4 class="modal__title">Standard modal</h4>
+                        </div>
+                        <div class="modal__body">
+                            <input type="text" id="textField" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `).appendTo(this.$body);
 
         this.$modalToggle = this.$html.find('a[href="#theModal"]');
         this.$modal = this.$html.find('#theModal');

--- a/tests/js/web/ModalTest.js
+++ b/tests/js/web/ModalTest.js
@@ -2,8 +2,9 @@
 
 'use strict'
 
-var $ = require('jquery'),
-    modal = require('../../../js/libs/modal');
+var $ = require('jquery');
+
+require('../../../js/libs/modal');
 
 describe('Test extra functionality added to Bootstrap modals', function() {
 

--- a/tests/js/web/ModalTest.js
+++ b/tests/js/web/ModalTest.js
@@ -1,0 +1,57 @@
+/*jshint multistr: true */
+
+'use strict'
+
+var $ = require('jquery'),
+    modal = require('../../../js/libs/modal');
+
+describe('Test extra functionality added to Bootstrap modals', function() {
+
+    beforeEach(function() {
+        this.$html = $('<div id="html"></div>').appendTo('html');
+        this.$body = $('<div id="body"></div>').appendTo(this.$html);
+        this.$code = $('\
+            <a href="#theModal">\
+            <div class="modal fade" id="theModal" tabindex="-1" role="dialog" aria-hidden="true">\
+                <div class="modal__dialog">\
+                    <div class="modal__content">\
+                        <div class="modal__header">\
+                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>\
+                            <h4 class="modal__title">Standard modal</h4>\
+                        </div>\
+                        <div class="modal__body">\
+                            <input type="text" id="textField" />\
+                        </div>\
+                    </div>\
+                </div>\
+            </div>\
+').appendTo(this.$body);
+
+        this.$modalToggle = this.$html.find('a[href="#theModal"]');
+        this.$modal = this.$html.find('#theModal');
+        this.$modalField = this.$html.find('#textField');
+
+    });
+
+    afterEach(function() {
+        this.$html.remove();
+    });
+
+    describe('Opening a modal', function() {
+
+        beforeEach(function() {
+            this.$modalToggle.click();
+            this.$modal.trigger('shown.bs.modal');
+        });
+
+        it('should focus the first input if one is available', function(done) {
+            setTimeout(() => {
+                expect(this.$modalField.is(':focus')).to.be.true;
+                done();
+            }, 500);
+        });
+
+    });
+
+});
+

--- a/views/lexicon/tabs/modals.html.twig
+++ b/views/lexicon/tabs/modals.html.twig
@@ -48,6 +48,12 @@
                 <h4 class="modal__title">Standard modal</h4>
             </div>
             <div class="modal__body">
+                {{
+                    form.text({
+                        'label': 'This field should get focus',
+                        'id': 'modal-input'
+                    })
+                }}
                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pharetra dui ac congue fringilla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nunc sit amet feugiat diam. Proin eu condimentum elit. Donec facilisis urna sed tortor semper tincidunt. Maecenas tortor justo, rhoncus a luctus eget, consectetur suscipit est. In molestie posuere lectus. Vestibulum sit amet ligula odio. Nulla lobortis neque ac porta accumsan.</p>
 
                 <p>Sed non maximus ante. Morbi nec interdum velit, quis accumsan felis. Ut laoreet egestas elit. Donec vulputate ex eu posuere auctor. Mauris sodales purus porta volutpat luctus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur vestibulum placerat eros eget tincidunt. Cras pellentesque vestibulum ligula, a posuere massa bibendum at. Quisque laoreet mauris eros, vel varius neque facilisis a. Suspendisse ornare aliquet tortor, id lacinia turpis commodo a. In tempus risus quis dapibus blandit. Sed semper odio id nulla faucibus consectetur. Nunc purus lectus, blandit quis est ac, lacinia cursus leo. Quisque dapibus, augue at consequat eleifend, orci sapien lacinia elit, in condimentum lacus lacus eu odio. Aliquam non sem tellus.</p>

--- a/views/lexicon/tabs/modals.html.twig
+++ b/views/lexicon/tabs/modals.html.twig
@@ -1,7 +1,7 @@
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
 {% block tab_content %}
-<div class="modal modal__example">
+<div class="modal modal__example show">
     <div class="modal__dialog">
         <div class="modal__content">
             <div class="modal__header">
@@ -19,7 +19,7 @@
     </div><!-- /.modal__dialog -->
 </div><!-- /.modal -->
 
-<div class="modal modal--danger modal__example">
+<div class="modal modal--danger modal__example show">
     <div class="modal__dialog">
         <div class="modal__content">
             <div class="modal__header">


### PR DESCRIPTION
This change allows the modal to capture keyboard focus and permit keyboard navigation through embedded forms.

> When a dialog opens, focus moves to an element inside the dialog.
>
> _WAI-ARIA Authoring Practices / 3.8 Dialog (Modal) / Keyboard Interaction <sup>[[1](https://www.w3.org/TR/2017/NOTE-wai-aria-practices-1.1-20171214/#dialog_modal)]</sup>_

### Current behaviour

* Fields are not focused and cannot be navigated to by keyboard alone.
* `autofocus` HTML attribute has no effect in Bootstrap modals and cannot be used <sup>[[2](https://getbootstrap.com/docs/4.0/components/modal/#how-it-works)]</sup>

![modal-before](https://user-images.githubusercontent.com/18653/38251064-4bf53f98-3748-11e8-9bd7-da8c4977f7b0.gif)

### After

```
Given I have a modal with an input field that can be focused (except buttons)
When I open the modal
Then the field should be focused
```

![modal-after](https://user-images.githubusercontent.com/18653/38250977-0e63eb16-3748-11e8-87d7-95d4bbf0eba9.gif)

I've started a new test file for any functionality we've added to modals above and beyond the default Bootstrap functionality.

Closes #754 

----
#### References
1. https://www.w3.org/TR/2017/NOTE-wai-aria-practices-1.1-20171214/#dialog_modal
2. https://getbootstrap.com/docs/4.0/components/modal/#how-it-works