### PR TITLE
Datatables pagination a11y

### DIFF
--- a/js/DataTables/dataTablesDrawCallback.js
+++ b/js/DataTables/dataTablesDrawCallback.js
@@ -1,0 +1,20 @@
+module.exports.drawCallback = function () {
+    let pagination = $(this).closest('.dataTables_wrapper').find('.dataTables_paginate'),
+        paginationNumbers;
+
+    // Only show pagination when needed
+    pagination.toggle(this.api().page.info().pages > 1);
+
+    // Add aria-current to current page number
+    pagination.find('.paginate_button.current').attr('aria-current', 'true');
+
+    // Remove disable links
+    pagination.find('.paginate_button.disabled').addClass('u-display-none');
+
+    // Add aria-labels to numbered links
+    paginationNumbers = pagination.find('.paginate_button:not(.first, .previous, .next, .last)');
+    paginationNumbers.each(function () {
+        let $numberLink = $(this);
+        $numberLink.attr('aria-label', 'Page ' + $numberLink.text());
+    });
+}

--- a/js/DataTables/dataTablesInitComplete.js
+++ b/js/DataTables/dataTablesInitComplete.js
@@ -1,0 +1,5 @@
+module.exports.initComplete = function () {
+    let pagination = $(this).closest('.dataTables_wrapper').find('.dataTables_paginate');
+
+    pagination.wrap('<nav aria-label="Table pagination"></nav>');
+}

