### PR TITLE
Increased input help block font size to recommended 16px

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -464,7 +464,7 @@ fieldset {
     clear: both;
     color: color(text, help);
     display: block;
-    font-size: $font-size-small;
+    font-size: $font-size-base;
 }
 
 // if a control label is in the help block (like a bare input) it doesn't need


### PR DESCRIPTION
Before:
![12px](https://user-images.githubusercontent.com/756393/55545796-e3afb500-56c5-11e9-9daa-24d4623c9b5e.png)

After:
![16px](https://user-images.githubusercontent.com/756393/55545807-e8746900-56c5-11e9-8d97-93e26371cbd9.png)

Line height is inherited from body is 24px which meets 1.4.12.