### PR TITLE
1012_add-reduced-motion-support

### DIFF
--- a/js/area/signin/signin.js
+++ b/js/area/signin/signin.js
@@ -45,7 +45,7 @@ SignInComponent.prototype.init = function () {
 	component.$videoBlock = this.$html.find('#video-bg');
 
 	// Handle background video and OS motion control
-	component.handleReduceMotion(component.motionQuery);
+	component.handleReduceMotion();
 	component.motionQuery.addListener(component.handleReduceMotion.bind(this));
 
 
@@ -451,7 +451,7 @@ SignInComponent.prototype.success = function () {
 
 }
 
-SignInComponent.prototype.handleReduceMotion = function (motionQuery) {
+SignInComponent.prototype.handleReduceMotion = function () {
 
 	var component = this,
 		videVideoPath = component.$videoBlock.attr('data-video-bg'),

--- a/js/area/signin/signin.js
+++ b/js/area/signin/signin.js
@@ -41,6 +41,14 @@ SignInComponent.prototype.init = function () {
 	component.transitionEnd = 'webkitTransitionEnd otransitionend oTransitionEnd msTransitionEnd transitionend',
 	component.twoStepAttempt = 0;
 
+	component.motionQuery = matchMedia('(prefers-reduced-motion: reduce)');
+	component.$videoBlock = this.$html.find('#video-bg');
+
+	// Handle background video and OS motion control
+	component.handleReduceMotion(component.motionQuery);
+	component.motionQuery.addListener(component.handleReduceMotion.bind(this));
+
+
 	// Polyfill placeholder behaviour in oldIE
 	this.$html.find('input').placeholder();
 
@@ -440,6 +448,28 @@ SignInComponent.prototype.success = function () {
 
 	component.$alert.append(document.createTextNode(component.successMessage));
 	component.$container.addClass('active-success');
+
+}
+
+SignInComponent.prototype.handleReduceMotion = function (motionQuery) {
+
+	var component = this,
+		videVideoPath = component.$videoBlock.attr('data-video-bg'),
+		videPosterPath = component.$videoBlock.attr('data-video-poster'),
+		videOptions;
+
+	if (!component.motionQuery.matches) {
+		videOptions = {
+			mp4: videVideoPath,
+			poster: videPosterPath
+		};
+	} else {
+		videOptions = {
+			poster: videPosterPath
+		};
+	}
+
+	component.$videoBlock.vide(videOptions);
 
 }
 

--- a/stylesheets/_component.dropzone.scss
+++ b/stylesheets/_component.dropzone.scss
@@ -261,14 +261,26 @@ $dropzone-icon-rotation: 30deg;
 
         .dropzone__icon--left {
             transform: rotate(-#{$dropzone-icon-rotation}) translateY(50%);
+
+            @include prefers-reduced-motion() {
+                transform: rotate(-#{$dropzone-icon-rotation}) translateY(75%);
+            }
         }
 
         .dropzone__icon--centre {
             transform: translateY(0) translateX(-50%);
+
+            @include prefers-reduced-motion() {
+                transform: translateX(-50%) translateY(25%);
+            }
         }
 
         .dropzone__icon--right {
             transform: rotate(#{$dropzone-icon-rotation}) translateY(50%);
+
+            @include prefers-reduced-motion() {
+                transform: rotate($dropzone-icon-rotation) translateY(75%);
+            }
         }
     }
 }

--- a/stylesheets/_component.loading.scss
+++ b/stylesheets/_component.loading.scss
@@ -69,6 +69,11 @@
     position: relative;
     width: 20px;
 
+    @include prefers-reduced-motion() {
+        height: auto;
+        width: auto;
+    }
+
     &.centered {
         display: block;
         margin: 0 auto;
@@ -95,6 +100,17 @@
     @include ie-lte(8) {
         border: 0;
         text-indent: 0;
+    }
+
+    @include prefers-reduced-motion() {
+        animation: none;
+        border: 0;
+        border-radius: 0;
+        float: none;
+        height: auto;
+        position: static;
+        text-indent: 0;
+        width: auto;
     }
 
     .lt-ie10 & {

--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -303,6 +303,11 @@
         transform: translate3d(70%, 0, 0) scale3d(.9, .9, .9);
         transition: opacity 300ms 100ms ease, transform 500ms ease;
 
+        @include prefers-reduced-motion() {
+            transition: none;
+            transform: none;
+        }
+
         @include respond-min($screen-desktop) {
             filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
             opacity: 1;
@@ -338,6 +343,10 @@
 
     @include respond-min($screen-desktop) {
         position: fixed;
+    }
+
+    @include prefers-reduced-motion() {
+        transition: none;
     }
 
     // cope with presence of scrollbars in IE
@@ -392,6 +401,10 @@
     margin-left: 242px;
     transition: all 100ms linear;
     width: 0;
+
+    @include prefers-reduced-motion() {
+        transition: none;
+    }
 }
 
 .nav-remove-search {

--- a/stylesheets/_component.tab-help.scss
+++ b/stylesheets/_component.tab-help.scss
@@ -2,7 +2,6 @@ $nav-color-light: color(jadu-blue) !default;
 $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
 
 .tab-help-container {
-
     backface-visibility: hidden;
     background: $nav-color-dark;
     box-shadow: inset 4px 0 0 darken($nav-color-dark, 5%);
@@ -38,6 +37,10 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
     transform-origin: 50% 0%;
     transform: translate3d(70%, 0, 0) scale3d(.9, .9, .9);
     transition: opacity 300ms 100ms ease, transform 400ms ease;
+
+    @include prefers-reduced-motion() {
+        transition: none;
+    }
 
     .open-help & {
         filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);

--- a/stylesheets/_component.table-detail.scss
+++ b/stylesheets/_component.table-detail.scss
@@ -21,6 +21,10 @@
     @include respond-min($screen-desktop) {
         display: table-cell;
     }
+
+    @include prefers-reduced-motion() {
+        transition: none;
+    }
 }
 
 .table-detail.table-detail--open {
@@ -39,6 +43,10 @@
 
     @include respond-min($screen-tablet) {
         width: 600px;
+    }
+
+    @include prefers-reduced-motion() {
+        transition: none;
     }
 }
 

--- a/stylesheets/_layout.tabs.scss
+++ b/stylesheets/_layout.tabs.scss
@@ -60,6 +60,11 @@
         width: 100%;
     }
 
+    @include prefers-reduced-motion() {
+        left: $nav-primary-width;
+        transform: none;
+    }
+
     .lt-ie10 & {
         left: $nav-primary-width;
     }
@@ -77,6 +82,12 @@
         transform: none;
         transition: transform 500ms ease;
         width: 100%;
+    }
+
+    @include prefers-reduced-motion() {
+        left: -300px;
+        transform: none;
+        transition: none;
     }
 }
 

--- a/stylesheets/_mixin.media-queries.scss
+++ b/stylesheets/_mixin.media-queries.scss
@@ -41,3 +41,9 @@
         }
     }
 }
+
+@mixin prefers-reduced-motion() {
+    @media screen and (prefers-reduced-motion: reduce) {
+        @content;
+    }
+}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/loading-label.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/loading-label.html
@@ -1,0 +1,1 @@
+<span class="loading"><i>Custom loading...</i></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/loading-label.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/loading-label.html.twig
@@ -1,0 +1,8 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    html.loading({
+        'label': 'Custom loading...'
+    })
+}}
+{% endblock %}

