### PR TITLE
Increase contrast ratio of text in footer

### DIFF
--- a/stylesheets/_component.footer.scss
+++ b/stylesheets/_component.footer.scss
@@ -9,7 +9,6 @@
     background-color: color(white);
     border-top: 1px solid color(gray, lightest);
     bottom: 0;
-    color: #999;
     font-size: $font-size-small;
     left: 0;
     padding: 6px $gutter-width;


### PR DESCRIPTION
Increases contrast ratio to meet 1.4.3 Contrast (Minimum): (Level AA).

**Before:**
<img width="238" alt="screen shot 2018-08-03 at 14 19 26" src="https://user-images.githubusercontent.com/18653/43646042-abffa98a-972b-11e8-944d-08e110ee3154.png">

**After:**
<img width="239" alt="screen shot 2018-08-03 at 14 43 02" src="https://user-images.githubusercontent.com/18653/43646051-b30fdcb8-972b-11e8-90dc-19d0c98db74f.png">

Verified that aXe and SiteImprove no longer complain about contrast ratio.