### PR TITLE
Stop tooltips in CMS hiding the tooltip parent on leave

### DIFF
--- a/js/libs/tooltip.js
+++ b/js/libs/tooltip.js
@@ -119,11 +119,13 @@ var $ = require('jquery');
     var self = obj instanceof this.constructor ?
       obj : $(obj.currentTarget)[this.type](this.getDelegateOptions()).data('bs.' + this.type)
 
+    var $tip = this.tip()
+
     clearTimeout(self.timeout)
 
     self.hoverState = 'out'
-
-    if (!self.options.delay || !self.options.delay.hide) return self.hide()
+  
+    if (!self.options.delay || !self.options.delay.hide) return $tip.hide()
 
     self.timeout = setTimeout(function () {
       if (self.hoverState == 'out') self.hide()
@@ -404,10 +406,6 @@ var $ = require('jquery');
       var $this   = $(this)
       var data    = $this.data('bs.tooltips')
       var options = typeof option == 'object' && option
-
-      if ('ontouchstart' in window) {
-        return;
-      }
 
       if (!data && option == 'destroy') return
       if (!data) $this.data('bs.tooltips', (data = new Tooltips(this, options)))


### PR DESCRIPTION
So... I'm not entirely sure why CMS behaves differently given the same markup, but it hides the tooltip parent on leave rather than the actual tooltip.

Making the leave method explicitly hide the tooltip element fixes in CMS, and behaviour in Pulsar is not changed.

## Before
![tooltip-before](https://user-images.githubusercontent.com/18653/61791498-0e0eb500-ae12-11e9-9c5d-b6324aefcc18.gif)

## After
![tooltip-after](https://user-images.githubusercontent.com/18653/61791499-1109a580-ae12-11e9-9b31-c5ec7e0dbddf.gif)