--- a/views/lexicon/tabs/loading.html.twig
+++ b/views/lexicon/tabs/loading.html.twig
@@ -8,6 +8,12 @@
     {{ html.loading() }}
     <br />
 
+    <h2 class="heading">Standalone with custom label</h2>
+    {{ html.loading({
+        'label': 'Custom loading'
+    }) }}
+    <br />
+
     <h2 class="heading">After form inputs</h2>
     {{ form.create() }}
     {{

--- a/views/playground/login/index.html.twig
+++ b/views/playground/login/index.html.twig
@@ -12,7 +12,7 @@
   <img src="../../../../images/video/galaxy.jpg" alt="galaxy background">
 </div>
 <!--<![endif]-->
-<div class="video" data-vide-bg="../../../../images/video/galaxy.mp4">
+<div class="video" id="video-bg" data-video-bg="../../../../images/video/galaxy.mp4" data-video-poster="../../../../images/video/galaxy.jpg">
 	<h1 class="signin-brand"><img src="../../../../images/branding/continuum-brandmark.svg" alt="Continuum Brandmark" /></h1>
 
 	<div class="signin-container">

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1019,12 +1019,13 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
     <span{{
         attributes(options
+            |exclude('label')
             |defaults({
                 'class': 'loading'
             })
         )
     }}>
-        <i>Loading...</i>
+        <i>{{- options.label|default('Loading...') -}}</i>
     </span>
 
 {% endspaceless %}


### PR DESCRIPTION
This MR adds support for OS prefer-reduced-motion settings to the following areas/components.

Fixes #1012 

1. Dropzone (icons are no longer animated on file drag and hover)
2. Loading component (now also supports a custom label for translations)
3. Navigation (All levels of navigation "fly outs")
4. Help mobile fly out
5. Table detail fly out
6. Continuum sign in video background playground

## Summary of breaking changes 🚨

Any UIs using the animated galaxy background (typically continuum sign in) will need to remove the `data-vide-bg` data attribute and add `id="video-bg" data-video-bg="{path/to/galaxy.mp4}" data-video-poster="{path/to/galaxy.jpg}"`. See example below:

Change from:

`<div class="video" data-vide-bg="{path/to/galaxy.mp4}">`

to 

`<div class="video" id="video-bg" data-video-bg="{path/to/galaxy.mp4}" data-video-poster="{path/to/galaxy.jpg}">`

## Breaking change checklist

The following points should be considered as an early-warning of introducing a breaking change to a Continuum platform product. This is not an exhaustive list of what constitutes a breaking change.

| Does this pull request... | Yes / No |
| ---- | ---- |
| require changes to `main.js` | ✅ No |
| require changes to `index.js` | ✅ No |
| require changes to `pulsar.scss` | ✅ No |
| require changes to `gruntfile.js` | ✅ No |
| require changes to `package.json` (not including dev dependencies) | ✅ No |
| require changes to `base.html.twig` (or other core views like header/footer) | ✅ No |
| require new arguments to be passed to a js component | ✅ No |
| require markup changes to maintain functionality | 🔴 YES (see background video changes detailed above) |
| require changes to existing unit tests | ✅ No |