### PR TITLE
Add bypass block example

### DIFF
--- a/stylesheets/_structure.scaffolding.scss
+++ b/stylesheets/_structure.scaffolding.scss
@@ -60,3 +60,21 @@ a.disabled {
     cursor: not-allowed !important;
   }
 }
+
+.skip-link {
+  background-color: color(white);
+  position: absolute;
+  left: -9999px;
+  padding: 0 10px;
+  text-align: left;
+  top: -9999px;
+  z-index: $zindex-nav;
+
+  &:focus {
+    display: block;
+    left: 0;
+    position: relative;
+    top: 0;
+    width: 100%;
+  }
+}

--- a/views/pulsar/layouts/base.html.twig
+++ b/views/pulsar/layouts/base.html.twig
@@ -80,6 +80,7 @@
     {% block pageStyle %}{% endblock %}
 </head>
 <body class="language-html theme-slate">
+<a class="skip-link" href="#skip-target">Skip to main content</a>
 
 {% block body %}
     <div role="main" class="container" id="top">
@@ -150,7 +151,9 @@
                     {% endif %}
 
                     {% block tabs_list %}{% endblock %}
-                    {% block tabs_content %}{% endblock %}
+                    <div id="skip-target">
+                        {% block tabs_content %}{% endblock %}
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
Required for Pulsar UIs to meet 2.4.1 Bypass Blocks: (Level A)

Skip link is hidden until `tab` key is pressed, a new wrapper element has been added to the base template around tab contents to act as the target.

![screen shot 2018-08-07 at 12 28 19](https://user-images.githubusercontent.com/18653/43773468-b5e8f572-9a3d-11e8-8b3d-8856a86aae21.png)