### PR TITLE
Make pre/appended content be constrained by grid modifiers

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -397,6 +397,7 @@ fieldset {
 .form__group.form__group .input-group .select2.select2,
 .form__group.form__group .input-group .form__control.form__control {
     flex: 1 1 auto;
+    overflow: hidden;
     width: 1%; // needed to stop overflow, when option has a long string on < desktop
 
     @include ie-lte(9) {

--- a/stylesheets/_component.input-groups.scss
+++ b/stylesheets/_component.input-groups.scss
@@ -57,6 +57,8 @@
     border: 1px solid $input-group-addon-border-color;
     border-radius: $border-radius;
     display: flex;
+    min-width: 0;
+    overflow: hidden;
     white-space: nowrap;
 
     @include ie-lte(9) {

--- a/views/lexicon/forms.html.twig
+++ b/views/lexicon/forms.html.twig
@@ -114,7 +114,8 @@
         {
           "id"    : "text",
           "label" : "Text",
-          "src"   : tab_text
+          "src"   : tab_text,
+          "active": true
         },
         {
           "id"    : "textarea",

--- a/views/lexicon/forms/date.html.twig
+++ b/views/lexicon/forms/date.html.twig
@@ -404,6 +404,97 @@
     }}
 
     {{ form.fieldset_end() }}
+    
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.date({
+                'id': 'date-' ~ random(),
+                'name': 'date-' ~ random(),
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.date({
+                'id': 'date-' ~ random(),
+                'name': 'date-' ~ random(),
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+   {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.date({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.date({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended & Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.date({
+                'id': 'appended-date-' ~ random(),
+                'name': 'appended-date-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.date({
+                'id': 'appended-date-' ~ random(),
+                'name': 'appended-date-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
 
     {{
         form.end()

--- a/views/lexicon/forms/password.html.twig
+++ b/views/lexicon/forms/password.html.twig
@@ -185,7 +185,7 @@
     {{ form.fieldset_start({ 'legend': 'Grid Sizes' }) }}
 
     {{
-        form.text({
+        form.password({
             'id': 'password-1-col',
             'label': 'One column',
             'class': 'form__control-col--1',
@@ -369,6 +369,97 @@
     }}
 
     {{ form.fieldset_end() }}
+
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.password({
+                'id': 'password-' ~ random(),
+                'name': 'password-' ~ random(),
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.password({
+                'id': 'password-' ~ random(),
+                'name': 'password-' ~ random(),
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+   {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.password({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.password({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended & Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.password({
+                'id': 'appended-password-' ~ random(),
+                'name': 'appended-password-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.password({
+                'id': 'appended-password-' ~ random(),
+                'name': 'appended-password-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
 
     {{
         form.end()

--- a/views/lexicon/forms/range.html.twig
+++ b/views/lexicon/forms/range.html.twig
@@ -461,6 +461,97 @@
 
     {{ form.fieldset_end() }}
 
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.range({
+                'id': 'range-' ~ random(),
+                'name': 'range-' ~ random(),
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.range({
+                'id': 'range-' ~ random(),
+                'name': 'range-' ~ random(),
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+   {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.range({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.range({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended & Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.range({
+                'id': 'appended-range-' ~ random(),
+                'name': 'appended-range-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.range({
+                'id': 'appended-range-' ~ random(),
+                'name': 'appended-range-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+
     {{
         form.end()
     }}

--- a/views/lexicon/forms/select.html.twig
+++ b/views/lexicon/forms/select.html.twig
@@ -831,6 +831,113 @@
 
     {{ form.fieldset_end() }}
 
+    {% set options = [
+            {
+                'label': 'Value one',
+                'value': 'value1'
+            },
+            {
+                'label': 'Value two',
+                'value': 'value2'
+            }
+        ]
+    %}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.select({
+                'id': 'prepended-' ~ random(),
+                'name': 'prepended-' ~ random(),
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+                'options': options
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.select({
+                'id': 'prepended-' ~ random(),
+                'name': 'prepended-' ~ random(),
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+                'options': options
+            })
+        }}
+    {% endfor %}
+   {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.select({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+                'options': options
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.select({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': width,
+                'class': 'form__group--' ~ width,
+                'options': options
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended & Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.select({
+                'id': 'appended-prepended-' ~ random(),
+                'name': 'appended-prepended-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+                'options': options
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.select({
+                'id': 'appended-prepended-' ~ random(),
+                'name': 'appended-prepended-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+                'options': options
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
     {{
         form.end()
     }}

--- a/views/lexicon/forms/select2.html.twig
+++ b/views/lexicon/forms/select2.html.twig
@@ -844,7 +844,7 @@
     }}
 
     {{
-        form.select({
+        form.select2({
             'id': 'select2-31',
             'label': 'Prepended button',
             'prepend': html.button({ 'label': 'foo' }),
@@ -901,6 +901,113 @@
             ]
         })
     }}
+
+    {% set options = [
+            {
+                'label': 'Value one',
+                'value': 'value1'
+            },
+            {
+                'label': 'Value two',
+                'value': 'value2'
+            }
+        ]
+    %}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.select2({
+                'id': 'prepended-' ~ random(),
+                'name': 'prepended-' ~ random(),
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+                'options': options
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.select2({
+                'id': 'prepended-' ~ random(),
+                'name': 'prepended-' ~ random(),
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+                'options': options
+            })
+        }}
+    {% endfor %}
+   {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.select2({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+                'options': options
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.select2({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': width,
+                'class': 'form__group--' ~ width,
+                'options': options
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended & Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.select2({
+                'id': 'appended-prepended-' ~ random(),
+                'name': 'appended-prepended-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+                'options': options
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.select2({
+                'id': 'appended-prepended-' ~ random(),
+                'name': 'appended-prepended-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+                'options': options
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
 
     {{
         form.end()

--- a/views/lexicon/forms/text.html.twig
+++ b/views/lexicon/forms/text.html.twig
@@ -477,10 +477,98 @@
 
     {{ form.fieldset_end() }}
 
+    {{ form.fieldset_start({ 'legend': 'Prepended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.text({
+                'id': 'prepended-' ~ random(),
+                'name': 'prepended-' ~ random(),
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.text({
+                'id': 'prepended-' ~ random(),
+                'name': 'prepended-' ~ random(),
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+   {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.text({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.text({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended & Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.text({
+                'id': 'appended-prepended-' ~ random(),
+                'name': 'appended-prepended-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.text({
+                'id': 'appended-prepended-' ~ random(),
+                'name': 'appended-prepended-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
     {{
         form.end()
     }}
-
 {% endblock tab_content %}
 
 {% block tab_sidebar %}

--- a/views/lexicon/forms/time.html.twig
+++ b/views/lexicon/forms/time.html.twig
@@ -379,6 +379,97 @@
 
     {{ form.fieldset_end() }}
 
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.time({
+                'id': 'time-' ~ random(),
+                'name': 'time-' ~ random(),
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.time({
+                'id': 'time-' ~ random(),
+                'name': 'time-' ~ random(),
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+   {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.time({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Appended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.time({
+                'id': 'appended-' ~ random(),
+                'name': 'appended-' ~ random(),
+                'append': 'Append',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended & Appended Grid Sizes' }) }}
+    {% for i in 1..9 %}
+        {{
+            form.time({
+                'id': 'appended-time-' ~ random(),
+                'name': 'appended-time-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': i ~ ' columns',
+                'class': 'form__control-col--' ~ i,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+    {{ form.fieldset_start({ 'legend': 'Prepended Legacy Grid Sizes' }) }}
+    {% set legacyGrid = ['mini', 'small', 'medium', 'regular', 'large', 'xlarge', 'full'] %}
+    {% for width in legacyGrid %}
+        {{
+            form.time({
+                'id': 'appended-time-' ~ random(),
+                'name': 'appended-time-' ~ random(),
+                'append': 'Append',
+                'prepend': 'Prepend',
+                'label': width,
+                'class': 'form__group--' ~ width,
+            })
+        }}
+    {% endfor %}
+    {{ form.fieldset_end() }}
+
+
     {{
         form.end()
     }}


### PR DESCRIPTION
This change makes prepended/appended content hidden on overflow so that grid widths affect the total with of the input including any prepended/appended content. 

## Before
![Screenshot 2019-04-29 at 09 53 13](https://user-images.githubusercontent.com/18653/56889526-7990f280-6a6e-11e9-869d-6b44e312ffae.png)

## After
![Screenshot 2019-04-29 at 09 54 53](https://user-images.githubusercontent.com/18653/56889530-801f6a00-6a6e-11e9-85d7-1b83c7d6eee8.png)

Change affects:
* form.date
* form.password
* form.range
* form.select
* form.select2
* form.text
* form.time