### PR TITLE
Fix no-wrap issues on collapsing datatables

### DIFF
--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -75,8 +75,6 @@ a.dt-button {
     // scss-lint:disable SelectorFormat
     td,
     th {
-        white-space: nowrap;
-
         &.sorting:hover,
         &.sorting_asc:hover,
         &.sorting_desc:hover {


### PR DESCRIPTION
Fixes #870 

After changes in this branch:

**Long col header example**

<img width="951" alt="screen shot 2018-08-14 at 11 25 32" src="https://user-images.githubusercontent.com/756393/44086994-49d01b80-9fb6-11e8-950a-7db376e13cba.png">

**Long cell value**

<img width="1120" alt="screen shot 2018-08-14 at 11 24 44" src="https://user-images.githubusercontent.com/756393/44087009-516fb1ac-9fb6-11e8-8df4-04ac533c9811.png">

**Responsive example**

![screen shot 2018-08-14 at 11 37 09](https://user-images.githubusercontent.com/756393/44087042-6a259ce8-9fb6-11e8-90ff-662899a1a1a3.png)
