### PR TITLE
Restore has-error / has-danger state classes

### DIFF
--- a/stylesheets/_utility.states.scss
+++ b/stylesheets/_utility.states.scss
@@ -34,10 +34,10 @@ $danger-to-text-color: black;
 
 .has-error:not(.form__group),
 .has-danger:not(.form__group) {
-    background-color: lighten(color(danger), 20) !important;
+    background-color: color(danger, light) !important;
 
     &:hover {
-        background-color: lighten(color(danger), 17) !important;
+        background-color: darken(color(danger, light), 5) !important;
     }
 }
 

--- a/stylesheets/_utility.states.scss
+++ b/stylesheets/_utility.states.scss
@@ -32,6 +32,15 @@ $danger-to-text-color: black;
     }
 }
 
+.has-error:not(.form__group),
+.has-danger:not(.form__group) {
+    background-color: lighten(color(danger), 20) !important;
+
+    &:hover {
+        background-color: lighten(color(danger), 17) !important;
+    }
+}
+
 @each $state, $state-color, $state-color-alt in $state-colors {
     %text--#{$state},
     .text--#{$state} {


### PR DESCRIPTION
This restores the expected light red background to elements with the relevant state class.

I can’t find a legitimate reason for these to have been removed, their restoration may cause a few unexpected situations though…

**This change should not affect forms.** Form helpers have their own has-error styling, the top level `has-error`/`has-danger` classes explicitly avoid being applied to `form__group`.

#### Example usage
`<tr class="has-error">...</tr>`
![screen shot 2018-04-20 at 15 36 04](https://user-images.githubusercontent.com/18653/39057199-9088c466-44b0-11e8-8962-590ee1ecb610.png)

## Breaking change quick checklist

The following points should be considered as an early-warning of introducing a breaking change to a Continuum platform product. This is not an exhaustive list of what constitutes a breaking change.

| Does this pull request... | Yes / No |
| ---- | ---- |
| require changes to `main.js` | ✅ No  |
| require changes to `index.js` | ✅ No |
| require changes to `pulsar.scss` | ✅ No |
| require changes to `gruntfile.js` | ✅ No |
| require changes to `package.json` (not including dev dependencies) | ✅ No |
| require changes to `base.html.twig` (or other core views like header/footer) | ✅ No |
| require new arguments to be passed to a js component | ✅ No |
| require markup changes to maintain functionality | ✅ No |