### PR TITLE
Fix issue causing modules with no pages to be incorrectly unselected

### DIFF
--- a/js/ModulePermissionsComponent.js
+++ b/js/ModulePermissionsComponent.js
@@ -113,11 +113,6 @@ ModulePermissionsComponent.prototype.toggleModuleRowState = function (target) {
         component.setDisabled($cud);
     }
 
-    component.toggleModulePageCrud($('[data-toggle="page"][data-crud="view"]', $this.closest('.module-page')));
-    component.toggleModulePageCrud($('[data-toggle="page"][data-crud="create"]', $this.closest('.module-page')));
-    component.toggleModulePageCrud($('[data-toggle="page"][data-crud="update"]', $this.closest('.module-page')));
-    component.toggleModulePageCrud($('[data-toggle="page"][data-crud="delete"]', $this.closest('.module-page')));
-
     component.toggleModuleCrud($('[data-toggle="module-crud"][data-crud="view"]', $this.closest('.module')));
     component.toggleModuleCrud($('[data-toggle="module-crud"][data-crud="create"]', $this.closest('.module')));
     component.toggleModuleCrud($('[data-toggle="module-crud"][data-crud="update"]', $this.closest('.module')));

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -594,6 +594,12 @@ fieldset {
         color: color(text);
         content: '\f00c';
     }
+
+    &:indeterminate::before {
+        color: color(text);
+        content: '\f068';
+        left: 3.5px;
+    }
 }
 
 .form__control.radio {


### PR DESCRIPTION
CMS team reported an issue with the module page component, the following behaviour was not being correctly triggered:

```
Given I have a module with no sub-pages
When I select the main module checkbox
Then the CRUD controls should all be checked
```

**Before**
![ezgif-2-13e2b449a55c](https://user-images.githubusercontent.com/18653/66403038-cd204880-e9dd-11e9-95bb-0686e946bf8a.gif)

**After**
![ezgif-2-2113828c1441-1](https://user-images.githubusercontent.com/18653/66403172-0953a900-e9de-11e9-8da0-b01cc03f4860.gif)

This change also restores indeterminate styling which was not originally added when we restyled the checkboxes.
