### PR TITLE
Fix documentation link in Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Watch a Jadu Academy session presented by Paul Stanton, Pulsar Product Owner whi
 
 ## Documentation
 
-Documentation is available online at [https://jadu.github.io/pulsar](https://jadu.github.io/pulsar), we welcome any feedback on areas which may need improvement.
+Documentation is available online at [https://pulsar.docs.jadu.net](https://pulsar.docs.jadu.net), we welcome any feedback on areas which may need improvement.
 
 ## Contributing
 


### PR DESCRIPTION
Documentation was pointing to the old docs. This MR fixes the URL

There is still the notes for contributors link which still points to the old docs but i couldn't find the same page on the new docs
