### PR TITLE
Documentation change to lexicon to demonstrate how to mark up notifications links

### DIFF
--- a/views/lexicon/includes/notifications.html.twig
+++ b/views/lexicon/includes/notifications.html.twig
@@ -30,14 +30,14 @@
                             >
                             <i class="icon-remove"><span class="hide">Close notifications</span></i>
                         </button>
-                        <p>CMS Continuum #29 now available.</p>
+                        <p id="notification-heading-1">CMS Continuum #29 now available.</p>
                         <span class="small-type muted">2 minutes ago</span>
 
                         <span class="divider"></span>
 
                         <p>We've updated our user manual to feature our new and improved user interface. If you need a copy, drop us a message and we'll be happy to send one over.</p>
 
-                        <p><i class="icon-file-text-alt"></i> <a href="#">View detailed release notes</a></p>
+                        <p><i class="icon-file-text-alt"></i> <a href="#" aria-labelledby="notification-heading-1">View detailed release notes</a></p>
                     </div>
                 </div>
             </div>
@@ -58,14 +58,14 @@
                             >
                             <i class="icon-remove"><span class="hide">Dismiss this notification</span></i>
                         </button>
-                        <p>CMS Continuum #29 now available.</p>
+                        <p id="notification-heading-2">CMS Continuum #29 now available.</p>
                         <span class="small-type muted">2 minutes ago</span>
 
                         <span class="divider"></span>
 
                         <p>We've updated our user manual to feature our new and improved user interface. If you need a copy, drop us a message and we'll be happy to send one over.</p>
 
-                        <p><i class="icon-file-text-alt"></i> <a href="#">View detailed release notes</a></p>
+                        <p><i class="icon-file-text-alt"></i> <a href="#" aria-labelledby="notification-heading-2">View detailed release notes</a></p>
                     </div>
                 </div>
             </div>
@@ -86,14 +86,14 @@
                             >
                             <i class="icon-remove"><span class="hide">Dismiss this notification</span></i>
                         </button>
-                        <p>CMS Continuum #29 now available.</p>
+                        <p id="notification-heading-3">CMS Continuum #29 now available.</p>
                         <span class="small-type muted">2 minutes ago</span>
 
                         <span class="divider"></span>
 
                         <p>We've updated our user manual to feature our new and improved user interface. If you need a copy, drop us a message and we'll be happy to send one over.</p>
 
-                        <p><i class="icon-file-text-alt"></i> <a href="#">View detailed release notes</a></p>
+                        <p><i class="icon-file-text-alt"></i> <a href="#" aria-labelledby="notification-heading-3">View detailed release notes</a></p>
                     </div>
                 </div>
             </div>
@@ -114,14 +114,14 @@
                             >
                             <i class="icon-remove"><span class="hide">Dismiss this notification</span></i>
                         </button>
-                        <p>CMS Continuum #29 now available.</p>
+                        <p id="notification-heading-4">CMS Continuum #29 now available.</p>
                         <span class="small-type muted">2 minutes ago</span>
 
                         <span class="divider"></span>
 
                         <p>We've updated our user manual to feature our new and improved user interface. If you need a copy, drop us a message and we'll be happy to send one over.</p>
 
-                        <p><i class="icon-file-text-alt"></i> <a href="#">View detailed release notes</a></p>
+                        <p><i class="icon-file-text-alt"></i> <a href="#" aria-labelledby="notification-heading-4">View detailed release notes</a></p>
                     </div>
                 </div>
             </div>
@@ -142,14 +142,14 @@
                             >
                             <i class="icon-remove"><span class="hide">Dismiss this notification</span></i>
                         </button>
-                        <p>CMS Continuum #29 now available.</p>
+                        <p id="notification-heading-5">CMS Continuum #29 now available.</p>
                         <span class="small-type muted">2 minutes ago</span>
 
                         <span class="divider"></span>
 
                         <p>We've updated our user manual to feature our new and improved user interface. If you need a copy, drop us a message and we'll be happy to send one over.</p>
 
-                        <p><i class="icon-file-text-alt"></i> <a href="#">View detailed release notes</a></p>
+                        <p><i class="icon-file-text-alt"></i> <a href="#" aria-labelledby="notification-heading-5">View detailed release notes</a></p>
                     </div>
                 </div>
             </div>
@@ -170,14 +170,14 @@
                             >
                             <i class="icon-remove"><span class="hide">Dismiss this notification</span></i>
                         </button>
-                        <p>CMS Continuum #29 now available.</p>
+                        <p id="notification-heading-6">CMS Continuum #29 now available.</p>
                         <span class="small-type muted">2 minutes ago</span>
 
                         <span class="divider"></span>
 
                         <p>We've updated our user manual to feature our new and improved user interface. If you need a copy, drop us a message and we'll be happy to send one over.</p>
 
-                        <p><i class="icon-file-text-alt"></i> <a href="#">View detailed release notes</a></p>
+                        <p><i class="icon-file-text-alt"></i> <a href="#" aria-labelledby="notification-heading-6">View detailed release notes</a></p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This is a documentation change only, products have implemented their own notifications partials.

This change is required to meet the following condition.

**2.4.4 Link Purpose (In Context) Level A**
> The same link text is used for links going to different destinations. Users might not know the difference if they are not somehow explained.
>
> If the destination page is the same, this is not an issue.
>
>If the destination pages are not the same, make sure the links can be distinguished by their link texts or WAI-ARIA labels ('aria-labelledby' or 'aria-label') alone to make the difference clear to all users.