### PR TITLE
Restore tab functionality with the presence of the new bypass block markup

### DIFF
--- a/stylesheets/_layout.tabs.scss
+++ b/stylesheets/_layout.tabs.scss
@@ -94,7 +94,7 @@
     width: 100%;
 
     // show/hide tab panes
-    > .tab__pane {
+    .tab__pane {
         display: none;
 
         &.is-active {


### PR DESCRIPTION
Adding a new wrapping div meant the descendant selector was no longer hiding tab panes.