### PR TITLE
Fix safari table-detail content shift issue

### DIFF
--- a/stylesheets/_component.table-detail.scss
+++ b/stylesheets/_component.table-detail.scss
@@ -3,7 +3,7 @@
     background: color(white);
     border-left: 1px solid $modal-header-border-color;
     bottom: 0;
-    display: table-cell;
+    display: none;
     height: 100%;
     overflow-x: none;
     overflow-y: auto;
@@ -17,6 +17,18 @@
     will-change: transform;
     z-index: $zindex-modal;
 
+    // Safari transition bug fix, if "display: table-cell" on mobile, content shifts left after panel opens.
+    @include respond-min($screen-desktop) {
+        display: table-cell;
+    }
+}
+
+.table-detail.table-detail--open {
+    -webkit-transform: none;
+    display: table-cell;
+    transform: none;
+    transition: transform .2s;
+
     @include respond-min($screen-xsmall) {
         width: 400px;
     }
@@ -27,12 +39,6 @@
 
     @include respond-min($screen-tablet) {
         width: 600px;
-    }
-
-    &.table-detail--open {
-        -webkit-transform: none;
-        transform: none;
-        transition: transform .2s;
     }
 }
 

--- a/stylesheets/_component.tables.scss
+++ b/stylesheets/_component.tables.scss
@@ -270,6 +270,7 @@ td.row__actions {
 .table--overflow-left,
 .table--overflow-right {
     &.table-container {
+        -webkit-overflow-scrolling: touch;
         overflow-x: auto;
 
         &::-webkit-scrollbar {
@@ -329,6 +330,7 @@ td.row__actions {
 .table-container.table--overflow-left .sticky-scrollbar::-webkit-scrollbar,
 .table-container.table--overflow-right .sticky-scrollbar::-webkit-scrollbar {
     -webkit-appearance: none;
+    -webkit-overflow-scrolling: touch;
     background: color(background, light);
     width: 7px;
 }

--- a/views/lexicon/patterns/table-detail/table-detail.html.twig
+++ b/views/lexicon/patterns/table-detail/table-detail.html.twig
@@ -1,12 +1,14 @@
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
-{% block tab_content %}
+{% block tab_sidebar %}
+    <h2 class="heading">{{ html.icon('info-sign', { 'class': 'sidebar-icon'}) }} Example help</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. In tellus dolor, condimentum efficitur arcu sed, feugiat pellentesque lacus. Pellentesque ac ipsum ac mauris cursus volutpat. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.</p>
+{% endblock tab_sidebar %}
 
-<table class="table datatable table--full" data-table-detail-table>
+{% block tab_content %}
+<table class="table table--horizontal table--full" data-table-detail-table>
     <thead>
         <tr>
-            <td class="table-responsive"></td>
-            <td class="table-selection"></td>
             <th><a href="#">Date</a></th>
             <th><a href="#">Time</a></th>
             <th><a href="#">User type</a></th>
@@ -25,12 +27,6 @@
                     <p>Nam tincidunt turpis eget augue feugiat, non facilisis mi pretium. Nunc in consequat lacus. Ut massa massa, vehicula egestas vehicula nec, egestas varius dolor. Ut tristique, nulla sed consectetur fermentum, augue libero vulputate augue, auctor elementum felis eros eget ante. Integer sapien tortor, vehicula ac scelerisque id, dapibus in dui. Cras blandit, dolor sed suscipit dictum, sapien elit semper sem, ut laoreet nisi libero vitae purus. Phasellus dui ante, tristique vitae pretium ut, eleifend quis leo. Etiam aliquet, est eu placerat lobortis, justo augue iaculis odio, nec auctor ex ex et nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Aenean volutpat augue nec massa sagittis, at mollis tortor gravida.</p>
 
                         <p>Phasellus at posuere leo, sit amet consectetur ligula. Donec ultrices odio ut diam efficitur, sit amet feugiat ligula convallis. Phasellus feugiat nunc mattis faucibus aliquam. Sed non elit eu purus vestibulum hendrerit varius a leo. Donec at fermentum nulla. Nam in libero varius, dignissim nulla non, ultrices sem. Integer in libero felis. Proin nec nulla ut augue dapibus aliquet id non odio. Integer sit amet mollis magna. Quisque iaculis neque ac lobortis tempor. Suspendisse potenti. Proin pellentesque arcu sed ante volutpat feugiat.</p></div>" data-table-detail-panel-custom-title="A custom title set on the clicked TR">
-            <td class="table-responsive">
-                {{ html.button({ 'label': html.icon('plus-sign', { 'label': 'Expand', 'class': 'table-child-toggle' }), 'class': 'btn--naked'}) }}
-            </td>
-            <td class="table-selection">
-                {{ html.icon('unchecked', { 'class': 'table-row-select js-select' }) }}
-            </td>
 
             <td>{{ html.link({ 'label': '13/01/2017', 'class': 'table-action', 'data-table-detail-view-detail': true }) }}</td>
             <td>3:30pm</td>


### PR DESCRIPTION
Fixes #995 

The issue seems to be related to a combination of the use of `display: table-cell` and `transform`. After trying multiple solutions and going down a lot of rabbit holes, I've set `display` to `none` on mobile when the panel is closed. This fixes the issue but loses the transition effect on mobile.

Tested in:
- Chrome
- Firefox
- Safari
- Edge
- IE11-9
- iOS Safari

After fix:
![Screenshot 2019-06-19 at 16 22 05](https://user-images.githubusercontent.com/756393/59778447-6b14c980-92ae-11e9-9243-c9bf47104d50.png)

![Screenshot 2019-06-19 at 16 21 43](https://user-images.githubusercontent.com/756393/59778416-5a645380-92ae-11e9-9f1a-8325a85ce3a4.png)
