### PR TITLE
Fix issue where children of elements triggering popovers do not trigger popovers

### DIFF
--- a/js/libs/popover.js
+++ b/js/libs/popover.js
@@ -122,9 +122,10 @@ var $ = require('jquery'),
   });
 
   $(document).on('click', function (e) {
+    var $target = $(e.target);
 
     // Ignore popover and clickover triggers and children
-    if ($(e.target).attr('data-toggle') === 'popover' || $(e.target).parent().attr('data-toggle') === 'popover' || $(e.target).attr('rel') === 'clickover') {
+    if ($target.attr('data-toggle') === 'popover' || $target.parent().attr('data-toggle') === 'popover' || $target.attr('rel') === 'clickover') {
         return;
     }
 

--- a/js/libs/popover.js
+++ b/js/libs/popover.js
@@ -123,8 +123,8 @@ var $ = require('jquery'),
 
   $(document).on('click', function (e) {
 
-    // Ignore popover and clickover triggers
-    if ($(e.target).attr('data-toggle') === 'popover' || $(e.target).attr('rel') === 'clickover') {
+    // Ignore popover and clickover triggers and children
+    if ($(e.target).attr('data-toggle') === 'popover' || $(e.target).parent().attr('data-toggle') === 'popover' || $(e.target).attr('rel') === 'clickover') {
         return;
     }
 


### PR DESCRIPTION
Previously clicking a child of an element which has `data-toggle="popover"` did not trigger the popover as expected.