### PR TITLE
Improved focus styles

### DIFF
--- a/stylesheets/_component.breadcrumb.scss
+++ b/stylesheets/_component.breadcrumb.scss
@@ -13,4 +13,9 @@
     a:hover {
         color: color(link); // must be AA 4.5:1
     }
+
+    a:focus {
+        outline: 3px solid color(border, focus);
+        color: color(link, focus);
+    }
 }

--- a/stylesheets/_component.button-groups.scss
+++ b/stylesheets/_component.button-groups.scss
@@ -31,6 +31,11 @@
         border-right: 1px solid #ccc;
     }
 
+    .form__control:focus + .control__label {
+        outline: 3px solid #ffbf47;
+        outline-offset: 2px;
+    }
+
     @each $state, $state-color, $state-color-alt in $state-colors {
         > .btn--#{$state}:not(:first-of-type):not(.btn--naked):not(.edit-button):not(.remove-button) {
             border-left-color: darken(color($state), 10);

--- a/stylesheets/_component.buttons.scss
+++ b/stylesheets/_component.buttons.scss
@@ -69,6 +69,10 @@ $btn-white:                 'white';
       border: 0;
       padding: 0;
     }
+
+    &:focus {
+        outline: 3px solid color(border, focus);
+    }
 }
 
 /**

--- a/stylesheets/_component.buttons.scss
+++ b/stylesheets/_component.buttons.scss
@@ -72,6 +72,7 @@ $btn-white:                 'white';
 
     &:focus {
         outline: 3px solid color(border, focus);
+        outline-offset: 3px;
     }
 }
 

--- a/stylesheets/_component.close.scss
+++ b/stylesheets/_component.close.scss
@@ -10,6 +10,10 @@
     color: color(black);
     cursor: pointer;
   }
+
+  &:focus {
+    outline: 3px solid color(border, focus);
+  }
 }
 
 // Additional properties for button version

--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -90,6 +90,7 @@ a.dt-button {
         &.sorting_asc:focus,
         &.sorting_desc:focus {
             outline: 3px solid color(border, focus);
+            outline-offset: -3px;
         }
 
         &.sorting::after,
@@ -205,7 +206,7 @@ th.sorting_disabled:hover {
         &:focus {
             border: 1px solid color(primary);
             outline: 3px solid color(border, focus);
-            outline-offset: 0;
+            outline-offset: 2px;
         }
     }
 }

--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -86,6 +86,12 @@ a.dt-button {
             }
         }
 
+        &.sorting:focus,
+        &.sorting_asc:focus,
+        &.sorting_desc:focus {
+            outline: 3px solid color(border, focus);
+        }
+
         &.sorting::after,
         &.sorting_asc::after,
         &.sorting_desc::after {
@@ -198,8 +204,8 @@ th.sorting_disabled:hover {
 
         &:focus {
             border: 1px solid color(primary);
-            box-shadow: inset 0 0 0 1px color(primary);
-            outline: none;
+            outline: 3px solid color(border, focus);
+            outline-offset: 0;
         }
     }
 }
@@ -238,6 +244,10 @@ th.sorting_disabled:hover {
 
 .paginate_button {
     padding: 5px;
+
+    &:focus {
+        outline: 3px solid color(border, focus);
+    }
 }
 
 // scss-lint:enable SelectorFormat

--- a/stylesheets/_component.flash.scss
+++ b/stylesheets/_component.flash.scss
@@ -40,6 +40,10 @@
     a {
         color: inherit;
         text-decoration: underline;
+
+        &:focus {
+            color: color(white);
+        }
     }
 }
 

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -239,9 +239,10 @@ fieldset {
     }
 
     &:focus {
-        border: 1px solid color(primary);
-        box-shadow: 0 0 0 1px color(primary);
-        outline: none;
+        border: 1px solid color(black);
+        box-shadow: 0 0 0 1px color(black);
+        outline: 3px solid color(border, focus);
+        outline-offset: 2px;
     }
 }
 
@@ -556,8 +557,8 @@ fieldset {
     }
 
     &:focus {
-        border-color: color(primary);
-        box-shadow: 0 0 0 2px color(primary);
+        border-color: color(black);
+        box-shadow: 0 0 0 2px color(black);
     }
 
     &::before {

--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -260,6 +260,10 @@
         color: color(white);
     }
 
+    .nav-link:focus {
+        outline: 3px solid color(border, focus);
+    }
+
     .nav-link.is-active:hover,
     .nav-link.is-active:focus {
         background-color: $nav-color-dark;
@@ -419,7 +423,8 @@
 
 .jadu-branding {
     display: block;
-    margin: 10px 0 4px;
+    margin-top: 3px;
+    padding: 10px 0 4px;
     text-decoration: none;
 
     &.is-active {
@@ -467,16 +472,21 @@
     border: 0;
     color: color(white);
     display: none;
-    padding: 0 20px 23px;
-    text-decoration: none;
+    margin-bottom: 23px;
     margin-top: 24px;
+    padding: 0 20px;
     text-align: right;
+    text-decoration: none;
     width: 100%;
 
     &:hover i::before,
     &:focus i::before {
         content: '\f0a8';
         color: color(white);
+    }
+
+    &:focus {
+        outline: 3px solid color(border, focus);
     }
 
     .nav-secondary.is-open &,

--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -194,6 +194,11 @@
         background: $nav-color-dark;
         color: color(white);
     }
+
+    &:focus {
+        outline: 3px solid color(border, focus);
+        outline-offset: 2px;
+    }
 }
 
 .nav-items {

--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -214,6 +214,10 @@
 .nav-link {
     color: color(white);
     text-decoration: none;
+
+    &:focus {
+        outline: 3px solid color(border, focus);
+    }
 }
 
 .nav-primary {
@@ -258,10 +262,6 @@
     .nav-link:focus {
         background-color: darken($nav-color-dark, 2%);
         color: color(white);
-    }
-
-    .nav-link:focus {
-        outline: 3px solid color(border, focus);
     }
 
     .nav-link.is-active:hover,

--- a/stylesheets/_component.progress-lists.scss
+++ b/stylesheets/_component.progress-lists.scss
@@ -99,11 +99,16 @@
             }
         }
     }
+
+    &:focus .progress-list__label {
+        outline: 3px solid color(border, focus);
+    }
 }
 
 .progress-list__label {
     @include word-break-all;
 
+    color: color(black);
     display: inline-block;
     position: relative;
     text-align: left;
@@ -134,6 +139,10 @@
 
     .badge {
         color: color(white) !important;
+    }
+
+    .progress-list__label {
+        color: color(success, alt);
     }
 
     &:not(:last-child)::after {
@@ -170,6 +179,10 @@
 
     .badge {
         color: color(white) !important;
+    }
+
+    .progress-list__label {
+        color: color(primary, alt);
     }
 
     &:not(:last-child)::after {

--- a/stylesheets/_component.range-slider.scss
+++ b/stylesheets/_component.range-slider.scss
@@ -4,13 +4,8 @@
     border-radius: 5px;
     display: block;
     height: 75px;
-    outline: none;
     overflow: visible;
     width: 100%;
-
-    &:focus {
-        outline: none;
-    }
 
     &::-ms-tooltip {
         display: none;
@@ -121,6 +116,8 @@
 
     &:focus {
         border: 0;
-        box-shadow: 0 0 0 2px white, 0 0 0 4px color(primary);
+        box-shadow: none;
+        outline: 3px solid color(border, focus);
+        outline-offset: 0;
     }
 }

--- a/stylesheets/_component.search.scss
+++ b/stylesheets/_component.search.scss
@@ -38,6 +38,10 @@ input.main-search__field {
     &::-webkit-input-placeholder {
         color: #555;
     }
+
+    &:focus {
+        outline: 3px solid color(border, focus);
+    }
 }
 
 input.main-search__field::-ms-clear {
@@ -57,6 +61,10 @@ input.main-search__field::-ms-clear {
     @include respond-min($screen-tablet) {
         left: 155px;
         right: auto;
+    }
+
+    &:focus {
+        outline: 3px solid color(border, focus);
     }
 }
 

--- a/stylesheets/_component.search.scss
+++ b/stylesheets/_component.search.scss
@@ -41,6 +41,7 @@ input.main-search__field {
 
     &:focus {
         outline: 3px solid color(border, focus);
+        outline-offset: 3px;
     }
 }
 

--- a/stylesheets/_component.select2.scss
+++ b/stylesheets/_component.select2.scss
@@ -332,8 +332,10 @@
 }
 
 .select2-container--default.select2-container--focus .select2-selection--multiple {
-    border: solid black 1px;
-    outline: 0;
+    border: 1px solid color(black);
+    box-shadow: 0 0 0 1px color(black);
+    outline: 3px solid color(border, focus);
+    outline-offset: 2px;
 }
 
 .select2-container--default.select2-container--disabled .select2-selection--multiple {
@@ -450,7 +452,10 @@
 }
 
 .select2-container--classic .select2-selection--single:focus {
-    border: 1px solid #5897fb;
+    border: 1px solid color(black);
+    box-shadow: 0 0 0 1px color(black);
+    outline: 3px solid color(border, focus);
+    outline-offset: 2px;
 }
 
 .select2-container--classic .select2-selection--single .select2-selection__rendered {
@@ -559,7 +564,10 @@
 }
 
 .select2-container--classic .select2-selection--multiple:focus {
-    border: 1px solid #5897fb;
+    border: 1px solid color(black);
+    box-shadow: 0 0 0 1px color(black);
+    outline: 3px solid color(border, focus);
+    outline-offset: 2px;
 }
 
 .select2-container--classic .select2-selection--multiple .select2-selection__rendered {
@@ -715,8 +723,9 @@ span.select2-selection.select2-selection--single {
 .select2-container--default.select2-container--open .select2-selection--single,
 .select2-container--default.select2-container--focus .select2-selection--single,
 .select2-container--default.select2-container--focus:focus .select2-selection--single {
-    border: 1px solid color(primary);
-    box-shadow: 0 0 0 1px color(primary);
-    outline: none;
+    border: 1px solid color(black);
+    box-shadow: 0 0 0 1px color(black);
+    outline: 3px solid color(border, focus);
+    outline-offset: 2px;
 }
 // scss-lint:enable all

--- a/stylesheets/_component.tab-help.scss
+++ b/stylesheets/_component.tab-help.scss
@@ -82,6 +82,10 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
     &:active {
         color: darken($nav-color-dark, 10%);
     }
+
+    &:focus {
+        outline: 3px solid color(border, focus);
+    }
 }
 
 .close-page-help {

--- a/stylesheets/_component.toggle-switch.scss
+++ b/stylesheets/_component.toggle-switch.scss
@@ -31,7 +31,8 @@
     }
 
     &:focus + .toggle-switch-label {
-        box-shadow: 0 0 0 2px white, 0 0 0 4px color(primary);
+        outline: 3px solid color(border, focus);
+        outline-offset: 1px;
     }
 
     &.toggle-switch--large + .toggle-switch-label {

--- a/stylesheets/_palette.base.scss
+++ b/stylesheets/_palette.base.scss
@@ -166,19 +166,22 @@ $palette-alias: (
         base:     #2a7da7, // WCAG 4.58:1 AA compliant
         dark:     darken(#2a7da7, 5),
         hover:    darken(#2a7da7, 5),
+        focus:    darken(#2a7da7, 15), // WCAG 5.39:1 AA compliant when used on color(background, focus)
         inverse:  #fff,
         inverse-hover: darken(#fff, 10%),
         disabled:  map-get(map-get($palette-monochromes, gray), lighter)
     ),
     border: (
-        base:      map-get(map-get($palette-monochromes, gray), lighter)
+        base:      map-get(map-get($palette-monochromes, gray), lighter),
+        focus:     #ffbf47
     ),
     background: (
         base:      map-get(map-get($palette-monochromes, gray), off-white),
         dark:      map-get(map-get($palette-monochromes, gray), lightest),
         light:     lighten(map-get(map-get($palette-monochromes, gray), off-white), 2),
-        selected:  map-get(map-get($palette-states, info), light)
-    )
+        selected:  map-get(map-get($palette-states, info), light),
+        focus:     #ffbf47
+    ),
 );
 
 

--- a/stylesheets/_structure.scaffolding.scss
+++ b/stylesheets/_structure.scaffolding.scss
@@ -42,14 +42,18 @@ body {
 }
 
 // Links
-
-a {
+a:link {
   color: color(link);
   cursor: pointer;
-}
 
-a:hover {
-  color: color(link, hover);
+  &:hover {
+    color: color(link, hover);
+  }
+
+  &:focus {
+    color: color(link, focus);
+    outline: 3px solid color(border, focus);
+  }
 }
 
 a.disabled {

--- a/stylesheets/_structure.scaffolding.scss
+++ b/stylesheets/_structure.scaffolding.scss
@@ -42,7 +42,7 @@ body {
 }
 
 // Links
-a:link {
+a {
   color: color(link);
   cursor: pointer;
 

--- a/stylesheets/_structure.scaffolding.scss
+++ b/stylesheets/_structure.scaffolding.scss
@@ -77,6 +77,8 @@ a.disabled {
   &:focus {
     display: block;
     left: 0;
+    outline-offset: -2px;
+    outline: 3px solid color(border, focus);
     position: relative;
     top: 0;
     width: 100%;


### PR DESCRIPTION
Focus styles have been improved to further meet 2.4.7 Focus Visible: (Level AA). 

Elements such as buttons, form elements, links, nav items, breadcrumbs and datatable sortable headers now show a orange outline when focused.

### **Examples:**

**Breadcrumbs:**

![image](https://user-images.githubusercontent.com/756393/46659304-9b975600-cbac-11e8-9e46-187bfc7d3895.png)

**Buttons:**

![image](https://user-images.githubusercontent.com/756393/46659555-0fd1f980-cbad-11e8-8cdd-d8505fe03b67.png)

**Main nav:**

![image](https://user-images.githubusercontent.com/756393/46659342-aeaa2600-cbac-11e8-8e1d-2229ec5a1d77.png)

**Secondary nav:**

![image](https://user-images.githubusercontent.com/756393/46659365-b964bb00-cbac-11e8-8807-dc05e99c7a42.png)

**Inputs:**

![image](https://user-images.githubusercontent.com/756393/46659382-c1bcf600-cbac-11e8-8702-e5e0e42790ae.png)

![image](https://user-images.githubusercontent.com/756393/46659393-c97c9a80-cbac-11e8-86a6-f9353fa1d80c.png)

![image](https://user-images.githubusercontent.com/756393/46659415-d1d4d580-cbac-11e8-94ad-ca04564ec7a2.png)

![image](https://user-images.githubusercontent.com/756393/46659434-d8fbe380-cbac-11e8-8274-0aa6323824e9.png)

![image](https://user-images.githubusercontent.com/756393/46659465-e44f0f00-cbac-11e8-9a47-3ff49f79c409.png)

![image](https://user-images.githubusercontent.com/756393/46659499-f16bfe00-cbac-11e8-8abc-bfee06528466.png)

![image](https://user-images.githubusercontent.com/756393/46659521-faf56600-cbac-11e8-9fe2-34aef6cbeec7.png)

**Links:**

![image](https://user-images.githubusercontent.com/756393/46659578-19f3f800-cbad-11e8-9118-e4879a427ab8.png)

**Sortable datatable headers**

![image](https://user-images.githubusercontent.com/756393/46659947-d6e65480-cbad-11e8-91e4-3d1ef1fdd38e.png)

