### PR TITLE
Make sure nav helper correctly parses CMS heading IDs

### DIFF
--- a/views/pulsar/v2/helpers/nav.html.twig
+++ b/views/pulsar/v2/helpers/nav.html.twig
@@ -29,7 +29,7 @@
                 {% if options.items is defined and options.items is iterable %}
 
                     <div class="nav-list" data-nav="{{ options.href }}">
-                        <h2 class="nav-item nav-item--header t-nav-header" id="aria-secondary-nav-heading-{{ options.label|raw }}">{{ options.label|raw }}</h2>
+                        <h2 class="nav-item nav-item--header t-nav-header" id="aria-secondary-nav-heading-{{ options.label|striptags|replace(' ', '-')|raw }}">{{ options.label|raw }}</h2>
 
                         <ul class="nav-items">
                             {% set heading_id = 'aria-secondary-nav-heading-' ~ options.label|raw %}
@@ -80,7 +80,7 @@
                    {% if options.items is defined and options.items is iterable %}
 
                        <div class="nav-list" data-nav="{{ options.href }}">
-                           <h2 class="nav-item nav-item--header t-nav-header" id="aria-quaternary-nav-heading-{{options.label|raw}}">{{ options.label|raw }}</h2>
+                           <h2 class="nav-item nav-item--header t-nav-header" id="aria-quaternary-nav-heading-{{ options.label|striptags|replace(' ', '-')|raw }}">{{ options.label|raw }}</h2>
                            {% set heading_id = 'aria-quaternary-nav-heading-' ~ options.label|raw %}
 
                            <ul class="nav-items">
@@ -120,7 +120,7 @@
             )
         }}
     >
-        <a {{ attributes(options|only('href data-toggle')) }} {% if heading_id is not null %} aria-describedby="{{ heading_id }}"{% endif %} class="nav-link t-nav-link" {% if options.class is defined and 'is-active' in options.class %} aria-current="page" {% endif %} {% if options.href starts with '#' %} aria-haspopup="true" aria-expanded="false" {% if aria_controls is not null %}aria-controls="{{ aria_controls }}"{% endif %}{% endif %}>
+        <a {{ attributes(options|only('href data-toggle')) }} {% if heading_id is not null %} aria-describedby="{{ heading_id|striptags|replace(' ', '-') }}"{% endif %} class="nav-link t-nav-link" {% if options.class is defined and 'is-active' in options.class %} aria-current="page" {% endif %} {% if options.href starts with '#' %} aria-haspopup="true" aria-expanded="false" {% if aria_controls is not null %}aria-controls="{{ aria_controls }}"{% endif %}{% endif %}>
             {% if options.icon is defined and options.icon is not empty %}
                 {{ html.icon(options.icon, { 'class': 'icon-fw nav-link__icon t-nav-icon' }) }}
             {% elseif options.image is defined and options.image is not empty %}


### PR DESCRIPTION
CMS uses labels with an embedded HTML comment, presumably for legacy ordering purposes.

```
<!-- a -->Publishing
```

This value is passed to the heading as an `id`, and nav links as `aria-describedby`, but the HTML comment causes issues with automated accessibility testing tools (like SiteImprove) which flag it as a failure of **3.3.2 Labels or Instructions: (Level A)**.

This fix strips the comment, and also replaces spaces with hyphens to make sure the `XForms Pro` label doesn't break when turned into an `id`.

## Breaking change checklist

The following points should be considered as an early-warning of introducing a breaking change to a Continuum platform product. This is not an exhaustive list of what constitutes a breaking change.

| Does this pull request... | Yes / No |
| ---- | ---- |
| require changes to `main.js` | No |
| require changes to `index.js` | No |
| require changes to `pulsar.scss` | No |
| require changes to `gruntfile.js` | No |
| require changes to `package.json` (not including dev dependencies) | No |
| require changes to `base.html.twig` (or other core views like header/footer) | No |
| require new arguments to be passed to a js component | No |
| require markup changes to maintain functionality | No |