### PR TITLE
[828] Modal Titles and Table Details Pattern Title Font Size Increase

### DIFF
--- a/stylesheets/_component.modals.scss
+++ b/stylesheets/_component.modals.scss
@@ -107,7 +107,7 @@
 
 // Title text within header
 .modal__title {
-    font-size: $font-size-base;
+    font-size: $font-size-xlarge;
     line-height: $modal-title-line-height;
     margin: 0;
 }

--- a/stylesheets/_component.modals.scss
+++ b/stylesheets/_component.modals.scss
@@ -263,7 +263,7 @@
     .modal__header-detailed {
         flex: 1 1 50px;
         margin-left: 15px;
-        margin-top: 10px;
+        margin-top: 4px;
         min-width: 0;
         padding-left: 45px;
 

--- a/stylesheets/_component.modals.scss
+++ b/stylesheets/_component.modals.scss
@@ -263,7 +263,7 @@
     .modal__header-detailed {
         flex: 1 1 50px;
         margin-left: 15px;
-        margin-top: 4px;
+        margin-top: 10px;
         min-width: 0;
         padding-left: 45px;
 
@@ -285,6 +285,7 @@
         }
 
         .modal__title {
+            font-size: $font-size-base;
             line-height: 1.2em;
         }
 

--- a/stylesheets/_component.table-detail.scss
+++ b/stylesheets/_component.table-detail.scss
@@ -47,7 +47,7 @@
 
 .table-detail__title {
     line-height: $modal-title-line-height;
-    font-size: $font-size-large;
+    font-size: $font-size-xlarge;
     margin: 0;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
This PR doesn't break anything. Affects the titles in Standard, Full Screen Modal and Table Detail Pattern. Related issue #828 

**Expected results:**

![modal-title-bigger](https://user-images.githubusercontent.com/1425876/40226265-17015e12-5a83-11e8-9b62-dbc1e4398c0d.png)
Increased

![modal-fullwidth](https://user-images.githubusercontent.com/1425876/40226330-4bc795d0-5a83-11e8-85fb-7cb39ccee777.png)
Kept the same

![image](https://user-images.githubusercontent.com/1425876/40226316-45d1bdc2-5a83-11e8-8201-eb492be2f58f.png)
Increased
