### PR TITLE
Big Funkin' Accessibility Test

### DIFF
--- a/docs/_layout/notifications.md
+++ b/docs/_layout/notifications.md
@@ -11,9 +11,8 @@ Provides a prominent location for notifications to be displayed. A toolbar indic
 {% raw %}
 ```twig
 {{
-    html.link({
-        'class': 'notifications-toggle',
-        'href': '#',
+    html.button({
+        'class': 'notifications-toggle btn--naked',
         'label': html.icon('bell'),
         'data-toggle': 'dropdown'
     })
@@ -22,9 +21,9 @@ Provides a prominent location for notifications to be displayed. A toolbar indic
 {% endraw %}
 
 <div class="pulsar-example">
-    <a href="#" class="notifications-toggle is-active has-new" data-toggle="dropdown"><i class="icon-bell-o"></i></a>
-    <a href="#" class="notifications-toggle is-active" data-toggle="dropdown"><i class="icon-bell-o"></i></a>
-    <a href="#" class="notifications-toggle" data-toggle="dropdown"><i class="icon-bell-o"></i></a>
+    <button class="notifications-toggle btn--naked is-active has-new" data-toggle="dropdown"><i class="icon-bell-o"></i></button>
+    <button class="notifications-toggle btn--naked is-active" data-toggle="dropdown"><i class="icon-bell-o"></i></button>
+    <button class="notifications-toggle btn--naked" data-toggle="dropdown"><i class="icon-bell-o"></i></button>
 </div>
 
 Toggle the states with common state classes
@@ -45,9 +44,8 @@ A main `notifications` container holds both the `notifications-toggle` and the `
 ```twig
 <div class="dropdown notifications">
     {{
-        html.link({
-            'class': 'notifications-toggle is-active',
-            'href': '#',
+        html.button({
+            'class': 'notifications-toggle btn--naked is-active',
             'label': html.icon('bell'),
             'data-toggle': 'dropdown'
         })

--- a/views/lexicon/includes/notifications.html.twig
+++ b/views/lexicon/includes/notifications.html.twig
@@ -1,8 +1,7 @@
     <div class="dropdown notifications">
         {{
-            html.link({
-                'class': 'notifications-toggle is-active',
-                'href': '#',
+            html.button({
+                'class': 'notifications-toggle btn--naked is-active',
                 'label': html.icon('bell-o', { 'label': 'Show notifications' }),
                 'data-toggle': 'dropdown'
             })

--- a/views/lexicon/tabs/message.html.twig
+++ b/views/lexicon/tabs/message.html.twig
@@ -11,7 +11,7 @@
         <li><strong>This is bold text</strong></li>
         <li><i>This is italic text</i></li>
         <li><strong><i>This is bold, italic text</i></strong></li>
-        <li><a href="#" title="This is a link">This is a link</a></li>
+        <li><a href="#" title="This is a link title">This is a link</a></li>
         <li><abbr title="This is the description">This is an abbreviation</abbr></li>
         <li><a href="#" title="This is the link description">This is a link with an <abbr title="This is the abbreviation description">abbr</abbr> inside it</a></li>
     </ul>

--- a/views/pulsar/v2/helpers/nav.html.twig
+++ b/views/pulsar/v2/helpers/nav.html.twig
@@ -5,7 +5,7 @@
 
 <nav class="nav-main" aria-label="Primary" id="aria-main-nav">
     <div class="nav-primary t-nav-primary">
-        <a href="{{ options.brand_link|default('#') }}" class="jadu-branding">
+        <a href="{{ options.brand_link|default('/') }}" class="jadu-branding">
             <span class="jadu-logomark"></span>
             <span class="jadu-wordmark">Jadu</span>
         </a>


### PR DESCRIPTION
## Changes which need to filter down to Continuum products

| Component | Reason | Change | 
| ---- | ---- | ---- |
| Navigation | WCAG 2.0, Level A: 4.1.2 | Change the default href for the main branding image (top left) to be `/` instead of `#` |
| Notifications | WCAG 2.0, Level A: 4.1.2 | Change the notification toggle (bell icon) to use `<button>` rather than a `<a>` |