### PR TITLE
Fix form helpers/macros to use aria-describedby when help text is used

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,7 +78,8 @@ module.exports = function(grunt) {
             options: {
                 bin: 'vendor/bin/phpunit',
                 bootstrap: 'tests/unit/bootstrap.php',
-                colors: true
+                colors: true,
+                bin: "php -d memory_limit=-1 ./vendor/bin/phpunit"
             }
         },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,10 +76,9 @@ module.exports = function(grunt) {
                 dir: 'tests/unit/'
             },
             options: {
-                bin: 'vendor/bin/phpunit',
+                bin: 'php -d memory_limit=-1 ./vendor/bin/phpunit',
                 bootstrap: 'tests/unit/bootstrap.php',
-                colors: true,
-                bin: "php -d memory_limit=-1 ./vendor/bin/phpunit"
+                colors: true
             }
         },
 

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-help.html
@@ -1,0 +1,11 @@
+<div aria-describedby="guid-1" class="form__group form__button-group">
+    <div class="controls btn__group">
+        <input name="bands" type="radio" class="form__control radio" />
+        <label class="control__label">AM</label>
+        <input name="bands" type="radio" class="form__control radio" />
+        <label class="control__label">FM</label>
+        <input name="bands" type="radio" class="form__control radio" />
+        <label class="control__label">MW</label>
+        <span class="help-block" id="guid-1">my help text</span>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-help.html.twig
@@ -1,0 +1,22 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.button_group({
+        'help': 'my help text',
+        'items': [
+            form.radio_simple({
+                'label': 'AM',
+                'name': 'bands'
+            }),
+            form.radio_simple({
+                'label': 'FM',
+                'name': 'bands'
+            }),
+            form.radio_simple({
+                'label': 'MW',
+                'name': 'bands'
+            })
+        ]
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox-help.html
@@ -1,0 +1,6 @@
+<div class="form__group form-checkbox">
+	<div class="controls">
+		<input type="checkbox" aria-describedby="guid-1" class="form__control checkbox" />
+		<span class="help-block" id="guid-1">my help text</span>
+	</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox-help.html.twig
@@ -1,0 +1,8 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.checkbox({
+        'help': 'my help text'
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox_inline-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox_inline-help.html
@@ -1,0 +1,5 @@
+<div class="form__group form-checkbox-inline">
+	<div class="controls">
+		<label class="control__label"><input type="checkbox" aria-describedby="guid-1" class="form__control checkbox" />foo</label><span class="help-block" id="guid-1">my help text</span>
+	</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox_inline-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox_inline-help.html.twig
@@ -1,0 +1,9 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.checkbox_inline({
+        'label': 'foo',
+        'help': 'my help text'
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-help.html
@@ -1,0 +1,17 @@
+<div aria-describedby="guid-1" class="form__group form-choice">
+    <div class="controls">
+        <label class="control__label">
+            <input name="choice" value="foo" type="radio" class="form__control radio" />
+            <span class="form-choice__label">Foo</span>
+        </label>
+        <label class="control__label">
+            <input name="choice" value="bar" type="radio" class="form__control radio" />
+            <span class="form-choice__label">Bar</span>
+        </label>
+        <label class="control__label">
+            <input name="choice" value="baz" type="radio" class="form__control radio" />
+            <span class="form-choice__label">Baz</span>
+        </label>
+        <span class="help-block" id="guid-1">my help text</span>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-help.html.twig
@@ -1,0 +1,25 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.choice({
+        'options': [
+            {
+                'label': 'Foo',
+                'name': 'choice',
+                'value': 'foo'
+            },
+            {
+                'label': 'Bar',
+                'name': 'choice',
+                'value': 'bar'
+            },
+            {
+                'label': 'Baz',
+                'name': 'choice',
+                'value': 'baz'
+            }
+        ],
+        'help': 'my help text'
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/color-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/color-help.html
@@ -1,0 +1,9 @@
+<div class="form__group colorpicker js-colorpicker">
+    <div class="controls">
+        <div class="input-group">
+            <span class="input-group-addon">#</span>
+            <input type="text" aria-describedby="guid-1" class="form__control" />
+        </div>
+        <span class="help-block" id="guid-1">my help text</span>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/color-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/color-help.html.twig
@@ -1,0 +1,8 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.color({
+    	'help': 'my help text'
+	})
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/compound-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/compound-help.html
@@ -1,0 +1,13 @@
+<fieldset id="foo" aria-describedby="guid-1" class="form__group form__group--compound">
+    <legend class="control__label" id="foo[label]">fooLabel</legend>
+
+    <div class="controls">
+        <label for="fooInputId" id="fooInputId[label]" class="control__label hide">fooInputLabel</label>
+        <input id="fooInputId" type="text" class="form__control fooInputClass" />
+
+        <label for="barInputId" id="barInputId[label]" class="control__label hide">barInputLabel</label>
+        <input id="barInputId" type="text" class="form__control barInputClass" />
+
+        <span class="help-block" id="guid-1">my help text</span>
+    </div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/compound-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/compound-help.html.twig
@@ -1,0 +1,26 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.compound({
+        'id': 'foo',
+        'label': 'fooLabel',
+        'help': 'my help text',
+        'inputs': [
+            {
+                'class': 'fooInputClass',
+                'label': 'fooInputLabel',
+                'id': 'fooInputId',
+                'show-label': false,
+                'type': 'text'
+            },
+            {
+                'class': 'barInputClass',
+                'label': 'barInputLabel',
+                'id': 'barInputId',
+                'show-label': false,
+                'type': 'text'
+            }
+        ]
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/date-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/date-help.html
@@ -1,0 +1,6 @@
+<div class="form__group">
+    <div class="controls">
+        <input placeholder="dd/mm/yyyy" data-datepicker="true" type="text" aria-describedby="guid-1" class="form__control" />
+        <span class="help-block" id="guid-1">my help text</span>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/date-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/date-help.html.twig
@@ -1,0 +1,8 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.date(
+    	{'help': 'my help text'}
+    )
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/date-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/date-help.html.twig
@@ -1,8 +1,6 @@
 {% extends '@cssTests/visual-regression-layout.html.twig' %}
 {% block body %}
 {{
-    form.date(
-    	{'help': 'my help text'}
-    )
+    form.date({'help': 'my help text'})
 }}
 {% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/email-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/email-help.html
@@ -1,0 +1,6 @@
+<div class="form__group">
+	<div class="controls">
+		<input type="email" aria-describedby="guid-1" class="form__control" />
+		<span class="help-block" id="guid-1">my help text</span>
+	</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/email-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/email-help.html.twig
@@ -1,0 +1,9 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.text({
+        'type': 'email',
+        'help': 'my help text'
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-help.html
@@ -1,0 +1,7 @@
+<div class="form__group">
+	<label class="control__label">foo</label>
+	<div class="controls">
+		<input type="file" aria-describedby="guid-1" class="form__control file" />
+		<span class="help-block" id="guid-1">my help text</span>
+	</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-help.html.twig
@@ -1,0 +1,9 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.file({
+        'label': 'foo',
+        'help': 'my help text'
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/password-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/password-help.html
@@ -1,0 +1,6 @@
+<div class="form__group">
+    <div class="controls">
+        <input type="password" aria-describedby="guid-1" class="form__control" />
+        <span class="help-block" id="guid-1">my help text</span>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/password-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/password-help.html.twig
@@ -1,0 +1,8 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.password({
+    	'help': 'my help text'
+	})
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio-help.html
@@ -1,0 +1,6 @@
+<div class="form__group form-radio">
+    <div class="controls">
+        <input type="radio" aria-describedby="guid-1" class="form__control radio" />
+        <span class="help-block" id="guid-1">my help text</span>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio-help.html.twig
@@ -1,0 +1,8 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.radio({
+    	'help': 'my help text'
+	})
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio_inline-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio_inline-help.html
@@ -1,0 +1,6 @@
+<div class="form__group form-radio-inline">
+	<div class="controls">
+		<label class="control__label"><input type="radio" aria-describedby="guid-1" class="form__control radio" />foo</label>
+		<span class="help-block" id="guid-1">my help text</span>
+	</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio_inline-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio_inline-help.html.twig
@@ -1,0 +1,9 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.radio_inline({
+        'label': 'foo',
+        'help': 'my help text'
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-help.html
@@ -1,0 +1,9 @@
+<div class="form__group">
+	<div class="controls">
+		<select aria-describedby="guid-1" class="form__control select">
+			<option value="foo">bar</option>
+			<option value="bar">baz</option>
+		</select>
+		<span class="help-block" id="guid-1">my help text</span>
+	</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-help.html.twig
@@ -1,0 +1,12 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.select({
+        'options': {
+            'foo': 'bar',
+            'bar': 'baz'
+        },
+        'help': 'my help text'
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-help.html
@@ -1,0 +1,9 @@
+<div class="form__group">
+    <div class="controls">
+        <select aria-describedby="guid-1" class="form__control select js-select2">
+            <option value="foo">bar</option>
+            <option value="bar">baz</option>
+        </select>
+        <span class="help-block" id="guid-1">my help text</span>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-help.html.twig
@@ -1,0 +1,12 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.select2({
+        'options': {
+            'foo': 'bar',
+            'bar': 'baz'
+        },
+        'help': 'my help text'
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/tel-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/tel-help.html
@@ -1,0 +1,6 @@
+<div class="form__group">
+	<div class="controls">
+		<input type="tel" aria-describedby="guid-1" class="form__control" />
+		<span class="help-block" id="guid-1">my help text</span>
+	</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/tel-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/tel-help.html.twig
@@ -1,0 +1,9 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.text({
+        'type': 'tel',
+        'help': 'my help text'
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-help.html
@@ -1,0 +1,6 @@
+<div class="form__group">
+	<div class="controls">
+		<input type="text" aria-describedby="guid-1" class="form__control" />
+		<span class="help-block" id="guid-1">my help text</span>
+	</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-help.html.twig
@@ -1,0 +1,8 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.text({
+    	'help': 'my help text'
+	})
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea-help.html
@@ -1,0 +1,7 @@
+<div class="form__group">
+	<label class="control__label">foo</label>
+	<div class="controls">
+		<textarea aria-describedby="guid-1" class="form__control textarea"></textarea>
+		<span class="help-block" id="guid-1">my help text</span>
+	</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea-help.html.twig
@@ -1,0 +1,9 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.textarea({
+        'label': 'foo',
+        'help': 'my help text'
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/time-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/time-help.html
@@ -1,0 +1,6 @@
+<div class="form__group">
+	<div class="controls">
+		<input placeholder="hh:mm" data-timepicker="true" type="text" aria-describedby="guid-1" class="form__control" />
+		<span class="help-block" id="guid-1">my help text</span>
+	</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/time-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/time-help.html.twig
@@ -1,0 +1,8 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.time({
+    	'help': 'my help text'
+	})
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-help.html
@@ -1,0 +1,10 @@
+<div class="form__group form__group--toggle">
+	<label class="control__label">Toggle</label>
+	<div class="controls">
+		<input id="toggletest" type="checkbox" aria-describedby="guid-1" class="form__control toggle-switch" />
+		<label for="toggletest" class="control__label toggle-switch-label">
+			<span class="hide">Toggle</span>
+		</label>
+		<span class="help-block" id="guid-1">my help text</span>
+	</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-help.html.twig
@@ -1,0 +1,10 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.toggle_switch({
+        'label': 'Toggle',
+        'id': 'toggletest',
+        'help': 'my help text'
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/url-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/url-help.html
@@ -1,0 +1,6 @@
+<div class="form__group">
+	<div class="controls">
+		<input type="url" aria-describedby="guid-1" class="form__control" />
+		<span class="help-block" id="guid-1">my help text</span>
+	</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/url-help.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/url-help.html.twig
@@ -1,0 +1,9 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.text({
+        'type': 'url',
+        'help': 'my help text'
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/MacroTest.php
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/MacroTest.php
@@ -80,6 +80,9 @@ class MacroTest extends \PHPUnit_Framework_TestCase
         $output = preg_replace('/>\s+/', '>', $output);
         $output = preg_replace('/\s+</', '<', $output);
 
+        // Normalise random ids generated and used by help text
+        $output = preg_replace('/(guid-)\w+/', 'guid-1', $output);
+        
         return $output;
     }
 

--- a/views/lexicon/forms/choice.html.twig
+++ b/views/lexicon/forms/choice.html.twig
@@ -26,7 +26,8 @@
                     'value': 'three',
                     'name': 'one'
                 }
-            ]
+            ],
+            'help': 'Help text to give more information about expected input'
         })
     }}
 
@@ -51,7 +52,8 @@
                     'value': 'three',
                     'name': 'two'
                 }
-            ]
+            ],
+            'help': 'Help text to give more information about expected input'
         })
     }}
 
@@ -76,7 +78,8 @@
                     'value': 'three',
                     'name': 'one'
                 }
-            ]
+            ],
+            'help': 'Help text to give more information about expected input'
         })
     }}
 
@@ -102,7 +105,8 @@
                     'value': 'three',
                     'name': 'one'
                 }
-            ]
+            ],
+            'help': 'Help text to give more information about expected input'
         })
     }}
 
