### PR TITLE
Allow datatables to accept a custom pageLength

### DIFF
--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -56,7 +56,8 @@ PulsarUIComponent.prototype.initDataTables = function () {
         datatablesHorizontal = component.$html.find('.datatable.table--horizontal');
 
     datatables.each(function () {
-        var $this = $(this);
+        var $this = $(this),
+            pageLength = 25;
 
         var select = {
             className: 'dt-row-selected',
@@ -70,6 +71,10 @@ PulsarUIComponent.prototype.initDataTables = function () {
             $this.data('empty-table', 'There are currently no items to display');
         }
 
+        if ($this.data('page-length')) {
+            pageLength = $this.data('page-length');
+        }
+
         if ($this.data('select') === false) {
             dom = '<"dataTables_top"irf><"dataTables_actions"T><"dt-disable-selection"t><"dataTables_bottom"p>';
             select = false;
@@ -79,7 +84,7 @@ PulsarUIComponent.prototype.initDataTables = function () {
             dom: dom,
             aaSorting: [],
             bAutoWidth: false,
-            pageLength: 25,
+            pageLength: pageLength,
             lengthChange: false,
             buttons: [],
             columnDefs: [
@@ -121,7 +126,8 @@ PulsarUIComponent.prototype.initDataTables = function () {
     });
 
     datatablesHorizontal.each(function () {
-        var $this = $(this);
+        var $this = $(this),
+            pageLength = 25;
 
         var select = {
             className: 'dt-row-selected',
@@ -136,6 +142,10 @@ PulsarUIComponent.prototype.initDataTables = function () {
             $this.data('empty-table', 'There are currently no items to display');
         }
 
+        if ($this.data('page-length')) {
+            pageLength = $this.data('page-length');
+        }
+
         if ($this.data('select') === false) {
             dom = '<"dataTables_top"irf><"dataTables_actions"T><"dt-disable-selection"<"table-container"t>><"dataTables_bottom"lp>';
             select = false;
@@ -146,7 +156,7 @@ PulsarUIComponent.prototype.initDataTables = function () {
             aaSorting: [],
             bAutoWidth: false,
             stateSave: true,
-            pageLength: 25,
+            pageLength: pageLength,
             lengthChange: false,
             buttons: [],
             columnDefs: [

--- a/tests/js/web/PulsarUIComponentTest.js
+++ b/tests/js/web/PulsarUIComponentTest.js
@@ -20,7 +20,7 @@ describe('Pulsar UI Component', function() {
             <table class="table--datagrid qa-datagrid"></table>\
             <table class="table datatable qa-datatable"></table>\
             <table class="table datatable qa-datatable-empty-message" data-empty-table="foo"></table>\
-            <table class="table datatable qa-datatable-no-selection" data-select="false"></table>\
+            <table class="table datatable qa-datatable-no-selection" data-select="false" data-page-length="20"></table>\
             <div class="table-container"><table class="table qa-table-dupe"></table></div>\
             <a href="#tab" data-toggle="tab">foo</a>\
             <a data-href="?tab=foo" href="#tab-foo" data-toggle="tab">foo</a>\


### PR DESCRIPTION
Defaults to 25, allows a custom page length to be set for a specific table, useful when embedding tables in modals where a shorter page length is required.

**Examples**

```
<table class="table datatable" data-page-length="10">...</table>
```

```
{{ 
    html.datatable({
        'data': tableData,
        'data-page-length': '10'
    })
}}
```
