### PR TITLE
Close quaternary menu when more icon is clicked a second time

### DIFF
--- a/js/NavMainComponent.js
+++ b/js/NavMainComponent.js
@@ -415,7 +415,9 @@ NavMainComponent.prototype.moreIconClickHandler = function ($moreLink) {
     if (component.$navTertiary.find('.nav-list').hasClass('is-active')) {
         $moreLink.attr('aria-expanded', 'false');
         component.$navTertiary.removeClass('is-open');
+        component.$navQuaternary.removeClass('is-open');
         component.$navTertiary.find('.nav-list').removeClass('is-active');
+        component.$navQuaternary.find('.nav-list').removeClass('is-active');
     } else {
         $moreLink.attr('aria-expanded', 'true');
 

--- a/tests/js/web/NavMainComponentTest.js
+++ b/tests/js/web/NavMainComponentTest.js
@@ -462,14 +462,30 @@ describe('NavMainComponent', function () {
             this.$moreIconLink.trigger(this.clickEvent2);
 
             expect(this.$html.find('.nav-tertiary').hasClass('is-open')).to.be.false;
-        });  
+        });
+
+        it('should close the quaternary nav if it is already open', function () {
+            this.$moreIconLink.trigger(this.clickEvent);
+            this.$tertiaryLink.trigger(this.clickEvent);
+            this.$moreIconLink.trigger(this.clickEvent2);
+
+            expect(this.$html.find('.nav-quaternary').hasClass('is-open')).to.be.false;
+        });
 
         it('should remove the is-active class from the tertiary navs active nav-list if its already open', function () {
             this.$moreIconLink.trigger(this.clickEvent);
             this.$moreIconLink.trigger(this.clickEvent2);
 
             expect(this.$html.find('.nav-tertiary .nav-list').hasClass('is-active')).to.be.false;
-        });  
+        });
+
+        it('should remove the is-active class from the quaternary navs active nav-list if its already open', function () {
+            this.$moreIconLink.trigger(this.clickEvent);
+            this.$tertiaryLink.trigger(this.clickEvent);
+            this.$moreIconLink.trigger(this.clickEvent2);
+
+            expect(this.$html.find('.nav-quaternary .nav-list').hasClass('is-active')).to.be.false;
+        });
 
         it('should change more button aria-expanded attribute to false if the tertiary nav was already open', function () {
             this.$moreIconLink.trigger(this.clickEvent);

--- a/tests/js/web/NavMainComponentTest.js
+++ b/tests/js/web/NavMainComponentTest.js
@@ -5,7 +5,7 @@
 var $ = require('jquery'),
     NavMainComponent = require('../../../js/NavMainComponent');
 
-$.fx.off = !$.fx.off;
+$.fx.off = true;
 
 describe('NavMainComponent', function () {
     beforeEach(function() {
@@ -429,6 +429,7 @@ describe('NavMainComponent', function () {
             this.$moreIconLink = this.$html.find('.more-icon > .nav-link');
             this.clickEvent = $.Event('click');
             this.clickEvent2 = $.Event('click');
+            this.clickEvent3 = $.Event('click');
         });
 
         it('should prevent the default bahavior', function () {
@@ -466,9 +467,12 @@ describe('NavMainComponent', function () {
 
         it('should close the quaternary nav if it is already open', function () {
             this.$moreIconLink.trigger(this.clickEvent);
-            this.$tertiaryLink.trigger(this.clickEvent);
-            this.$moreIconLink.trigger(this.clickEvent2);
+            this.$tertiaryButton.trigger(this.clickEvent3);
 
+            expect(this.$html.find('.nav-quaternary').hasClass('is-open')).to.be.true;
+
+            this.$moreIconLink.trigger(this.clickEvent2);
+            
             expect(this.$html.find('.nav-quaternary').hasClass('is-open')).to.be.false;
         });
 
@@ -481,7 +485,10 @@ describe('NavMainComponent', function () {
 
         it('should remove the is-active class from the quaternary navs active nav-list if its already open', function () {
             this.$moreIconLink.trigger(this.clickEvent);
-            this.$tertiaryLink.trigger(this.clickEvent);
+            this.$tertiaryButton.trigger(this.clickEvent3);
+            
+            expect(this.$html.find('.nav-quaternary').hasClass('is-open')).to.be.true;
+
             this.$moreIconLink.trigger(this.clickEvent2);
 
             expect(this.$html.find('.nav-quaternary .nav-list').hasClass('is-active')).to.be.false;


### PR DESCRIPTION
This change makes sure the quaternary navigation is closed when the more icon is clicked a second time.

### Before
The quaternary navigation stays open.

![nav-before](https://user-images.githubusercontent.com/18653/52220566-150f2e80-2897-11e9-8450-36c5d9264a73.gif)

### After
The quaternary navigation is closed.

![nav-after](https://user-images.githubusercontent.com/18653/52220579-1e989680-2897-11e9-9364-364eff1494d6.gif)

Fixes #930 

## Breaking change checklist

The following points should be considered as an early-warning of introducing a breaking change to a Continuum platform product. This is not an exhaustive list of what constitutes a breaking change.

| Does this pull request... | Yes / No |
| ---- | ---- |
| require changes to `main.js` | ✅ No |
| require changes to `index.js` | ✅ No |
| require changes to `pulsar.scss` | ✅ No |
| require changes to `gruntfile.js` | ✅ No |
| require changes to `package.json` (not including dev dependencies) | ✅ No |
| require changes to `base.html.twig` (or other core views like header/footer) | ✅ No |
| require new arguments to be passed to a js component | ✅ No |
| require markup changes to maintain functionality | ✅ No |
| require changes to existing unit tests | ✅ No |