### PR TITLE
Improve labelling of main navigation links

### DIFF
--- a/views/pulsar/v2/helpers/nav.html.twig
+++ b/views/pulsar/v2/helpers/nav.html.twig
@@ -120,7 +120,7 @@
             )
         }}
     >
-        <a {{ attributes(options|only('href data-toggle')) }} {% if heading_id is not null %} aria-describedby="{{ heading_id }}"{% endif %} class="nav-link t-nav-link" {% if options.class is defined and 'is-active' in options.class %} aria-current="page" {% endif %} {% if options.href starts with '#' %} aria-haspopup="true" aria-expanded="false" {% if aria_controls is not null %}aria-controls="{{ aria_controls }}"{% endif %}{% endif %}>
+        <a {{ attributes(options|only('href data-toggle')) }} {% if heading_id is not null %} aria-labelledby="{{ heading_id }}"{% endif %} class="nav-link t-nav-link" {% if options.class is defined and 'is-active' in options.class %} aria-current="page" {% endif %} {% if options.href starts with '#' %} aria-haspopup="true" aria-expanded="false" {% if aria_controls is not null %}aria-controls="{{ aria_controls }}"{% endif %}{% endif %}>
             {% if options.icon is defined and options.icon is not empty %}
                 {{ html.icon(options.icon, { 'class': 'icon-fw nav-link__icon t-nav-icon' }) }}
             {% elseif options.image is defined and options.image is not empty %}


### PR DESCRIPTION
Currently, SiteImprove raises errors with the main navigation links, this is particularly an issue in cases where multiple modules use the same link text (like 'settings').

**2.4.4 Link Purpose (In Context) Level A**
> The same link text is used for links going to different destinations. Users might not know the difference if they are not somehow explained.
>
> If the destination page is the same, this is not an issue.
>
>If the destination pages are not the same, make sure the links can be distinguished by their link texts or WAI-ARIA labels ('aria-labelledby' or 'aria-label') alone to make the difference clear to all users.

This PR changes our use of `aria-describedby` to `aria-labelledby`, which means that a settings link in the utilities menu would now be announced as "settings, utilities".

It also helps to make sure users know which module they're in while navigating around the main navigation with a screen reader.

## Breaking change checklist

The following points should be considered as an early-warning of introducing a breaking change to a Continuum platform product. This is not an exhaustive list of what constitutes a breaking change.

| Does this pull request... | Yes / No |
| ---- | ---- |
| require changes to `main.js` | No |
| require changes to `index.js` | No |
| require changes to `pulsar.scss` | No |
| require changes to `gruntfile.js` | No |
| require changes to `package.json` (not including dev dependencies) | No |
| require changes to `base.html.twig` (or other core views like header/footer) | No |
| require new arguments to be passed to a js component | No |
| require markup changes to maintain functionality | ⚠️ Hardcoded navigation in CMS will need updating, although this is not a breaking change |