@@ -143,7 +147,8 @@
                     'value': 'six',
                     'name': 'three'
                 }
-            ]
+            ],
+            'help': 'Help text to give more information about expected input'
         })
     }}
 
@@ -185,7 +190,8 @@
                     'value': 'six',
                     'name': 'four'
                 }
-            ]
+            ],
+            'help': 'Help text to give more information about expected input'
         })
     }}
 
@@ -210,7 +216,8 @@
                     'value': 'underline',
                     'name': 'five'
                 },
-            ]
+            ],
+            'help': 'Help text to give more information about expected input'
         })
     }}
 
@@ -235,7 +242,8 @@
                     'value': 'underline',
                     'name': 'foo'
                 },
-            ]
+            ],
+            'help': 'Help text to give more information about expected input'
         })
     }}
 

--- a/views/lexicon/forms/compound.html.twig
+++ b/views/lexicon/forms/compound.html.twig
@@ -44,6 +44,39 @@
 
     {{
         form.compound({
+            'id': 'comp-1',
+            'label': 'Date of birth',
+            'inputs': [
+                {
+                    'class': 'form__control-col--1',
+                    'label': 'Day',
+                    'id': 'dd-1',
+                    'placeholder': 'DD',
+                    'show-label': false,
+                    'type': 'text'
+                },
+                {
+                    'class': 'form__control-col--1',
+                    'label': 'Month',
+                    'id': 'mm-1',
+                    'placeholder': 'MM',
+                    'show-label': false,
+                    'type': 'text'
+                },
+                {
+                    'class': 'form__control-col--1',
+                    'label': 'Year',
+                    'id': 'yyyy-1',
+                    'placeholder': 'YYYY',
+                    'show-label': false,
+                    'type': 'text'
+                }
+            ]
+        })
+    }}
+
+    {{
+        form.compound({
             'id': 'comp-2',
             'help': 'How long the system should wait for a response, usually 30 seconds',
             'label': 'Timeout',

--- a/views/pulsar/v2/helpers/elem.html.twig
+++ b/views/pulsar/v2/helpers/elem.html.twig
@@ -43,7 +43,11 @@ value       | string | Specifies the value of the input
         {% set options = options|defaults({'class': 'form__control'}) %}
     {% endif %}
 
-    <input{{ attributes(options|exclude('append bare input_placement prepend naked')) }} />
+    {% if options.help_id is defined and options.help_id is not empty %}
+        {% set options = options|defaults({'aria-describedby': options.help_id}) %}
+    {% endif %}
+
+    <input{{ attributes(options|exclude('append bare input_placement prepend naked help_id')) }} />
 
 {% endspaceless %}
 {% endmacro %}
@@ -182,9 +186,14 @@ value       | string | Specifies the value of the input
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
+
+    {% if options.help_id is defined and options.help_id is not empty %}
+        {% set options = options|defaults({'aria-describedby': options.help_id}) %}
+    {% endif %}
+
     <select{{
         attributes(options
-            |exclude('append bare label prepend selected value options')
+            |exclude('append bare label prepend selected value options help_id')
             |defaults({
                 'class': 'form__control'
             })
@@ -327,9 +336,13 @@ value       | string  | Specifies the value of the input
 {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
+    {% if options.help_id is defined and options.help_id is not empty %}
+        {% set options = options|defaults({'aria-describedby': options.help_id}) %}
+    {% endif %}
+
     <textarea{{
         attributes(options
-            |exclude('append bare prepend value')
+            |exclude('append bare prepend value help_id')
             |defaults({
                 'class': 'form__control'
             })

--- a/views/pulsar/v2/helpers/elem.html.twig
+++ b/views/pulsar/v2/helpers/elem.html.twig
@@ -47,7 +47,7 @@ value       | string | Specifies the value of the input
         {% set options = options|defaults({'aria-describedby': options.help_id}) %}
     {% endif %}
 
-    <input{{ attributes(options|exclude('append bare input_placement prepend naked help_id')) }} />
+    <input{{ attributes(options|exclude('append bare help_id input_placement prepend naked')) }} />
 
 {% endspaceless %}
 {% endmacro %}
@@ -193,7 +193,7 @@ value       | string | Specifies the value of the input
 
     <select{{
         attributes(options
-            |exclude('append bare label prepend selected value options help_id')
+            |exclude('append bare help_id label prepend selected value options')
             |defaults({
                 'class': 'form__control'
             })
@@ -342,7 +342,7 @@ value       | string  | Specifies the value of the input
 
     <textarea{{
         attributes(options
-            |exclude('append bare prepend value help_id')
+            |exclude('append bare help_id prepend value')
             |defaults({
                 'class': 'form__control'
             })

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -54,15 +54,31 @@ items         | array  | An array of items to put in the dropdown list (usually 
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
-    {{
-        form.group({
-            'parent': options
-                |only('bare class error guidance guidance-container help id label required show-label type')
-                |merge({'class': options.class|default ~ ' form__button-group'}),
-            'controls': {'class': 'btn__group'},
-            'inputs': options.items
-        })
-    }}
+    {% if options.help is defined and options.help is not empty %}
+        {% set help_id = 'guid-' ~ random() %}
+        {% set options = options|merge({ 'help_id': help_id }) %}
+
+        {{
+            form.group({
+                'parent': options
+                    |only('bare class error guidance guidance-container help help_id id label required show-label type')
+                    |merge({'class': options.class|default ~ ' form__button-group', 'aria-describedby': help_id}),
+                'controls': {'class': 'btn__group'},
+                'inputs': options.items
+            })
+        }}
+    {% else %}
+        {{
+            form.group({
+                'parent': options
+                    |only('bare class error guidance guidance-container help help_id id label required show-label type')
+                    |merge({'class': options.class|default ~ ' form__button-group'}),
+                'controls': {'class': 'btn__group'},
+                'inputs': options.items
+            })
+        }}
+    {% endif %}
+
 {% endspaceless %}
 {% endmacro %}
 
@@ -116,10 +132,14 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
+    {% if options.help is defined and options.help is not empty %}
+        {% set options = options|merge({ 'help_id': 'guid-' ~ random() }) %}
+    {% endif %}
+
     {{
         form.group({
             'parent': options
-                |only('bare class error guidance guidance-container help id label required show-label')
+                |only('bare class error guidance guidance-container help help_id id label required show-label')
                 |defaults({
                     'class': 'form-checkbox'
                 }),
@@ -192,6 +212,10 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
+    {% if options.help is defined and options.help is not empty %}
+        {% set options = options|merge({ 'help_id': 'guid-' ~ random() }) %}
+    {% endif %}
+
     {% set inputClass = 'checkbox' %}
     {%
         if options.bare is defined
@@ -204,7 +228,7 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {%
         set input = elem.input(options
-            |exclude('error guidance guidance-container')
+            |exclude('error guidance guidance-container help')
             |merge({
                 'class': inputClass,
                 'label': null,
@@ -224,7 +248,7 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
     {{
         form.group({
             'parent': options
-                |only('bare class error help id')
+                |only('bare class error help help_id id')
                 |defaults({
                     'class': 'form-checkbox-inline'
                 }),
@@ -274,7 +298,6 @@ label through the use of the sibling `+` CSS selector.
 Option   | Type   | Description
 -------- | ------ | ------------------------------------------------------------
 form     | string | Specific one or more forms this label belongs to
-help     | string | Additional guidance information to be displayed next to the input
 id       | string | A unique identifier, will also be used as the label's `for` attribute
 name     | string | The name of this control
 required | bool   | Adds `required` and `aria-required="true"` attributes
@@ -418,15 +441,34 @@ show-label | bool   | Control visibility of the `<label>` element without affect
 
     {% endif %}
 
-    {{
-        form.group({
-            'parent': options
-                |only('bare class error guidance guidance-container help id label required show-label')
-                |exclude('multiple')
-                |defaults({'class': 'form-choice'}),
-            'inputs': inputs
-        })
-    }}
+    {% if options.help is defined and options.help is not empty %}
+        {% set help_id = 'guid-' ~ random() %}
+        {% set options = options|merge({ 'help_id': help_id }) %}
+
+        {{
+            form.group({
+                'parent': options
+                    |only('bare class error guidance guidance-container help help_id id label required show-label')
+                    |exclude('multiple')
+                    |defaults({'class': 'form-choice'})
+                    |merge({'aria-describedby': help_id}),
+                'inputs': inputs
+            })
+        }}
+    
+    {% else %}
+
+        {{
+            form.group({
+                'parent': options
+                    |only('bare class error guidance guidance-container help help_id id label required show-label')
+                    |exclude('multiple')
+                    |defaults({'class': 'form-choice'}),
+                'inputs': inputs
+            })
+        }}
+
+    {% endif %}
 
 {% endspaceless %}
 {% endmacro %}
@@ -482,6 +524,10 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
+    {% if options.help is defined and options.help is not empty %}
+        {% set options = options|merge({ 'help_id': 'guid-' ~ random() }) %}
+    {% endif %}
+
     {%
         set options = options|default({})|merge({
             'class': options.class|default ~ ' colorpicker js-colorpicker',
@@ -518,6 +564,20 @@ https://jadu.github.io/pulsar/form-helpers/compound
         {% set groupClass = groupClass ~ ' has-error' %}
     {% endif %}
 
+    {% if options.help is defined and options.help is not empty %}
+        {% set help_id = 'guid-' ~ random() %}
+        {% set options = options|merge({ 'help_id': help_id }) %} {# needed? #}
+
+    <fieldset{{
+        attributes(options
+                |only('class id')
+                |defaults({
+                    'class': groupClass,
+                    'aria-describedby': help_id,
+                })
+            )
+    -}}>
+    {% else %}
     <fieldset{{
         attributes(options
                 |only('class id')
@@ -526,6 +586,8 @@ https://jadu.github.io/pulsar/form-helpers/compound
                 })
             )
     -}}>
+    {% endif %}
+
     <legend class="control__label" {{ util.id(options.id ~ '[label]') }}>{{ options.label|default }} {{ util.guidance(options.guidance|default, { 'guidance-container': options['guidance-container']|default }) }}</legend>
 
     <div class="controls">
@@ -554,7 +616,10 @@ https://jadu.github.io/pulsar/form-helpers/compound
         {% endfor %}
 
         {{ form.error({ 'value': options.error|default }) }}
-        {{ form.help({ 'value': options.help|default }) }}
+
+        {% if options.help is defined and options.help is not empty %}
+            {{ form.help({ 'value': options.help|default, 'id': options.help_id }) }}
+        {% endif %}
     </div>
 </fieldset>
 
@@ -776,6 +841,10 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
             'data-datepicker': 'true'
         })
     %}
+
+    {% if options.help is defined and options.help is not empty %}
+        {% set options = options|merge({ 'help_id': 'guid-' ~ random() }) %}
+    {% endif %}
 
     {{ form.text(options) }}
 
@@ -1014,9 +1083,13 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
+    {% if options.help is defined and options.help is not empty %}
+        {% set options = options|merge({ 'help_id': 'guid-' ~ random() }) %}
+    {% endif %}
+
     {{
         form.group({
-            'parent': options|only('bare class error guidance guidance-container help id label required show-label'),
+            'parent': options|only('bare class error guidance guidance-container help help_id id label required show-label'),
             'inputs': [
                 elem.input(options
                     |exclude('bare class guidance guidance-container error help label show-label')
@@ -1141,7 +1214,7 @@ controls.class    | string | A space separated list of class names
     {% if options.parent.bare is not defined or options.parent.bare != true %}
     <div{{
         attributes(options.parent
-                |only('class')
+                |only('class aria-describedby')
                 |defaults({
                     'class': groupClass
                 })
@@ -1241,7 +1314,10 @@ controls.class    | string | A space separated list of class names
         {% endif %}
 
             {{ form.error({ 'value': options.parent.error|default }) }}
-            {{ form.help({ 'value': options.parent.help|default }) }}
+
+        {% if options.parent.help is defined and options.parent.help is not empty and options.parent.help_id is defined and options.parent.help_id is not empty %}
+            {{ form.help({ 'value': options.parent.help|default, 'id': options.parent.help_id }) }}
+        {% endif %}
 
         {% if options.parent.bare is not defined or options.parent.bare != true %}
         </div>
@@ -1282,7 +1358,7 @@ value  | string | The string or html markup to render inside the help block
 {% spaceless %}
 
     {% if options.value is defined and options.value is not empty %}
-        <span class="help-block">
+        <span class="help-block"{% if options.id is defined and options.id is not empty %} id="{{- options.id|raw -}}"{% endif %}>
             {{- options.value|raw -}}
         </span>
     {% endif %}
@@ -1447,10 +1523,14 @@ data-*     | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
+    {% if options.help is defined and options.help is not empty %}
+        {% set options = options|merge({ 'help_id': 'guid-' ~ random() }) %}
+    {% endif %}
+
     {{
         form.group({
             'parent': options
-                |only('bare class error guidance guidance-container help id label required show-label')
+                |only('bare class error guidance guidance-container help help_id id label required show-label')
                 |defaults({
                     'class': 'form-radio'
                 }),
@@ -1520,6 +1600,10 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
+    {% if options.help is defined and options.help is not empty %}
+        {% set options = options|merge({ 'help_id': 'guid-' ~ random() }) %}
+    {% endif %}
+
     {% set inputClass = 'radio' %}
     {%
         if options.bare is defined
@@ -1532,7 +1616,7 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {%
         set input = elem.input(options
-            |exclude('error guidance guidance-container')
+            |exclude('error guidance guidance-container help')
             |merge({
                 'class': inputClass,
                 'label': null,
@@ -1553,7 +1637,7 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
     {{
         form.group({
             'parent': options
-                |only('bare class error guidance-container help id')
+                |only('bare class error guidance-container help help_id id')
                 |defaults({
                     'class': 'form-radio-inline'
                 }),
@@ -1760,9 +1844,13 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
+    {% if options.help is defined and options.help is not empty %}
+        {% set options = options|merge({ 'help_id': 'guid-' ~ random() }) %}
+    {% endif %}
+
     {{
         form.group({
-            'parent': options|only('append append_type bare class error guidance guidance-container help id label prepend prepend_type required show-label'),
+            'parent': options|only('append append_type bare class error guidance guidance-container help help_id id label prepend prepend_type required show-label'),
             'inputs': [
                 elem.select(
                     options
@@ -1835,9 +1923,13 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
+    {% if options.help is defined and options.help is not empty %}
+        {% set options = options|merge({ 'help_id': 'guid-' ~ random() }) %}
+    {% endif %}
+
     {{
         form.group({
-            'parent': options|only('append append_type bare class error guidance guidance-container help id prepend prepend_type label required show-label'),
+            'parent': options|only('append append_type bare class error guidance guidance-container help help_id id prepend prepend_type label required show-label'),
             'inputs': [
                 elem.select2(options
                     |exclude('bare class error guidance guidance-container help label show-label')
@@ -1951,9 +2043,13 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {% set options = options|default({})|merge({ 'type': options.type|default('text') }) %}
 
+    {% if options.help is defined and options.help is not empty %}
+        {% set options = options|merge({ 'help_id': 'guid-' ~ random() }) %}
+    {% endif %}
+
     {{
         form.group({
-            'parent': options|only('append append_type bare class error guidance guidance-container help id label prepend prepend_type required show-label'),
+            'parent': options|only('append append_type bare class error guidance guidance-container help help_id id label prepend prepend_type required show-label'),
             'inputs': [
                 elem.input(
                     options|exclude('append_type bare class error guidance guidance-container help label prepend_type show-label')
@@ -2017,9 +2113,13 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
+    {% if options.help is defined and options.help is not empty %}
+        {% set options = options|merge({ 'help_id': 'guid-' ~ random() }) %}
+    {% endif %}
+
     {{
         form.group({
-            'parent': options|only('bare class error guidance guidance-container help id label required show-label'),
+            'parent': options|only('bare class error guidance guidance-container help help_id id label required show-label'),
             'inputs': [
                 elem.textarea(options
                     |exclude('bare class error guidance guidance-container help label show-label')
@@ -2147,9 +2247,13 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {% set toggleLabel = '<span class="hide">' ~ options.label ~ '</span>' %}
 
+    {% if options.help is defined and options.help is not empty %}
+        {% set options = options|merge({ 'help_id': 'guid-' ~ random() }) %}
+    {% endif %}
+
     {%
         set toggle = elem.input(options
-            |exclude('error guidance guidance-container show-label label')
+            |exclude('error guidance guidance-container show-label label help')
             |merge({
                 'class': 'toggle-switch',
                 'type': 'checkbox'
@@ -2164,7 +2268,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
     {{
         form.group({
             'parent': options
-                |only('bare class error guidance guidance-container help label required show-label')
+                |only('bare class error guidance guidance-container help help_id label required show-label')
                 |merge({
                     'class': options.class|default ~ ' form__group--toggle'
                 }),

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -54,31 +54,26 @@ items         | array  | An array of items to put in the dropdown list (usually 
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
+    {% set help_id = null %}
     {% if options.help is defined and options.help is not empty %}
         {% set help_id = 'guid-' ~ random() %}
-        {% set options = options|merge({ 'help_id': help_id }) %}
-
-        {{
-            form.group({
-                'parent': options
-                    |only('bare class error guidance guidance-container help help_id id label required show-label type')
-                    |merge({'class': options.class|default ~ ' form__button-group', 'aria-describedby': help_id}),
-                'controls': {'class': 'btn__group'},
-                'inputs': options.items
-            })
-        }}
-    {% else %}
-        {{
-            form.group({
-                'parent': options
-                    |only('bare class error guidance guidance-container help help_id id label required show-label type')
-                    |merge({'class': options.class|default ~ ' form__button-group'}),
-                'controls': {'class': 'btn__group'},
-                'inputs': options.items
-            })
-        }}
+        {% 
+            set options = options|merge({ 
+                'help_id': help_id,
+                'aria-describedby': help_id
+            }) 
+        %}
     {% endif %}
 
+    {{
+        form.group({
+            'parent': options
+                |only('aria-describedby bare class error guidance guidance-container help help_id id label required show-label type')
+                |merge({'class': options.class|default ~ ' form__button-group'}),
+            'controls': {'class': 'btn__group'},
+            'inputs': options.items
+        })
+    }}
 {% endspaceless %}
 {% endmacro %}
 
@@ -441,34 +436,26 @@ show-label | bool   | Control visibility of the `<label>` element without affect
 
     {% endif %}
 
+    {% set help_id = null %}
     {% if options.help is defined and options.help is not empty %}
         {% set help_id = 'guid-' ~ random() %}
-        {% set options = options|merge({ 'help_id': help_id }) %}
-
-        {{
-            form.group({
-                'parent': options
-                    |only('bare class error guidance guidance-container help help_id id label required show-label')
-                    |exclude('multiple')
-                    |defaults({'class': 'form-choice'})
-                    |merge({'aria-describedby': help_id}),
-                'inputs': inputs
-            })
-        }}
-    
-    {% else %}
-
-        {{
-            form.group({
-                'parent': options
-                    |only('bare class error guidance guidance-container help help_id id label required show-label')
-                    |exclude('multiple')
-                    |defaults({'class': 'form-choice'}),
-                'inputs': inputs
-            })
-        }}
-
+        {% 
+            set options = options|merge({ 
+                'help_id': help_id,
+                'aria-describedby': help_id
+            }) 
+        %}
     {% endif %}
+
+    {{
+        form.group({
+            'parent': options
+                |only('aria-describedby bare class error guidance guidance-container help help_id id label required show-label')
+                |exclude('multiple')
+                |defaults({'class': 'form-choice'}),
+            'inputs': inputs
+        })
+    }}
 
 {% endspaceless %}
 {% endmacro %}
@@ -564,29 +551,23 @@ https://jadu.github.io/pulsar/form-helpers/compound
         {% set groupClass = groupClass ~ ' has-error' %}
     {% endif %}
 
+    {% set help_id = null %}
     {% if options.help is defined and options.help is not empty %}
         {% set help_id = 'guid-' ~ random() %}
-        {% set options = options|merge({ 'help_id': help_id }) %}
+        {% 
+            set options = options|merge({ 
+                'help_id': help_id,
+                'aria-describedby': help_id
+            }) 
+        %}
+    {% endif %}
 
     <fieldset{{
         attributes(options
-                |only('class id')
-                |defaults({
-                    'class': groupClass,
-                    'aria-describedby': help_id,
-                })
+                |only('aria-describedby class id')
+                |defaults({ 'class': groupClass })
             )
     -}}>
-    {% else %}
-    <fieldset{{
-        attributes(options
-                |only('class id')
-                |defaults({
-                    'class': groupClass
-                })
-            )
-    -}}>
-    {% endif %}
 
     <legend class="control__label" {{ util.id(options.id ~ '[label]') }}>{{ options.label|default }} {{ util.guidance(options.guidance|default, { 'guidance-container': options['guidance-container']|default }) }}</legend>
 
@@ -1358,7 +1339,7 @@ value  | string | The string or html markup to render inside the help block
 {% spaceless %}
 
     {% if options.value is defined and options.value is not empty %}
-        <span class="help-block"{% if options.id is defined and options.id is not empty %} id="{{- options.id|raw -}}"{% endif %}>
+        <span class="help-block"{% if options.id is defined and options.id is not empty %} id="{{- options.id -}}"{% endif %}>
             {{- options.value|raw -}}
         </span>
     {% endif %}

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -566,7 +566,7 @@ https://jadu.github.io/pulsar/form-helpers/compound
 
     {% if options.help is defined and options.help is not empty %}
         {% set help_id = 'guid-' ~ random() %}
-        {% set options = options|merge({ 'help_id': help_id }) %} {# needed? #}
+        {% set options = options|merge({ 'help_id': help_id }) %}
 
     <fieldset{{
         attributes(options


### PR DESCRIPTION
Previously, if a help text was passed to a form helper/macro it didn't get read by screenreaders. 

Now, if help text is passed to a form helper/macro via the `help` option, a random `guid` ID is created for the help block which the input (or `fieldset` / `form_group` wrapper - depending on the helper type) uses for aria-describedby.

Screen readers now read any supplied help text correctly.

*Note*: this does not cover validation errors - that will be resolved in a separate ticket

Fixed #790 