### PR TITLE
Increase font weight of error summary

### DIFF
--- a/stylesheets/_component.error-summary.scss
+++ b/stylesheets/_component.error-summary.scss
@@ -2,6 +2,7 @@
     background-color: color(white);
     border: 5px solid color(danger);
     color: color(text);
+    font-family: $font-family-regular;
     margin-bottom: $margin-base * 2;
     padding: $padding-base * 1.5;
 


### PR DESCRIPTION
Before:
![Screenshot 2019-10-02 at 10 55 52](https://user-images.githubusercontent.com/756393/66035991-1cf5a000-e504-11e9-9e75-92f822247920.png)

After:
![Screenshot 2019-10-02 at 10 55 44](https://user-images.githubusercontent.com/756393/66035998-2121bd80-e504-11e9-8d44-e452acf9fafd.png)
