### PR TITLE
Add docker config and update makefile to resolve recent installation issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+    web:
+        image: php:7.0-apache
+        working_dir: /var/www/html
+        volumes:
+          - ./:/var/www/html/:cached        
+        ports:
+          - 3000:80

--- a/docs/Local_development.md
+++ b/docs/Local_development.md
@@ -41,7 +41,11 @@ This may take a while if it’s your first time, once that’s ready you should 
 vagrant up
 ```
 
-The first time you run this, vagrant will download a ‘box’ which is basically a lightweight Ubuntu build, it will then run a provisioning script which installs and configures Apache, PHP, MySQL and Git.
+or alternatively, using docker
+
+```
+docker-compose up -d
+```
 
 Once that’s complete, you will need to run the main `grunt` task which will build the main CSS and javascript files, and watch for any further changes. This can be started with:
 

--- a/makefile
+++ b/makefile
@@ -36,10 +36,6 @@ build:
 	@ -rbenv global 2.3.0
 	@ echo "\n${CHECK} Done"
 
-	# echo "${HR}\nInstalling Ruby...${HR}\n"
-	# -brew install ruby
-	# echo "\n${CHECK} Done"
-
 	@ echo "${HR}\nInstalling scss-lint...${HR}\n"
 	@ gem install scss_lint -v ${SASSLINTVER} --no-ri --no-rdoc --no-user-install
 	@ echo "\n${CHECK} Done"

--- a/makefile
+++ b/makefile
@@ -29,12 +29,19 @@ build:
 	@ -brew cask install virtualbox
 	@ echo "\n${CHECK} Done"
 
-	@ echo "${HR}\nInstalling Ruby...${HR}\n"
-	@ -brew install ruby
+	@ echo "${HR}\nInstalling Ruby via rbenv...${HR}\n"
+	@ -brew install rbenv
+	@ -rbenv init
+	@ -rbenv install 2.3.0
+	@ -rbenv global 2.3.0
 	@ echo "\n${CHECK} Done"
 
+	# echo "${HR}\nInstalling Ruby...${HR}\n"
+	# -brew install ruby
+	# echo "\n${CHECK} Done"
+
 	@ echo "${HR}\nInstalling scss-lint...${HR}\n"
-	@ gem install scss_lint -v ${SASSLINTVER} --no-ri --no-rdoc
+	@ gem install scss_lint -v ${SASSLINTVER} --no-ri --no-rdoc --no-user-install
 	@ echo "\n${CHECK} Done"
 
 	@ echo "${HR}\nInstalling PhantomJS...${HR}\n"
@@ -46,7 +53,7 @@ build:
 	@ echo "\n${CHECK} Done"
 
 	@ echo "${HR}\nInstalling Wraith...${HR}\n"
-	@ gem install wraith --no-ri --no-rdoc
+	@ gem install wraith --no-ri --no-rdoc --no-user-install
 	@ echo "\n${CHECK} Done"
 
 	@ echo "${HR}\nInstalling Node & NPM...${HR}\n"

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -3,7 +3,7 @@
   tasks:
     - name: install server components
       apt: name={{ item }} state=present update_cache=yes
-      sudo: yes
+      become: yes
       with_items:
        - apache2
        - mysql-server
@@ -12,7 +12,7 @@
        - git
 
     - name: update php.ini
-      sudo: yes
+      become: yes
       template: >
         src=./templates/php.ini.j2
         dest=/etc/php5/apache2/php.ini


### PR DESCRIPTION
Docker can be used instead of vagrant, which is much faster, start the server with `docker-compose up -d`.

Makefile has been updated with some things that were required for me to get a clean working install after reinstalling MacOS.