### PR TITLE
[809] Close the table details panel when clicking outside of the details container

### DIFF
--- a/js/TableDetailComponent.js
+++ b/js/TableDetailComponent.js
@@ -59,8 +59,8 @@ class TableDetailComponent {
 
         //Close with backdrop click
         this.$html.find('.table-detail-backdrop').on('click', (event) => {
+            event.preventDefault();
             if (this.$html.find('.table-detail-backdrop').hasClass('in')) {
-                event.preventDefault();
                 this.closeDetail();
             }
         });

--- a/js/TableDetailComponent.js
+++ b/js/TableDetailComponent.js
@@ -60,8 +60,9 @@ class TableDetailComponent {
         //Close with backdrop click
         this.$html.find('.table-detail-backdrop').on('click', (event) => {
             if (this.$html.find('.table-detail-backdrop').hasClass('in')) {
+                event.preventDefault();
                 this.closeDetail();
-            };
+            }
         });
     }
     /**

--- a/js/TableDetailComponent.js
+++ b/js/TableDetailComponent.js
@@ -40,6 +40,7 @@ class TableDetailComponent {
         this.$detailPanel = this.$html.find('[data-table-detail-panel]');
         this.$detailPanelBody = this.$html.find('[data-table-detail-panel-body]');
         this.$detailPanelTitle = this.$html.find('[data-table-detail-panel-title]');
+        this.$tableDetailBackdrop = this.$html.find('.table-detail-backdrop');
 
         // Open click listener
         this.$table.find('[data-table-detail-view-detail]').on('click', (event) => {
@@ -58,9 +59,9 @@ class TableDetailComponent {
         });
 
         //Close with backdrop click
-        this.$html.find('.table-detail-backdrop').on('click', (event) => {
+        this.$tableDetailBackdrop.on('click', (event) => {
             event.preventDefault();
-            if (this.$html.find('.table-detail-backdrop').hasClass('in')) {
+            if (this.$tableDetailBackdrop.hasClass('in')) {
                 this.closeDetail();
             }
         });
@@ -83,7 +84,7 @@ class TableDetailComponent {
         this.$detailPanelBody.html(content);
 
         // Apply backdrop
-        this.$html.find('.table-detail-backdrop').addClass('in');
+        this.$tableDetailBackdrop.addClass('in');
 
         // Open panel
         this.$detailPanel.addClass('table-detail--open');
@@ -94,7 +95,7 @@ class TableDetailComponent {
      */
     closeDetail () {
         // Remove backdrop
-        this.$html.find('.table-detail-backdrop').removeClass('in');
+        this.$tableDetailBackdrop.removeClass('in');
 
         // Close panel
         this.$detailPanel.removeClass('table-detail--open');

--- a/js/TableDetailComponent.js
+++ b/js/TableDetailComponent.js
@@ -1,5 +1,5 @@
 class TableDetailComponent {
-    
+
     /**
      * TableDetailComponent
      * @constructor
@@ -47,7 +47,7 @@ class TableDetailComponent {
 
             let detailContent = $(event.currentTarget).closest('tr').data('table-detail-content');
             let customDetailPanelTitle = $(event.currentTarget).closest('tr').data('table-detail-panel-custom-title');
-            
+
             this.viewDetail(detailContent, customDetailPanelTitle);
         });
 
@@ -56,8 +56,14 @@ class TableDetailComponent {
             event.preventDefault();
             this.closeDetail();
         });
-    }
 
+        //Close with backdrop click
+        this.$html.find('.table-detail-backdrop').on('click', (event) => {
+            if (this.$html.find('.table-detail-backdrop').hasClass('in')) {
+                this.closeDetail();
+            };
+        });
+    }
     /**
      * Show detail panel and populate with content and optional custom title
      * @param {String} content - string of html content to populate the detail panel body with
@@ -71,7 +77,7 @@ class TableDetailComponent {
 
         // Remove any previously added contents
         this.$detailPanelBody.empty();
-        
+
         // Add attached data to detail panel body
         this.$detailPanelBody.html(content);
 

--- a/tests/js/web/TableDetailComponentTest.js
+++ b/tests/js/web/TableDetailComponentTest.js
@@ -121,8 +121,9 @@ describe('TableDetailComponent', () => {
 			tableDetailComponent.init($body);
 
 			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
-			$body.find('.table-detail-backdrop').trigger(clickEvent);
+			expect($body.find('.table-detail-backdrop').hasClass('in')).to.be.true;
 
+			$body.find('.table-detail-backdrop').trigger(clickEvent);
 			expect($body.find('.table-detail-backdrop').hasClass('in')).to.be.false;
 		});
 
@@ -130,8 +131,9 @@ describe('TableDetailComponent', () => {
 			tableDetailComponent.init($body);
 
 			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
-			$body.find('.table-detail-backdrop').trigger(clickEvent);
+			expect($body.find('[data-table-detail-panel]').hasClass('table-detail--open')).to.be.true;
 
+			$body.find('.table-detail-backdrop').trigger(clickEvent);
 			expect($body.find('[data-table-detail-panel]').hasClass('table-detail--open')).to.be.false;
 		});
 	})

--- a/tests/js/web/TableDetailComponentTest.js
+++ b/tests/js/web/TableDetailComponentTest.js
@@ -128,7 +128,7 @@ describe('TableDetailComponent', () => {
 		it('remove the "table-detail--open" class to the panel to open it', () => {
 			tableDetailComponent.init($body);
 
-			$body.find('[data-table-detail-close-panel]').trigger(clickEvent);
+			$body.find('.table-detail-backdrop').trigger(clickEvent);
 
 			expect($body.find('[data-table-detail-panel]').hasClass('table-detail--open')).to.be.false;
 		});

--- a/tests/js/web/TableDetailComponentTest.js
+++ b/tests/js/web/TableDetailComponentTest.js
@@ -25,7 +25,7 @@ describe('TableDetailComponent', () => {
 			'	</tbody>' +
 			'</table>'
 		).appendTo($body);
-	
+
 		tableDetailComponent = new TableDetailComponent($html);
 	});
 
@@ -103,6 +103,24 @@ describe('TableDetailComponent', () => {
 			tableDetailComponent.init($body);
 
 			$body.find('[data-table-detail-close-panel]').trigger(clickEvent);
+
+			expect($body.find('.table-detail-backdrop').hasClass('in')).to.be.false;
+		});
+
+		it('remove the "table-detail--open" class to the panel to open it', () => {
+			tableDetailComponent.init($body);
+
+			$body.find('[data-table-detail-close-panel]').trigger(clickEvent);
+
+			expect($body.find('[data-table-detail-panel]').hasClass('table-detail--open')).to.be.false;
+		});
+	})
+
+	describe('When the backdrop overlay is clicked', () => {
+		it('should remove the "in" class from the backdrop to hide it', () => {
+			tableDetailComponent.init($body);
+
+			$body.find('.table-detail-backdrop').trigger(clickEvent);
 
 			expect($body.find('.table-detail-backdrop').hasClass('in')).to.be.false;
 		});

--- a/tests/js/web/TableDetailComponentTest.js
+++ b/tests/js/web/TableDetailComponentTest.js
@@ -120,6 +120,7 @@ describe('TableDetailComponent', () => {
 		it('should remove the "in" class from the backdrop to hide it', () => {
 			tableDetailComponent.init($body);
 
+			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
 			$body.find('.table-detail-backdrop').trigger(clickEvent);
 
 			expect($body.find('.table-detail-backdrop').hasClass('in')).to.be.false;
@@ -128,6 +129,7 @@ describe('TableDetailComponent', () => {
 		it('should remove the "table-detail--open" class from the panel to close it', () => {
 			tableDetailComponent.init($body);
 
+			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
 			$body.find('.table-detail-backdrop').trigger(clickEvent);
 
 			expect($body.find('[data-table-detail-panel]').hasClass('table-detail--open')).to.be.false;

--- a/tests/js/web/TableDetailComponentTest.js
+++ b/tests/js/web/TableDetailComponentTest.js
@@ -125,7 +125,7 @@ describe('TableDetailComponent', () => {
 			expect($body.find('.table-detail-backdrop').hasClass('in')).to.be.false;
 		});
 
-		it('remove the "table-detail--open" class to the panel to open it', () => {
+		it('should remove the "table-detail--open" class from the panel to close it', () => {
 			tableDetailComponent.init($body);
 
 			$body.find('.table-detail-backdrop').trigger(clickEvent);


### PR DESCRIPTION
Related ticket: #809 

This PR adds the ability to close the Table Details from clicking on the backdrop overlay.
![pulsar-table details close via backdrop](https://user-images.githubusercontent.com/1425876/43391160-d6674c4c-93e7-11e8-9515-2fd67c2631a8.gif)
