### PR TITLE
Add iso and locale formatting to date helper

### DIFF
--- a/js/PulsarFormComponent.js
+++ b/js/PulsarFormComponent.js
@@ -90,7 +90,7 @@ PulsarFormComponent.prototype.initDatePickers = function () {
 
     datepickers.each((index, element) => {
         let $element = $(element);
-        let dateFormat;
+        let dateFormat = 'DD/MM/YYYY';
         let formatKey = element.getAttribute('data-format');
         let locale = element.getAttribute('data-locale');
 
@@ -108,8 +108,6 @@ PulsarFormComponent.prototype.initDatePickers = function () {
                 case 'reverse':
                     dateFormat = 'YYYY/MM/DD';
                     break;
-                default:
-                    dateFormat = 'DD/MM/YYYY';
             }
         }
 

--- a/js/PulsarFormComponent.js
+++ b/js/PulsarFormComponent.js
@@ -89,6 +89,7 @@ PulsarFormComponent.prototype.initDatePickers = function () {
     const datepickers = this.$html.find('[data-datepicker="true"]');
 
     datepickers.each((index, element) => {
+        let $element = $(element);
         let dateFormat;
         let formatKey = element.getAttribute('data-format');
         let locale = element.getAttribute('data-locale');
@@ -113,19 +114,19 @@ PulsarFormComponent.prototype.initDatePickers = function () {
         }
 
         // Initialize pikaday with the correct date format
-        $(element).pikaday({ format: dateFormat });
+        $element.pikaday({ format: dateFormat });
 
         // Initialize placeholder attribute based on the date format
-        $(element).attr('placeholder', dateFormat.toLowerCase());
+        $element.attr('placeholder', dateFormat.toLowerCase());
 
         if (element.hasAttribute('data-iso') && element.hasAttribute('name')) {
-            let elementName = $(element).attr('name');
+            let elementName = $element.attr('name');
             let hiddenElement = $('<input>', {'type': 'hidden', 'name': elementName});
 
-            $(element).removeAttr('name');
-            $(element).after(hiddenElement);
+            $element.removeAttr('name');
+            $element.after(hiddenElement);
 
-            $(element).change(function() {
+            $element.change(function() {
                 let parsed = moment($(this).val(), dateFormat);
                 let ISOTime = parsed.toISOString(true);
 

--- a/js/PulsarFormComponent.js
+++ b/js/PulsarFormComponent.js
@@ -87,32 +87,29 @@ PulsarFormComponent.prototype.initTimePickers = function () {
  */
 PulsarFormComponent.prototype.initDatePickers = function () {
     const datepickers = this.$html.find('[data-datepicker="true"]');
-    let defaultDateFormat = 'DD/MM/YYYY';
-
-    moment.locale(window.navigator.userLanguage || window.navigator.language);
 
     datepickers.each((index, element) => {
+        let dateFormat;
         let formatKey = element.getAttribute('data-format');
-        let dateFormat = defaultDateFormat;
+        let locale = element.getAttribute('data-locale');
 
-        // Check if data-format attribute exists and lowercase it
-        // to eliminate different styles of writing issues
-        if (formatKey !== null) {
-            formatKey = formatKey.toLowerCase();
+        if (typeof locale === 'string') {
+            dateFormat = moment.localeData(locale).longDateFormat('L');
         }
 
-        switch (formatKey) {
-            case 'us':
-                dateFormat = 'MM/DD/YYYY';
-                break;
-            case 'reverse':
-                dateFormat = 'YYYY/MM/DD';
-                break;
-            case 'locale':
-                dateFormat = moment.localeData().longDateFormat('L');
-                break;
-            default:
-                dateFormat = 'DD/MM/YYYY';
+        if (typeof formatKey === 'string') {
+            formatKey = formatKey.toLowerCase();
+
+            switch (formatKey) {
+                case 'us':
+                    dateFormat = 'MM/DD/YYYY';
+                    break;
+                case 'reverse':
+                    dateFormat = 'YYYY/MM/DD';
+                    break;
+                default:
+                    dateFormat = 'DD/MM/YYYY';
+            }
         }
 
         // Initialize pikaday with the correct date format
@@ -136,7 +133,7 @@ PulsarFormComponent.prototype.initDatePickers = function () {
                     ISOTime = ISOTime.substr(0, 10);
                 }
 
-                hiddenElement.val(ISOTime || '');
+                hiddenElement.val(ISOTime || '').change();
             });
         }
     });

--- a/views/lexicon/forms/date.html.twig
+++ b/views/lexicon/forms/date.html.twig
@@ -41,6 +41,23 @@
 
     {{
         form.date({
+            'format': 'locale',
+            'id': 'date-locale',
+            'label': 'Date locale style',
+        })
+    }}
+
+    {{
+        form.date({
+            'id': 'date-locale',
+            'name': 'date-locale',
+            'label': 'Date with iso value',
+            'iso': true,
+        })
+    }}
+
+    {{
+        form.date({
             'id': 'date-2',
             'label': 'Date field with value',
             'value': '04/07/1981'
@@ -404,7 +421,7 @@
     }}
 
     {{ form.fieldset_end() }}
-    
+
 
     {{ form.fieldset_start({ 'legend': 'Prepended Grid Sizes' }) }}
     {% for i in 1..9 %}

--- a/views/lexicon/forms/date.html.twig
+++ b/views/lexicon/forms/date.html.twig
@@ -23,9 +23,9 @@
 
     {{
         form.date({
-            'format': 'US',
+            'locale': 'en_US',
             'id': 'date-US',
-            'label': 'Date US style',
+            'label': 'Date US locale',
             'placeholder': 'mm/dd/yyyy'
         })
     }}
@@ -34,27 +34,28 @@
         form.date({
             'format': 'reverse',
             'id': 'date-reverse',
-            'label': 'Date reverse style',
+            'label': 'Date reverse format',
             'placeholder': 'yyyy/mm/dd'
         })
     }}
 
     {{
         form.date({
-            'format': 'locale',
-            'id': 'date-locale',
-            'label': 'Date locale style',
+            'id': 'date-iso',
+            'name': 'date-iso',
+            'label': 'Date with iso value',
+            'iso': true,
+            'help': 'Current Value: \'<span id="date-iso-value"></span>\''
         })
     }}
 
-    {{
-        form.date({
-            'id': 'date-locale',
-            'name': 'date-locale',
-            'label': 'Date with iso value',
-            'iso': true,
+    <script>
+        $(document).ready(function () {
+            $(document).on('change', '[name=date-iso]', function () {
+                $('#date-iso-value').text($(this).val());
+            })
         })
-    }}
+    </script>
 
     {{
         form.date({

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -859,7 +859,7 @@ Option      | Type   | Description
 autofocus   | bool   | Whether the field should have input focus on page load
 disabled    | bool   | Stops the element from being interactive if true
 form        | string | Specific one or more forms this label belongs to
-format      | string | Options for this can be `default`, `US`, `reverse` or `locale`
+locale      | string | The locale to format the date in
 iso         | bool   | Convert the value to an ISO format (default false)
 id          | string | A unique identifier, will also be used as the label's `for` attribute
 name        | string | The name of this control
@@ -880,9 +880,12 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
             'placeholder': options.placeholder|default('dd/mm/yyyy'),
             'data-datepicker': options['data-datepicker']|default('true'),
             'data-iso': options.iso|default(false),
-            'data-format': options.format|default('default')
+            'data-format': options.format|default(false),
+            'data-locale': options.locale|default('en_gb'),
         })|exclude([
-            'iso'
+            'iso',
+            'format',
+            'locale',
         ])
     %}
 

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -859,7 +859,8 @@ Option      | Type   | Description
 autofocus   | bool   | Whether the field should have input focus on page load
 disabled    | bool   | Stops the element from being interactive if true
 form        | string | Specific one or more forms this label belongs to
-format      | string | Options for this can be `default`, `US` or `reverse`
+format      | string | Options for this can be `default`, `US`, `reverse` or `locale`
+iso         | bool   | Convert the value to an ISO format (default false)
 id          | string | A unique identifier, will also be used as the label's `for` attribute
 name        | string | The name of this control
 placeholder | string | A short hint that describes the expected value
@@ -878,8 +879,11 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
         set options = options|default({})|merge({
             'placeholder': options.placeholder|default('dd/mm/yyyy'),
             'data-datepicker': options['data-datepicker']|default('true'),
+            'data-iso': options.iso|default(false),
             'data-format': options.format|default('default')
-        })
+        })|exclude([
+            'iso'
+        ])
     %}
 
     {% set options = modify_options(options|default({})) %}


### PR DESCRIPTION
POC of enabling the date helper to post back its data value in the HTML5 ISO format.

Additionally, there is a new format called `locale` which will automatically determine the format to display based on the browser locale.