### PR TITLE
Add appropriate aria attributes to toggle switch when help text is present

### DIFF
--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-error.html
@@ -2,9 +2,9 @@
     <label class="toggle-switch-wrapper-label" for="toggletest">
         <span class="control__label">Toggle</span>
         <span class="controls">
-            <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
+            <input id="toggletest" type="checkbox" aria-describedby="guid-1" aria-invalid="true" class="form__control toggle-switch" />
             <span class="toggle-switch-label"></span>
-            <span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+            <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
         </span>
     </label>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-help.html
@@ -2,9 +2,9 @@
     <label class="toggle-switch-wrapper-label" for="toggletest">
         <span class="control__label">Toggle</span>
         <span class="controls">
-            <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
+            <input id="toggletest" type="checkbox" aria-describedby="guid-1" class="form__control toggle-switch" />
             <span class="toggle-switch-label"></span>
-            <span class="help-block">my help text</span>
+            <span class="help-block" id="guid-1">my help text</span>
         </span>
     </label>
 </div>

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -1364,14 +1364,8 @@ controls.class    | string | A space separated list of class names
             {{ form.error({ 'value': options.parent.error|default }) }}
         {% endif %}
 
-        {% if isToggleSwitch %}
-            {% if options.parent.help is defined and options.parent.help is not empty %}
-                {{ form.help({ 'value': options.parent.help|default }) }}
-            {% endif %}
-        {% else %}
-            {% if options.parent.help is defined and options.parent.help is not empty and options.parent.help_id is defined and options.parent.help_id is not empty %}
-                {{ form.help({ 'value': options.parent.help|default, 'id': options.parent.help_id }) }}
-            {% endif %}
+        {% if options.parent.help is defined and options.parent.help is not empty and options.parent.help_id is defined and options.parent.help_id is not empty %}
+            {{ form.help({ 'value': options.parent.help|default, 'id': options.parent.help_id }) }}
         {% endif %}
 
         {% if options.parent.bare is not defined or options.parent.bare != true %}
@@ -2296,6 +2290,9 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
 {% spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
+
+
+    {% set options = modify_options(options|default({})) %}
 
     {% set toggleLabel = '<span class="hide">toggle ' ~ options.label ~ '</span>' %}
 


### PR DESCRIPTION
This change adds the `modify_options` function to the toggle switch macro so that the presence of `help` will add the missing `aria_describedby` attribute to the toggle checkbox, and the guid id to the help text.

This change also adds the `aria-invalid` attribute when the toggle contains an `error` which was an unintended effect of the change.

Closes #970 