### PR TITLE
Increases contrast of ‘close’ control on modals

### DIFF
--- a/stylesheets/_component.close.scss
+++ b/stylesheets/_component.close.scss
@@ -3,14 +3,12 @@
   font-size: 2em;
   font-weight: bold;
   line-height: $line-height-base;
-  color: color(black);
-  opacity: .2;
+  color: color(grey, dark);
   text-decoration: none;
 
   &:hover {
     color: color(black);
     cursor: pointer;
-    opacity: .4;
   }
 }
 

--- a/stylesheets/_component.modals.scss
+++ b/stylesheets/_component.modals.scss
@@ -149,7 +149,6 @@
     }
 
     .close {
-        @include opacity(.7);
         color: color(white);
     }
 }
@@ -247,7 +246,6 @@
 
     .close {
         margin-top: 0;
-        opacity: 1;
     }
 
     .download {


### PR DESCRIPTION
Done to improve the accessibility and obviousness of the close control.

**Before**

<img width="493" alt="screenshot 2018-06-12 at 14 03 17" src="https://user-images.githubusercontent.com/18653/41292088-6ae6b6ec-6e49-11e8-8a16-9ed2a70b322a.png">

**After**

<img width="445" alt="screenshot 2018-06-12 at 14 03 28" src="https://user-images.githubusercontent.com/18653/41292093-6f8c844c-6e49-11e8-837a-0c4a0c3c36fc.png">

Closes #815