### PR TITLE
Restore expected botton border to th cells in datatables

### DIFF
--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -99,6 +99,7 @@ a.dt-button {
         &.sorting_desc:focus {
             outline: 3px solid color(border, focus);
             outline-offset: -3px;
+            z-index: 1;
         }
 
         &.sorting::after,

--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -76,6 +76,7 @@ a.dt-button {
 
     // support absolutely positioned sorting arrows
     th {
+        background-clip: padding-box; // Make sure borders are displayed in FF & IE - https://bugzilla.mozilla.org/show_bug.cgi?id=688556
         padding-right: 20px;
         position: relative;
     }


### PR DESCRIPTION
Due to longstanding browser bugs in FireFox and Internet Explorer, using a background colour paints over the bottom border.

e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=688556

This change uses background-clip to restore the expected border in FireFox and IE9+

**Before**
![screenshot 2018-11-02 at 16 03 35](https://user-images.githubusercontent.com/18653/47928538-8d440d80-debe-11e8-912c-e3e43ceff1ef.png)

**After**
![screenshot 2018-11-02 at 16 19 13](https://user-images.githubusercontent.com/18653/47928512-7e5d5b00-debe-11e8-8f22-6ee585ebea41.png)

## Breaking change checklist

The following points should be considered as an early-warning of introducing a breaking change to a Continuum platform product. This is not an exhaustive list of what constitutes a breaking change.

| Does this pull request... | Yes / No |
| ---- | ---- |
| require changes to `main.js` | ✅ No |
| require changes to `index.js` | ✅ No |
| require changes to `pulsar.scss` | ✅ No |
| require changes to `gruntfile.js` | ✅ No |
| require changes to `package.json` (not including dev dependencies) | ✅ No |
| require changes to `base.html.twig` (or other core views like header/footer) | ✅ No |
| require new arguments to be passed to a js component | ✅ No |
| require markup changes to maintain functionality | ✅ No |
| require changes to existing unit tests | ✅ No |

## Browser testing checklist

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge
- [x] IE 11
- [x] IE 10
- [x] IE 9
- [x] Mobile Safari
- [x] Samsung Internet