### PR TITLE
Fix mobile swipe issue

### DIFF
--- a/stylesheets/_component.tab-help.scss
+++ b/stylesheets/_component.tab-help.scss
@@ -93,6 +93,7 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
     border: 0;
     font-size: $font-size-xlarge;
     margin-bottom: 10px;
+    padding-right: 0;
     position: absolute;
     right: 10px;
     text-decoration: none;

--- a/stylesheets/_structure.scaffolding.scss
+++ b/stylesheets/_structure.scaffolding.scss
@@ -23,6 +23,7 @@ body {
   height: 100%;
   // Allow any content to clear the fixed footer
   margin: 0;
+  overflow-x: hidden;
   position: relative;
   width: 100%;
 


### PR DESCRIPTION
Fixes issue reported in #951
UI can no longer be swiped to the left.
Original fix for search bar being obscured after jumping to a page fragment still works.