### PR TITLE
[886] Add Placeholder Initialization Functionality for Date Helpers

### DIFF
--- a/js/PulsarFormComponent.js
+++ b/js/PulsarFormComponent.js
@@ -109,7 +109,7 @@ PulsarFormComponent.prototype.initDatePickers = function () {
         // Initialize pikaday with the correct date format
         $(element).pikaday({ format: defaultDateFormat });
 
-        //Initialize placeholder attribute based on the date format
+        // Initialize placeholder attribute based on the date format
         $(element).attr('placeholder', defaultDateFormat.toLowerCase());
     });
 }

--- a/js/PulsarFormComponent.js
+++ b/js/PulsarFormComponent.js
@@ -89,6 +89,8 @@ PulsarFormComponent.prototype.initDatePickers = function () {
     datepickers.each((index, element) => {
         let dateFormat = element.getAttribute('data-format');
 
+        // Check if data-format attribute exists and lowercase it
+        // to eliminate different styles of writing issues
         if (dateFormat !== null) {
             dateFormat = dateFormat.toLowerCase();
         }
@@ -106,6 +108,9 @@ PulsarFormComponent.prototype.initDatePickers = function () {
 
         // Initialize pikaday with the correct date format
         $(element).pikaday({ format: defaultDateFormat });
+
+        //Initialize placeholder attribute based on the date format
+        $(element).attr('placeholder', defaultDateFormat.toLowerCase());
     });
 }
 

--- a/tests/js/web/PulsarFormComponentTest.js
+++ b/tests/js/web/PulsarFormComponentTest.js
@@ -276,6 +276,19 @@ describe('PulsarFormComponent', function() {
             expect($.fn.pikaday).to.have.been.calledWith({ format: 'YYYY/MM/DD' });
         });
 
+        it('should have "dd/mm/yyyy" as a placeholder for inputs with "default" or no option at all', function() {
+            expect(this.$datepicker.attr('placeholder')).to.equal('dd/mm/yyyy');
+            expect(this.$datepickerDefault.attr('placeholder')).to.equal('dd/mm/yyyy');
+        });
+
+        it('should have "mm/dd/yyyy" as a placeholder for inputs with "us" option', function() {
+            expect(this.$datepickerUS.attr('placeholder')).to.equal('mm/dd/yyyy');
+        });
+
+        it('should have "yyyy/mm/dd" as a placeholder for inputs with "reverse" option', function() {
+            expect(this.$datepickerReverse.attr('placeholder')).to.equal('yyyy/mm/dd');
+        });
+
     });
 
     describe('Timepickers', function() {
@@ -288,9 +301,11 @@ describe('PulsarFormComponent', function() {
         it('should call the timePickerComponents init method', function() {
             expect(this.pulsarForm.timePickerComponent.init).to.have.been.called;
         });
+
     });
 
     describe('refresh', function () {
+
         beforeEach(function () {
             this.$html.append('<div class="js-colorpicker"></div>');
         });
@@ -312,5 +327,6 @@ describe('PulsarFormComponent', function() {
 
             expect($.fn.timepicker).to.have.been.calledOnce;
         });
+
     });
 });


### PR DESCRIPTION
This PR is for date helpers without the placeholder option. It initializes the input field with the correct placeholder text to order accurately the letters of days, months and years.

Issue: #886 

![dateformat-without-placeholder](https://user-images.githubusercontent.com/1425876/46006657-f3fc2d00-c0af-11e8-89e9-c4e365638a49.gif)
