### PR TITLE
Improved accessibility of toggle switches

### DIFF
--- a/stylesheets/_component.toggle-switch.scss
+++ b/stylesheets/_component.toggle-switch.scss
@@ -81,6 +81,7 @@
     }
 
     &::after {
+        color: color(white);
         content: '\F00C \F00D';
         font-family: 'FontAwesome';
         font-size: 14px;
@@ -116,4 +117,13 @@
 
 .toggle-switch.is-disabled + .toggle-switch-label {
     opacity: .5;
+}
+
+.toggle-switch-wrapper-label {
+    display: block;
+
+    .control__label {
+        padding-top: 11px;
+        padding-right: 10px;
+    }
 }

--- a/stylesheets/_structure.forms.scss
+++ b/stylesheets/_structure.forms.scss
@@ -12,7 +12,8 @@
     width: 100%;
 
     // the main label, usually placed in the left hand column
-    > .control__label {
+    > .control__label,
+    span.control__label {
         @include col-span($form-label-cols);
         word-wrap: break-word;
     }

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-class.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-class.html
@@ -1,5 +1,5 @@
 <div class="form__group foo form__group--toggle">
-    <label class="toggle-switch-wrapper-label" for="toggletest" >
+    <label class="toggle-switch-wrapper-label" for="toggletest">
         <span class="control__label">Toggle</span>
         <span class="controls">
             <input id="toggletest" type="checkbox" class="form__control toggle-switch" />

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-class.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-class.html
@@ -1,9 +1,9 @@
 <div class="form__group foo form__group--toggle">
-    <label class="control__label">Toggle</label>
-    <div class="controls">
-        <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
-        <label for="toggletest" class="control__label toggle-switch-label">
-            <span class="hide">Toggle</span>
-        </label>
-    </div>
+    <label class="toggle-switch-wrapper-label" for="toggletest" >
+        <span class="control__label">Toggle</span>
+        <span class="controls">
+            <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
+            <span class="toggle-switch-label"></span>
+        </span>
+    </label>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-error.html
@@ -1,5 +1,5 @@
 <div class="form__group has-error  form__group--toggle">
-    <label class="toggle-switch-wrapper-label" for="toggletest" >
+    <label class="toggle-switch-wrapper-label" for="toggletest">
         <span class="control__label">Toggle</span>
         <span class="controls">
             <input id="toggletest" type="checkbox" class="form__control toggle-switch" />

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-error.html
@@ -1,10 +1,10 @@
-<div class="form__group has-error form__group--toggle">
-    <label class="control__label">Toggle</label>
-    <div class="controls">
-        <input id="toggletest" type="checkbox" aria-describedby="guid-1" aria-invalid="true" class="form__control toggle-switch" />
-        <label for="toggletest" class="control__label toggle-switch-label">
-            <span class="hide">Toggle</span>
-        </label>
-        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
-    </div>
+<div class="form__group has-error  form__group--toggle">
+    <label class="toggle-switch-wrapper-label" for="toggletest" >
+        <span class="control__label">Toggle</span>
+        <span class="controls">
+            <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
+            <span class="toggle-switch-label"></span>
+            <span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        </span>
+    </label>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance-container.html
@@ -1,5 +1,5 @@
 <div class="form__group  form__group--toggle">
-    <label class="toggle-switch-wrapper-label" for="toggletest" >
+    <label class="toggle-switch-wrapper-label" for="toggletest">
         <span class="control__label">Toggle <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></span>
         <span class="controls">
             <input id="toggletest" type="checkbox" class="form__control toggle-switch" />

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance-container.html
@@ -1,9 +1,9 @@
-<div class="form__group form__group--toggle">
-    <label class="control__label">Toggle <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></label>
-    <div class="controls">
-        <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
-        <label for="toggletest" class="control__label toggle-switch-label">
-            <span class="hide">Toggle</span>
-        </label>
-    </div>
+<div class="form__group  form__group--toggle">
+    <label class="toggle-switch-wrapper-label" for="toggletest" >
+        <span class="control__label">Toggle <i data-container="baz" data-content="bar" data-placement="top" rel="clickover" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></span>
+        <span class="controls">
+            <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
+            <span class="toggle-switch-label"></span>
+        </span>
+    </label>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance.html
@@ -1,5 +1,5 @@
 <div class="form__group  form__group--toggle">
-    <label class="toggle-switch-wrapper-label" for="toggletest" >
+    <label class="toggle-switch-wrapper-label" for="toggletest">
         <span class="control__label">Toggle <i data-container="body" data-content="bar" data-placement="top" rel="clickover" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></span>
         <span class="controls">
             <input id="toggletest" type="checkbox" class="form__control toggle-switch" />

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-guidance.html
@@ -1,9 +1,9 @@
-<div class="form__group form__group--toggle">
-    <label class="control__label">Toggle <i data-container="body" data-content="bar" data-placement="top" rel="clickover" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></label>
-    <div class="controls">
-        <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
-        <label for="toggletest" class="control__label toggle-switch-label">
-            <span class="hide">Toggle</span>
-        </label>
-    </div>
+<div class="form__group  form__group--toggle">
+    <label class="toggle-switch-wrapper-label" for="toggletest" >
+        <span class="control__label">Toggle <i data-container="body" data-content="bar" data-placement="top" rel="clickover" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></span>
+        <span class="controls">
+            <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
+            <span class="toggle-switch-label"></span>
+        </span>
+    </label>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-help.html
@@ -1,5 +1,5 @@
 <div class="form__group  form__group--toggle">
-    <label class="toggle-switch-wrapper-label" for="toggletest" >
+    <label class="toggle-switch-wrapper-label" for="toggletest">
         <span class="control__label">Toggle</span>
         <span class="controls">
             <input id="toggletest" type="checkbox" class="form__control toggle-switch" />

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-help.html
@@ -1,10 +1,10 @@
-<div class="form__group form__group--toggle">
-	<label class="control__label">Toggle</label>
-	<div class="controls">
-		<input id="toggletest" type="checkbox" aria-describedby="guid-1" class="form__control toggle-switch" />
-		<label for="toggletest" class="control__label toggle-switch-label">
-			<span class="hide">Toggle</span>
-		</label>
-		<span class="help-block" id="guid-1">my help text</span>
-	</div>
+<div class="form__group  form__group--toggle">
+    <label class="toggle-switch-wrapper-label" for="toggletest" >
+        <span class="control__label">Toggle</span>
+        <span class="controls">
+            <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
+            <span class="toggle-switch-label"></span>
+            <span class="help-block">my help text</span>
+        </span>
+    </label>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-label-hide.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-label-hide.html
@@ -1,9 +1,9 @@
-<div class="form__group form__group--toggle">
-    <label class="control__label hide">Toggle</label>
-    <div class="controls">
-        <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
-        <label for="toggletest" class="control__label toggle-switch-label">
-            <span class="hide">Toggle</span>
-        </label>
-    </div>
+<div class="form__group  form__group--toggle">
+    <label class="toggle-switch-wrapper-label" for="toggletest" >
+        <span class="control__label hide">Toggle</span>
+        <span class="controls">
+            <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
+            <span class="toggle-switch-label"></span>
+        </span>
+    </label>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-label-hide.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-label-hide.html
@@ -1,5 +1,5 @@
 <div class="form__group  form__group--toggle">
-    <label class="toggle-switch-wrapper-label" for="toggletest" >
+    <label class="toggle-switch-wrapper-label" for="toggletest">
         <span class="control__label hide">Toggle</span>
         <span class="controls">
             <input id="toggletest" type="checkbox" class="form__control toggle-switch" />

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch.html
@@ -1,5 +1,5 @@
 <div class="form__group  form__group--toggle">
-    <label class="toggle-switch-wrapper-label" for="toggletest" >
+    <label class="toggle-switch-wrapper-label" for="toggletest">
         <span class="control__label">Toggle</span>
         <span class="controls">
             <input id="toggletest" type="checkbox" class="form__control toggle-switch" />

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch.html
@@ -1,9 +1,9 @@
-<div class="form__group form__group--toggle">
-    <label class="control__label">Toggle</label>
-    <div class="controls">
-        <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
-        <label for="toggletest" class="control__label toggle-switch-label">
-            <span class="hide">Toggle</span>
-        </label>
-    </div>
+<div class="form__group  form__group--toggle">
+    <label class="toggle-switch-wrapper-label" for="toggletest" >
+        <span class="control__label">Toggle</span>
+        <span class="controls">
+            <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
+            <span class="toggle-switch-label"></span>
+        </span>
+    </label>
 </div>

--- a/views/pulsar/v2/helpers/elem.html.twig
+++ b/views/pulsar/v2/helpers/elem.html.twig
@@ -124,7 +124,7 @@ name    | string | The name of this control
             {{- options.label|raw -}}
             {{ util.required(options.required|default(false)) }}
             {{ util.guidance(options.guidance|default, { 'guidance-container': options['guidance-container']|default }) }}
-        </{{tag}}>
+        </{{ tag }}>
     {% endif %}
 
 {% endspaceless %}

--- a/views/pulsar/v2/helpers/elem.html.twig
+++ b/views/pulsar/v2/helpers/elem.html.twig
@@ -109,19 +109,22 @@ name    | string | The name of this control
         {% set labelVisibilityClass = ' hide' %}
     {% endif %}
 
+    {% set tag = 'label' %}
+    {% if options.tag is defined and options.tag == 'span' %}
+        {% set tag = 'span' %}
+    {% endif %}
+
     {% if options.label is not empty or options.guidance is not empty %}
-        <label{{
-            attributes(options
-                |exclude('container guidance guidance-container label required show-label')
-                |defaults({
-                    'class': 'control__label' ~ labelVisibilityClass|default
-                })
-            )
-        }}>
+        <{{ attributes(options
+            |exclude('container guidance guidance-container label required show-label tag ' ~ (tag == 'span' ? 'for'))
+            |defaults({
+                'class': 'control__label' ~ labelVisibilityClass|default
+            }), {'tag': (tag)}) }}>
+
             {{- options.label|raw -}}
             {{ util.required(options.required|default(false)) }}
             {{ util.guidance(options.guidance|default, { 'guidance-container': options['guidance-container']|default }) }}
-        </label>
+        </{{tag}}>
     {% endif %}
 
 {% endspaceless %}

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -1275,7 +1275,7 @@ controls.class    | string | A space separated list of class names
 
         {% if options.parent.bare is not defined or options.parent.bare != true %}
             <{{ attributes(options|defaults({
-                'class': 'controls' ~ (options.controls.class is defined ? options.controls.class)
+                'class': 'controls ' ~ (options.controls.class is defined ? options.controls.class)
             }), {'tag': ((isToggleSwitch) ? 'span' : 'div')}) }}>
         {% endif %}
 

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -1241,6 +1241,11 @@ controls.class    | string | A space separated list of class names
         {% set showLabel = false %}
     {% endif %}
 
+    {% set isToggleSwitch = false %}
+    {% if options.parent.class is defined and 'form__group--toggle' in options.parent.class %}
+        {% set isToggleSwitch = true %}
+    {% endif %}
+
     {% if options.parent.bare is not defined or options.parent.bare != true %}
     <div{{
         attributes(options.parent
@@ -1252,6 +1257,10 @@ controls.class    | string | A space separated list of class names
     -}}>
     {% endif %}
 
+        {% if isToggleSwitch %}
+        <label class="toggle-switch-wrapper-label" {% if options.parent.id is defined and options.parent.id is not empty %}for="{{ options.parent.id|default }}" {% endif %}>
+        {% endif %}
+
         {{
             elem.label({
                 'for': options.parent.id|default,
@@ -1260,11 +1269,14 @@ controls.class    | string | A space separated list of class names
                 'show-label': showLabel,
                 'required': options.parent.required|default,
                 'guidance-container': options.parent['guidance-container']|default,
+                'tag': (isToggleSwitch) ? 'span' : 'label'
             })
         }}
 
         {% if options.parent.bare is not defined or options.parent.bare != true %}
-        <div class="controls{% if options.controls.class is defined %} {{ options.controls.class }}{% endif %}">
+            <{{ attributes(options|defaults({
+                'class': 'controls' ~ (options.controls.class is defined ? options.controls.class)
+            }), {'tag': ((isToggleSwitch) ? 'span' : 'div')}) }}>
         {% endif %}
 
         {% set input_group_classes = '' %}
@@ -1349,12 +1361,22 @@ controls.class    | string | A space separated list of class names
             {{ form.error({ 'value': options.parent.error|default }) }}
         {% endif %}
 
-        {% if options.parent.help is defined and options.parent.help is not empty and options.parent.help_id is defined and options.parent.help_id is not empty %}
-            {{ form.help({ 'value': options.parent.help|default, 'id': options.parent.help_id }) }}
+        {% if isToggleSwitch %}
+            {% if options.parent.help is defined and options.parent.help is not empty %}
+                {{ form.help({ 'value': options.parent.help|default }) }}
+            {% endif %}
+        {% else %}
+            {% if options.parent.help is defined and options.parent.help is not empty and options.parent.help_id is defined and options.parent.help_id is not empty %}
+                {{ form.help({ 'value': options.parent.help|default, 'id': options.parent.help_id }) }}
+            {% endif %}
         {% endif %}
 
         {% if options.parent.bare is not defined or options.parent.bare != true %}
-        </div>
+            </{{(isToggleSwitch) ? 'span' : 'div' }}>
+        {% endif %}
+
+        {% if isToggleSwitch %}
+        </label>
         {% endif %}
     {% if options.parent.bare is not defined or options.parent.bare != true %}
     </div>
@@ -2274,8 +2296,6 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {% set toggleLabel = '<span class="hide">' ~ options.label ~ '</span>' %}
 
-    {% set options = modify_options(options|default({})) %}
-
     {%
         set toggle = elem.input(options
             |exclude('error guidance guidance-container show-label label help')
@@ -2283,17 +2303,13 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
                 'class': 'toggle-switch',
                 'type': 'checkbox'
             })
-        ) ~ elem.label({
-                'class': 'toggle-switch-label',
-                'for': options.id|default,
-                'label': toggleLabel
-            })
+        ) ~ '<span class="toggle-switch-label"></span>'
     %}
 
     {{
         form.group({
             'parent': options
-                |only('bare class error error_ids guidance guidance-container help help_id label required show-label')
+                |only('bare class error error_ids guidance guidance-container help help_id label required show-label id')
                 |merge({
                     'class': options.class|default ~ ' form__group--toggle'
                 }),

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -1258,7 +1258,7 @@ controls.class    | string | A space separated list of class names
     {% endif %}
 
         {% if isToggleSwitch %}
-        <label class="toggle-switch-wrapper-label" {% if options.parent.id is defined and options.parent.id is not empty %}for="{{ options.parent.id|default }}" {% endif %}>
+        <label class="toggle-switch-wrapper-label"{% if options.parent.id is defined and options.parent.id is not empty %} for="{{ options.parent.id }}"{% endif %}>
         {% endif %}
 
         {{
@@ -1372,7 +1372,7 @@ controls.class    | string | A space separated list of class names
         {% endif %}
 
         {% if options.parent.bare is not defined or options.parent.bare != true %}
-            </{{(isToggleSwitch) ? 'span' : 'div' }}>
+            </{{ (isToggleSwitch) ? 'span' : 'div' }}>
         {% endif %}
 
         {% if isToggleSwitch %}
@@ -2309,7 +2309,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
     {{
         form.group({
             'parent': options
-                |only('bare class error error_ids guidance guidance-container help help_id label required show-label id')
+                |only('bare class error error_ids guidance guidance-container help help_id id label required show-label')
                 |merge({
                     'class': options.class|default ~ ' form__group--toggle'
                 }),


### PR DESCRIPTION
Previously there where a number of issues with toggle switches, these include:
- not being able to click the control label to activate the toggle
- an orphaned control label, not associated with a form control

This branch changes the the mark up of toggle switches fixing the above issues. The changes are backwards compatible so any existing toggle switches using raw mark up will be un effected though should be updated to use the `toggle_switch` helper or new mark up to address the above issues.

Browser tested in:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [x] IE9-11

Screen reader tested in:
- [x] JAWS 2018
- [x] JAWS 18
- [x] NVDA
- [x] VO