### PR TITLE
[699]Add missing ‘:’ in the Radio Simple Docs

### DIFF
--- a/docs/assets/code_examples/form_helpers/twig/radio-simple
+++ b/docs/assets/code_examples/form_helpers/twig/radio-simple
@@ -1,7 +1,7 @@
 {{
     form.radio_simple({
         'label': 'Radio simple',
-        'id' 'foo',
+        'id': 'foo',
         'name': 'bar'
     })
 }}

--- a/docs/assets/code_examples/form_helpers/twig/radio-simple-disabled
+++ b/docs/assets/code_examples/form_helpers/twig/radio-simple-disabled
@@ -1,7 +1,7 @@
 {{
     form.radio_simple({
         'label': 'Radio simple disabled',
-        'id' 'foo',
+        'id': 'foo',
         'name': 'bar',
         'disabled': true
     })


### PR DESCRIPTION
This is just a quick fix for the #699 . Docs have been properly updated.