--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -42,6 +42,7 @@ PulsarUIComponent.getDatatableOptions = function ($table) {
     let dom = '<"dataTables_top"Birf><"dataTables_actions"T>t<"dataTables_bottom"pl>',
         langEmptyTable = 'There are currently no items to display',
         pageLength = 25,
+        lengthChange = false,
         select = {
             className: 'dt-row-selected',
             style: 'multi',
@@ -54,6 +55,10 @@ PulsarUIComponent.getDatatableOptions = function ($table) {
 
     if ($table.length && $table.data('page-length')) {
         pageLength = $table.data('page-length');
+    }
+
+    if ($table.length && $table.data('length-change')) {
+        lengthChange = $table.data('length-change');
     }
 
     if ($table.length && $table.data('select') === false) {
@@ -100,7 +105,7 @@ PulsarUIComponent.getDatatableOptions = function ($table) {
                 }
             }
         },
-        lengthChange: true,
+        lengthChange: lengthChange,
         pageLength: pageLength,
         pagingType: 'full_numbers',
         responsive: {

--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -3,6 +3,9 @@
 var $ = require('jquery'),
     StickyScrollBarComponent = require('./StickyScrollBarComponent');
 
+const { initComplete } = require('./DataTables/datatablesInitComplete');
+const { drawCallback } = require('./DataTables/datatablesDrawCallback');
+
 require('datatables.net')(window, $);
 require('datatables.net-buttons')(window, $);
 require('datatables.net-responsive')(window, $);
@@ -78,32 +81,8 @@ PulsarUIComponent.getDatatableOptions = function ($table) {
                 targets: [0, 1]
             }
         ],
-        initComplete: function () {
-            let pagination = $(this).closest('.dataTables_wrapper').find('.dataTables_paginate');
-
-            // Wrap pagination in nav
-            pagination.wrap('<nav aria-label="Table pagination"></nav>');
-        },
-        drawCallback: function() {
-            let pagination = $(this).closest('.dataTables_wrapper').find('.dataTables_paginate'),
-                paginationNumbers;
-
-            // Only show pagination when needed
-            pagination.toggle(this.api().page.info().pages > 1);
-
-            // Add aria-current to current page number
-            pagination.find('.paginate_button.current').attr('aria-current', 'true');
-
-            // Remove disable links
-            pagination.find('.paginate_button.disabled').addClass('u-display-none');
-
-            // Add aria-labels to numbered links
-            paginationNumbers = pagination.find('.paginate_button:not(.first, .previous, .next, .last)');
-            paginationNumbers.each(function () {
-                let $numberLink = $(this);
-                $numberLink.attr('aria-label', 'Page ' + $numberLink.text());
-            });
-        },
+        initComplete: initComplete,
+        drawCallback: drawCallback,
         dom: dom,
         language: {
             emptyTable: langEmptyTable,

--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -36,7 +36,7 @@ PulsarUIComponent.prototype.init = function () {
 };
 
 PulsarUIComponent.getDatatableOptions = function ($table) {
-    let dom = '<"dataTables_top"Birf><"dataTables_actions"T>t<"dataTables_bottom"lp>',
+    let dom = '<"dataTables_top"Birf><"dataTables_actions"T>t<"dataTables_bottom"pl>',
         langEmptyTable = 'There are currently no items to display',
         pageLength = 25,
         select = {
@@ -44,7 +44,7 @@ PulsarUIComponent.getDatatableOptions = function ($table) {
             style: 'multi',
             selector: 'td.table-selection'
         };
-    
+
     if ($table.length && $table.data('empty-table')) {
         langEmptyTable = $table.data('empty-table');
     }
@@ -54,7 +54,7 @@ PulsarUIComponent.getDatatableOptions = function ($table) {
     }
 
     if ($table.length && $table.data('select') === false) {
-        dom = '<"dataTables_top"irf><"dataTables_actions"T><"dt-disable-selection"t><"dataTables_bottom"p>';
+        dom = '<"dataTables_top"irf><"dataTables_actions"T><"dt-disable-selection"t><"dataTables_bottom"pl>';
         select = false;
     }
 
@@ -64,13 +64,13 @@ PulsarUIComponent.getDatatableOptions = function ($table) {
         buttons: [],
         className: 'dt-row-selected',
         columnDefs: [
-            { 
-                className: 'control', 
-                orderable: false, 
+            {
+                className: 'control',
+                orderable: false,
                 targets: 0
             },
-            { 
-                searchable: false, 
+            {
+                searchable: false,
                 targets: [0]
             },
             {
@@ -78,6 +78,32 @@ PulsarUIComponent.getDatatableOptions = function ($table) {
                 targets: [0, 1]
             }
         ],
+        initComplete: function () {
+            let pagination = $(this).closest('.dataTables_wrapper').find('.dataTables_paginate');
+
+            // Wrap pagination in nav
+            pagination.wrap('<nav aria-label="Table pagination"></nav>');
+        },
+        drawCallback: function() {
+            let pagination = $(this).closest('.dataTables_wrapper').find('.dataTables_paginate'),
+                paginationNumbers;
+
+            // Only show pagination when needed
+            pagination.toggle(this.api().page.info().pages > 1);
+
+            // Add aria-current to current page number
+            pagination.find('.paginate_button.current').attr('aria-current', 'true');
+
+            // Remove disable links
+            pagination.find('.paginate_button.disabled').addClass('u-display-none');
+
+            // Add aria-labels to numbered links
+            paginationNumbers = pagination.find('.paginate_button:not(.first, .previous, .next, .last)');
+            paginationNumbers.each(function (i) {
+                let $numberLink = $(this);
+                $numberLink.attr('aria-label', 'Page ' + $numberLink.text());
+            });
+        },
         dom: dom,
         language: {
             emptyTable: langEmptyTable,
@@ -85,10 +111,19 @@ PulsarUIComponent.getDatatableOptions = function ($table) {
             infoEmpty: 'No items',
             infoFiltered: " (filtered from _MAX_ items)",
             zeroRecords: "No items matched your filter, please clear it and try again",
-            search: "Filter records"
+            search: "Filter records",
+            aria: {
+                paginate: {
+                    first:    'First page',
+                    previous: 'Previous page',
+                    next:     'Next page',
+                    last:     'Last page'
+                }
+            }
         },
-        lengthChange: false,
+        lengthChange: true,
         pageLength: pageLength,
+        pagingType: 'full_numbers',
         responsive: {
             details: {
                 type: 'column'
@@ -121,12 +156,12 @@ PulsarUIComponent.prototype.initDataTables = function () {
     var component = this,
         datatables = component.$html.find('.datatable:not([data-init="false"]):not(.table--horizontal)'),
         datatablesHorizontal = component.$html.find('.datatable.table--horizontal:not([data-init="false"])');
-        
+
     datatables.each(function () {
         var $this = $(this);
 
         const datatableOptions = PulsarUIComponent.getDatatableOptions($this);
-        
+
         const table = $this.DataTable(datatableOptions);
 
         $this.on('click', '.js-select-all', function(e) {
@@ -154,7 +189,7 @@ PulsarUIComponent.prototype.initDataTables = function () {
                 selector:  '.js-select',
                 info:       true
             };
-            
+
         if ($this.data('select') === false) {
             dom = '<"dataTables_top"irf><"dataTables_actions"T><"dt-disable-selection"<"table-container"t>><"dataTables_bottom"lp>';
             select = false;
@@ -166,7 +201,7 @@ PulsarUIComponent.prototype.initDataTables = function () {
             dom: dom,
             select: select,
         });
-        
+
         const table = $this.DataTable(horizontalOptions);
 
         // Add sticky scroll bar
@@ -286,7 +321,7 @@ PulsarUIComponent.prototype.toggleBulkActions = function(table) {
                 'data-container': 'body',
                 'title': 'Select one or more items to perform this bulk action'
             }).tooltips();
-    } 
+    }
     else {
         $bulkActionsBadge
             .attr('aria-label', count + ' row' + ((count > 1) ? 's' : '') + ' selected')

--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -99,7 +99,7 @@ PulsarUIComponent.getDatatableOptions = function ($table) {
 
             // Add aria-labels to numbered links
             paginationNumbers = pagination.find('.paginate_button:not(.first, .previous, .next, .last)');
-            paginationNumbers.each(function (i) {
+            paginationNumbers.each(function () {
                 let $numberLink = $(this);
                 $numberLink.attr('aria-label', 'Page ' + $numberLink.text());
             });

--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -3,8 +3,8 @@
 var $ = require('jquery'),
     StickyScrollBarComponent = require('./StickyScrollBarComponent');
 
-const { initComplete } = require('./DataTables/datatablesInitComplete');
-const { drawCallback } = require('./DataTables/datatablesDrawCallback');
+const { initComplete } = require('./DataTables/dataTablesInitComplete');
+const { drawCallback } = require('./DataTables/dataTablesDrawCallback');
 
 require('datatables.net')(window, $);
 require('datatables.net-buttons')(window, $);

--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -249,7 +249,6 @@ th.sorting_disabled:hover {
 
 .dataTables_bottom {
     display: block;
-    margin-top: -1px;
     width: 100%;
 }
 
@@ -320,6 +319,8 @@ th.sorting_disabled:hover {
 }
 
 .dataTables_bottom {
+    @include clear-fix;
+
     margin-bottom: 24px;
 }
 
@@ -329,6 +330,8 @@ th.sorting_disabled:hover {
     width: 100%;
 
     @include respond-min($screen-tablet) {
+        display: inline-block;
+        float: left;
         text-align: left;
         width: auto;
     }
@@ -342,25 +345,8 @@ th.sorting_disabled:hover {
         text-decoration: none;
     }
 
-    .paginate_button.previous::before {
-        content: '\f100';
-        font-family: 'FontAwesome';
-        padding-right: 5px;
-    }
-
-    .paginate_button.next::after {
-        content: '\f101';
-        font-family: 'FontAwesome';
-        padding-left: 5px;
-    }
-
     .paginate_button.current {
         background-color: darken(color(white), 10%);
-    }
-
-    .paginateButton.disabled,
-    .ellipsis {
-        color: color(text, disabled);
     }
 }
 
@@ -379,6 +365,10 @@ th.sorting_disabled:hover {
         margin-bottom: 0;
         text-align: left;
         width: auto;
+    }
+
+    select:focus {
+        outline: 3px solid color(border, focus);
     }
 }
 

--- a/stylesheets/_component.pagination.scss
+++ b/stylesheets/_component.pagination.scss
@@ -1,4 +1,5 @@
 .pagination {
+  @include clear-fix;
   background-color: color(white);
 
   // We assume pagination will always sit underneath an element, and that

--- a/tests/js/web/DataTables/dataTableDrawCallbackTest.js
+++ b/tests/js/web/DataTables/dataTableDrawCallbackTest.js
@@ -1,0 +1,84 @@
+const { drawCallback } = require('../../../../js/DataTables/dataTablesDrawCallback'),
+    $ = require('jquery');
+
+describe('datatablesDrawCallback', () => {
+    const infoStub = sinon.stub().returns({
+        pages: 666
+    });
+
+    let $body,
+        $dataTableWrapper,
+        $datatable,
+        $datatablePagination,
+        drawCallbackWithContext;
+
+    beforeEach(() => {
+        $body = $('body');
+        $dataTableWrapper = $(`<div class="dataTables_wrapper"></div>`).appendTo($body);
+        $datatable = $(`<div class="fake-table"></div>`).appendTo($dataTableWrapper);
+        $datatablePagination = $(`
+            <div class="dataTables_paginate">
+                <a class="paginate_button first disabled">First</a>
+                <a class="paginate_button previous disabled">Previous</a>
+                <a class="paginate_button current">1</a>
+                <a class="paginate_button">2</a>
+                <a class="paginate_button next">Next</a>
+                <a class="paginate_button last">Last</a>
+            </div>
+        `).appendTo($dataTableWrapper);
+
+        $datatable.api = sinon.stub().returns({
+            page: {
+                info: infoStub
+            }
+        });
+    });
+
+    afterEach(() => {
+        $body.empty()
+    });
+
+    it('should add aria-current="true" to the current page', () => {
+        drawCallbackWithContext = drawCallback.bind($datatable);
+        drawCallbackWithContext();
+
+        expect($datatablePagination.find('.paginate_button.current').attr('aria-current')).to.equal('true');
+    });
+
+    it('should hide disabled links', () => {
+        drawCallbackWithContext = drawCallback.bind($datatable);
+        drawCallbackWithContext();
+
+        expect($datatablePagination.find('.paginate_button.disabled').hasClass('u-display-none')).to.be.true;
+    });
+
+    it('should add aria-labels to the numbered links', () => {
+        drawCallbackWithContext = drawCallback.bind($datatable);
+        drawCallbackWithContext();
+
+        expect($datatablePagination.find('.paginate_button.current').attr('aria-label')).to.equal('Page 1');
+        expect($datatablePagination.find('.paginate_button:contains("2")').attr('aria-label')).to.equal('Page 2');
+    });
+
+    describe('When there is more than 1 page of results', () => {
+        it('should show pagination', () => {
+            drawCallbackWithContext = drawCallback.bind($datatable);
+            drawCallbackWithContext();
+
+            expect($datatablePagination.is(':visible')).to.be.true;
+        });
+    });
+
+    describe('When there is less than 2 pages of results', () => {
+        it('should not show pagination', () => {
+            infoStub.returns({
+                pages: 1
+            });
+
+            drawCallbackWithContext = drawCallback.bind($datatable);
+            drawCallbackWithContext();
+
+            expect($datatablePagination.is(':visible')).to.be.false;
+        });
+    });
+});

--- a/tests/js/web/DataTables/dataTablesInitCompleteTest.js
+++ b/tests/js/web/DataTables/dataTablesInitCompleteTest.js
@@ -1,0 +1,32 @@
+const { initComplete } = require('../../../../js/DataTables/dataTablesInitComplete'),
+    $ = require('jquery');
+
+describe('datatablesInitComplete', () => {
+    let $body,
+        $dataTableWrapper,
+        $datatable,
+        $datatablePagination,
+        initCompleteWithContext;
+
+    beforeEach(() => {
+        $body = $('body');
+        $dataTableWrapper = $(`<div class="dataTables_wrapper"></div>`).appendTo($body);
+        $datatable = $(`<div class="fake-table"></div>`).appendTo($dataTableWrapper);
+        $datatablePagination = $(`<div class="dataTables_paginate"></div>`).appendTo($dataTableWrapper);
+
+        initCompleteWithContext = initComplete.bind($datatable);
+        initCompleteWithContext();
+    });
+
+    afterEach(() => {
+        $body.empty()
+    });
+
+    it('should wrap the datatable pagination in a nav element', () => {
+        expect($datatablePagination.parent().is('nav')).to.be.true;
+    });
+
+    it('should add an accessible name to the wrapping nav element', () => {
+        expect($datatablePagination.parent().attr('aria-label')).to.equal('Table pagination');
+    });
+});

--- a/tests/js/web/PulsarUIComponentTest.js
+++ b/tests/js/web/PulsarUIComponentTest.js
@@ -164,6 +164,61 @@ describe('Pulsar UI Component', function() {
         it('should recalculate the table', function() {
             expect(this.recalc).to.have.been.calledOnce;
         });
+    });
 
+    describe('initialising DataTables', function() {
+
+        beforeEach(function() {
+            $.fn.DataTable = sinon.stub();
+        });
+
+        afterEach(function () {
+            delete $.fn.DataTable;
+        });
+
+        it('should not show the length change select by default', function() {
+            this.pulsarUIComponent.init();
+
+            expect($.fn.DataTable.args[0][0].lengthChange).to.equal(false);
+        });
+
+        it('should show the length change select if the data-length-change attribute is true', function () {
+            let $tableWithLengthChangeDataAttribute = $('<table class="table datatable qa-datatable-length-change" data-length-change="true"></table>');
+            $tableWithLengthChangeDataAttribute.appendTo(this.$body);
+
+            this.pulsarUIComponent.init();
+
+            expect($.fn.DataTable.args[0][0].lengthChange).to.equal(true);
+        })
+
+        it('should default to 25 rows pageLength', function() {
+            this.pulsarUIComponent.init();
+
+            expect($.fn.DataTable.args[0][0].pageLength).to.equal(25);
+        });
+
+        it('should change the page length to the value provided by data-page-length', function() {
+            let $tableWithPageLengthDataAttribute = $(' <table class="table datatable" data-page-length="20"></table>');
+            $tableWithPageLengthDataAttribute.appendTo(this.$body);
+
+            this.pulsarUIComponent.init();
+
+            expect($.fn.DataTable.args[0][0].pageLength).to.equal(20);
+        });
+
+        it('should initialise datatables with the default DOM option value', function() {
+            this.pulsarUIComponent.init();
+
+            expect($.fn.DataTable.args[0][0].dom).to.equal('<"dataTables_top"Birf><"dataTables_actions"T>t<"dataTables_bottom"pl>');
+        });
+
+        it('should change the DOM option value when data-select is false', function() {
+            let $tableWithSelectFalseDataAttribute = $(' <table class="table datatable" data-select="false"></table>');
+            $tableWithSelectFalseDataAttribute.appendTo(this.$body);
+
+            this.pulsarUIComponent.init();
+
+            expect($.fn.DataTable.args[0][0].dom).to.equal('<"dataTables_top"irf><"dataTables_actions"T><"dt-disable-selection"t><"dataTables_bottom"pl>');
+        });
     });
 });

--- a/views/lexicon/tabs/pagination.html.twig
+++ b/views/lexicon/tabs/pagination.html.twig
@@ -1,15 +1,52 @@
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
 {% block tab_content %}
-<div class="pagination">
-    <ul class="pull-left"><!--
-        --><li class="is-disabled"><a href="#prev"><i class="icon-double-angle-left"></i> Previous</a></li><!--
-        --><li><a href="#1">1</a></li><!--
-        --><li class="selected"><a href="#2">2</a></li><!--
-        --><li><a href="#3">3</a></li><!--
-        --><li><a href="#4">4</a></li><!--
-        --><li><a href="#5">5</a></li><!--
-        --><li><a href="#next">Next <i class="icon-double-angle-right"></i></a></li><!--
-    --></ul>
+{% spaceless %}
+<div class="u-margin-bottom--large">
+    <h2 class="heading">Previous link hidden on first page</h2>
+    <nav aria-label="Table pagination" class="pagination">
+        <ul class="pull-left">
+            <li class="selected"><a href="#1" aria-current="true" aria-label="Current page, page 1">1</a></li>
+            <li><a href="#2" aria-label="page 2">2</a></li>
+            <li><a href="#3" aria-label="page 3">3</a></li>
+            <li><a href="#4" aria-label="page 4">4</a></li>
+            <li><a href="#5" aria-label="page 5">5</a></li>
+            <li><a href="#next" aria-label="next page">Next</a></li>
+        </ul>
+    </nav>
 </div>
+{% endspaceless %}
+
+{% spaceless %}
+<div class="u-margin-bottom--large">
+    <h2 class="heading">Previous and next link shown when previous or next pages exist</h2>
+    <nav aria-label="Table pagination" class="pagination">
+        <ul class="pull-left">
+            <li><a href="#prev" aria-label="previous page">Previous</a></li>
+            <li><a href="#1" aria-label="page 1">1</a></li>
+            <li class="selected"><a href="#2" aria-current="true" aria-label="Current page, page 2">2</a></li>
+            <li><a href="#3" aria-label="page 3">3</a></li>
+            <li><a href="#4" aria-label="page 4">4</a></li>
+            <li><a href="#5" aria-label="page 5">5</a></li>
+            <li><a href="#next" aria-label="next page">Next</a></li>
+        </ul>
+    </nav>
+</div>
+{% endspaceless %}
+
+{% spaceless %}
+<div>
+    <h2 class="heading">Next link hidden on last page</h2>
+    <nav aria-label="Table pagination" class="pagination">
+        <ul class="pull-left">
+            <li><a href="#prev" aria-label="previous page">Previous</a></li>
+            <li><a href="#1" aria-label="page 1">1</a></li>
+            <li><a href="#2" aria-label="page 2">2</a></li>
+            <li><a href="#3" aria-label="page 3">3</a></li>
+            <li><a href="#4" aria-label="page 4">4</a></li>
+            <li class="selected"><a href="#5" aria-current="true" aria-label="Current page, page 5">5</a></li>
+        </ul>
+    </nav>
+</div>
+{% endspaceless %}
 {% endblock tab_content %}


### PR DESCRIPTION
This branch addresses a number of issues with the datatables pagination listed below:

1. Disabled links (such as "previous" on when on page 1) were shown to the user, could be focused and failed AA contrast. These have now been hidden both visually and from screen readers when not relevant. For example, there is no previous link when on page 1 and no next link when on the final page.

2. Link text was non descriptive to screen reader users. `aria-label`'s have now been added tp pagination links, for example `aria-label="page 1"` along with `aria-current="true"` where a link refers to the currently displayed page.

3. Pagination was shown when no records or only one page of records were present. Pagination is now only disabled when there are enough records to cause pagination.

4. For large amounts of records, First and Last links weren't present. These have been added with appropriate `aria-label`'s.

5. The mark up datatables generates isn't the most semantic. Pagination links are now wrapped in a `nav` element with an accessible name.

6. The record length picker was incorrectly missing from all datatables. This has been re-added.

7. The record length picker was missing the default Pulsar orange focus indicator and relying on the browser default style. This has been fixed.

8. The tab order was incorrect, after tabbing from the last focusable element in a table, focus would move to the record length picker and not the pagination. This has been fixed.

I've also updated the lexicon non datatable pagination examples with more accessible markup and fixed an overflow issue.

**Before:** 

![image](https://user-images.githubusercontent.com/756393/58811642-17508200-8618-11e9-95a4-4263c95d3dbb.png)

**After:**

![image](https://user-images.githubusercontent.com/756393/58811739-44049980-8618-11e9-8054-48fbf0766df1.png)

![image](https://user-images.githubusercontent.com/756393/58811755-4cf56b00-8618-11e9-98d6-000148e6a5eb.png)

![image](https://user-images.githubusercontent.com/756393/58811772-541c7900-8618-11e9-8e35-a561c96b2125.png)

**Browser tested in:**

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [x] IE11-9

**Screen reader tested in:**

- [x] JAWS 2018 IE11
- [x] JAWS 18 IE11
- [x] NVDA IE11
- [x] Mac VO Safari and Chrome

Addresses #983 