### PR TITLE
Stop default link underline from leaking to naked button styling

### DIFF
--- a/stylesheets/_component.buttons.scss
+++ b/stylesheets/_component.buttons.scss
@@ -260,7 +260,7 @@ $btn-white:                 'white';
 .btn--naked,
 .btn--naked > .btn {
     background: none;
-    border: 0;
+    border: 0 !important;
     box-shadow: none;
     color: color(text) !important;
 


### PR DESCRIPTION
Example, `.table [href]` applies the consistent dotted link underline but we don’t particularly want them to leak to naked buttons at this time.

We will need to have a discussion about the a11y affordance of naked buttons, which will likely fail the scruitiny of a WCAG audit, but for now this hotfix is required to maintain existing visuals.

**Before**
<img width="492" alt="screenshot 2018-10-11 at 15 22 43" src="https://user-images.githubusercontent.com/18653/46811240-443ee480-cd6a-11e8-89d5-eff30430078f.png">

**After**
<img width="505" alt="screenshot 2018-10-11 at 15 22 25" src="https://user-images.githubusercontent.com/18653/46811224-3ab57c80-cd6a-11e8-9433-a2e019614fe4.png">
