### PR TITLE
Stop using empty alt attributes on user guide and notifications menus

### DIFF
--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/media-presentation.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/media-presentation.html
@@ -1,0 +1,7 @@
+<div class="media">
+    <img src="foo.png" role="presentation" class="media__image" />
+    <div class="media__body">
+        <p>Bar</p>
+        <span class="small-type muted">Baz</span>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/media-presentation.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/media-presentation.html.twig
@@ -1,0 +1,10 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    html.media({
+        'image': 'foo.png',
+        'title': 'Bar',
+        'description': 'Baz'
+    })
+}}
+{% endblock %}

--- a/views/lexicon/includes/notifications.html.twig
+++ b/views/lexicon/includes/notifications.html.twig
@@ -44,7 +44,7 @@
 
             <div class="notification">
                 <div class="media">
-                    <img src="/images/favicons/xfp/android-chrome-48x48.png" alt="" class="media__image" />
+                    <img src="/images/favicons/xfp/android-chrome-48x48.png" role="presentation" class="media__image" />
 
                     <div class="media__body">
                         <button
@@ -72,7 +72,7 @@
 
             <div class="notification">
                 <div class="media">
-                    <img src="/images/favicons/xfp/android-chrome-48x48.png" alt="" class="media__image" />
+                    <img src="/images/favicons/xfp/android-chrome-48x48.png" role="presentation" class="media__image" />
 
                     <div class="media__body">
                         <button
@@ -100,7 +100,7 @@
 
             <div class="notification">
                 <div class="media">
-                    <img src="/images/favicons/xfp/android-chrome-48x48.png" alt="" class="media__image" />
+                    <img src="/images/favicons/xfp/android-chrome-48x48.png" role="presentation" class="media__image" />
 
                     <div class="media__body">
                         <button
@@ -128,7 +128,7 @@
 
             <div class="notification">
                 <div class="media">
-                    <img src="/images/favicons/xfp/android-chrome-48x48.png" alt="" class="media__image" />
+                    <img src="/images/favicons/xfp/android-chrome-48x48.png" role="presentation" class="media__image" />
 
                     <div class="media__body">
                         <button
@@ -156,7 +156,7 @@
 
             <div class="notification">
                 <div class="media">
-                    <img src="/images/favicons/xfp/android-chrome-48x48.png" alt="" class="media__image" />
+                    <img src="/images/favicons/xfp/android-chrome-48x48.png" role="presentation" class="media__image" />
 
                     <div class="media__body">
                         <button

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1084,7 +1084,11 @@ data-*      | string    | Data attributes, eg: `'data-foo': 'bar'`
     {% if options.icon is defined and options.icon is not empty %}
         {{ html.icon(options.icon, { 'class': 'media__image', 'colour': options.icon_colour|default('#000') }) }}
     {% elseif options.image is defined and options.image is not empty %}
-        <img src="{{ options.image }}" alt="{{ options.image_alt|default }}" class="media__image" />
+        {% set alt = ' role=presentation' %}
+        {% if options.image_alt is defined and options.image_alt is not empty %}
+            {% set alt = ' ' ~ options.image_alt %} 
+        {% endif %}
+        <img src="{{ options.image }}"{{ alt|default }} class="media__image" />
     {% endif %}
         <div class="media__body">
         {% if options.action is defined and options.action is not empty %}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1084,7 +1084,7 @@ data-*      | string    | Data attributes, eg: `'data-foo': 'bar'`
     {% if options.icon is defined and options.icon is not empty %}
         {{ html.icon(options.icon, { 'class': 'media__image', 'colour': options.icon_colour|default('#000') }) }}
     {% elseif options.image is defined and options.image is not empty %}
-        {% set alt = ' role=presentation' %}
+        {% set alt = ' role="presentation"' %}
         {% if options.image_alt is defined and options.image_alt is not empty %}
             {% set alt = ' alt="' ~ options.image_alt ~ '"' %} 
         {% endif %}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1086,9 +1086,9 @@ data-*      | string    | Data attributes, eg: `'data-foo': 'bar'`
     {% elseif options.image is defined and options.image is not empty %}
         {% set alt = ' role=presentation' %}
         {% if options.image_alt is defined and options.image_alt is not empty %}
-            {% set alt = ' ' ~ options.image_alt %} 
+            {% set alt = ' alt="' ~ options.image_alt ~ '"' %} 
         {% endif %}
-        <img src="{{ options.image }}"{{ alt|default }} class="media__image" />
+        <img src="{{ options.image }}"{{ alt|default|raw }} class="media__image" />
     {% endif %}
         <div class="media__body">
         {% if options.action is defined and options.action is not empty %}

--- a/views/pulsar/v2/helpers/nav.html.twig
+++ b/views/pulsar/v2/helpers/nav.html.twig
@@ -161,7 +161,7 @@
             {{
                 html.link({
                     'class': 'toolbar-help-link',
-                    'href': '#',
+                    'href': '#user-guides',
                     'icon': 'question-sign',
                     'label': options.label|default('user guides'),
                     'data-toggle': 'dropdown'


### PR DESCRIPTION
This fix will stop Pulsar UIs from failing WCAG `1.1.1 Non-text Content: (Level A)`.

html.media helper will add `role="presentation"` if no `image_alt` attribute is supplied.

Also stopped notifications example using empty alt attributes but I believe this is implemented separately in continuum products.