### PR TITLE
Close popovers when opening the secondary navigation

### DIFF
--- a/js/NavMainComponent.js
+++ b/js/NavMainComponent.js
@@ -110,6 +110,9 @@ NavMainComponent.prototype.openSecondaryNav = function ($linkClicked, event) {
     component.closeTertiaryNav();
     component.closeQuaternaryNav();
 
+    // Close any open popovers which would appear over the navigation
+    component.$html.find('[data-toggle="popover"]').popover('hide');
+
     // If href is a fragment (therefore opens a sub nav), don't add it to the URL because it breaks the back button
     if (target.indexOf('#') !== -1) {
         event.preventDefault();

--- a/tests/js/web/NavMainComponentTest.js
+++ b/tests/js/web/NavMainComponentTest.js
@@ -74,7 +74,9 @@ describe('NavMainComponent', function () {
                    </div>
                </div>
             </nav>
-            <div class="content-main"></div>
+            <div class="content-main">
+                <a href="#" data-toggle="popover" data-content="foo">popover test</a>
+            </div>
         `).appendTo(this.$body);
 
         this.$mobileMenuButton = this.$html.find('.mobile-menu-button');
@@ -92,6 +94,9 @@ describe('NavMainComponent', function () {
         this.$linkThree = this.$html.find('[href="#three"]');
         this.$tertiaryLinkThree = this.$html.find('[href="#three_one"]');
 
+        $.fn.popover = sinon.stub().returnsThis();
+        this.$popoverLink = this.$html.find('[data-toggle="popover"]');
+
         // set height on nav items as no css in tests
         this.$html.find('.nav-item').height(20);
         this.$html.find('.more-icon').height(20);
@@ -101,6 +106,7 @@ describe('NavMainComponent', function () {
 
     afterEach(function () {
         this.$html.remove(); // Detach test DOM from the real one
+        delete $.fn.popover;
     });
 
     describe('when component is initalised, if html arguement is missing', function () {
@@ -493,5 +499,22 @@ describe('NavMainComponent', function () {
             expect(this.$navTertiary.hasClass('is-open')).to.be.false;
             expect(this.$navQuaternary.hasClass('is-open')).to.be.false;
         });
+    });
+
+    describe('opening the secondary nav when a popover is open', function () {
+        beforeEach(function () {
+            this.navMainComponent.init();
+            this.clickEvent = $.Event('click');
+            this.$linkOne.trigger(this.clickEvent);
+            this.$popoverLink.trigger(this.clickEvent);
+        });
+
+        it('should trigger a popover', function () {
+			expect($.fn.popover).to.have.been.called;
+		});
+
+        it('should be hidden when opening the secondary navigation', function () {
+            expect($.fn.popover).to.have.been.calledWith('hide');            
+        })
     });
 });


### PR DESCRIPTION
Fixes an issue where open popovers would appear over the secondary navigation when it was opened.

(Popovers still need to have a higher z-index than nav to stop them being obscured during normal operation)

### Before
![pop-after](https://user-images.githubusercontent.com/18653/38868725-faa0184a-423f-11e8-8d71-df3e2cac5ec1.gif)

### After
![pop-after2](https://user-images.githubusercontent.com/18653/38868730-fdf78230-423f-11e8-99dd-f3088906c6df.gif)