### PR TITLE
Fix issue preventing IE11 from removing repeater placeholders

### DIFF
--- a/js/Repeater/RepeaterComponent.js
+++ b/js/Repeater/RepeaterComponent.js
@@ -353,9 +353,10 @@ class Repeater {
         event.preventDefault();
 
         // Remove DOM
-        preview.remove();
-        edit.remove();
-        saved.remove();
+        
+        $(preview).remove();
+        $(edit).remove();
+        $(saved).remove();
 
         // Update state
         this.savedEntries--;

--- a/js/Repeater/RepeaterPlaceholderService.js
+++ b/js/Repeater/RepeaterPlaceholderService.js
@@ -30,7 +30,7 @@ class RepeaterPlaceholderService {
         this.queryService.updateRef('preview-placeholder', placeholder.cloneNode(true));
 
         // remove the placeholder from the DOM
-        placeholder.remove();
+        $(placeholder).remove();
     }
 }
 


### PR DESCRIPTION
IE doesn't support `.remove()` so I've bumped the objects to jQuery objects so jQuery can do the `.remove()`.

Closes #1041