### PR TITLE
form.choice improvements

### DIFF
--- a/stylesheets/_component.choice.scss
+++ b/stylesheets/_component.choice.scss
@@ -3,6 +3,21 @@
     overflow: visible;
 }
 
+fieldset.form-choice {
+    padding: 0;
+
+    > .control__label {
+        border-bottom: 0;
+        float: left; // as we can't use inline-block
+        font-size: inherit;
+        line-height: inherit;
+    }
+
+    > .controls {
+        clear: left;
+    }
+}
+
 // Align form-choice to grid
 @include respond-min($screen-tablet) {
     .form-choice > .controls > .control__label {

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-class.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-class.html
@@ -1,4 +1,4 @@
-<div class="form__group form-choice">
+<fieldset class="form__group form-choice">
     <div class="controls">
         <label class="control__label">
             <input name="choice" value="foo" type="radio" class="form__control radio foo-class" />
@@ -13,4 +13,4 @@
             <span class="form-choice__label">Baz</span>
         </label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-disabled.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-disabled.html
@@ -1,4 +1,4 @@
-<div class="form__group form-choice">
+<fieldset class="form__group form-choice">
     <div class="controls">
         <label class="control__label">
             <input name="choice" value="foo" type="radio" class="form__control radio" />
@@ -13,4 +13,4 @@
             <span class="form-choice__label">Baz</span>
         </label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-error.html
@@ -1,4 +1,4 @@
-<div class="form__group has-error form-choice">
+<fieldset class="form__group form-choice has-error">
     <div class="controls">
         <label class="control__label">
             <input name="choice" value="foo" aria-describedby="guid-1" type="radio" aria-invalid="true" class="form__control radio" />
@@ -14,4 +14,4 @@
         </label>
         <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-guidance-container.html
@@ -1,5 +1,5 @@
-<div class="form__group form-choice">
-    <label class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" data-toggle="popover" data-autoclose="true" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></label>
+<fieldset class="form__group form-choice">
+    <legend class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" data-toggle="popover" data-autoclose="true" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></legend>
     <div class="controls">
         <label class="control__label">
             <input name="choice" value="foo" type="radio" class="form__control radio" />
@@ -14,4 +14,4 @@
             <span class="form-choice__label">Baz</span>
         </label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-guidance.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-guidance.html
@@ -1,5 +1,5 @@
-<div class="form__group form-choice">
-    <label class="control__label">foo <i data-container="body" data-content="bar" data-placement="top" data-toggle="popover" data-autoclose="true" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></label>
+<fieldset class="form__group form-choice">
+    <legend class="control__label">foo <i data-container="body" data-content="bar" data-placement="top" data-toggle="popover" data-autoclose="true" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></legend>
     <div class="controls">
         <label class="control__label">
             <input name="choice" value="foo" type="radio" class="form__control radio" />
@@ -14,4 +14,4 @@
             <span class="form-choice__label">Baz</span>
         </label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-help.html
@@ -1,4 +1,4 @@
-<div class="form__group form-choice">
+<fieldset class="form__group form-choice">
     <div class="controls">
         <label class="control__label">
             <input name="choice" value="foo" aria-describedby="guid-1" type="radio" class="form__control radio" />
@@ -14,4 +14,4 @@
         </label>
         <span class="help-block" id="guid-1">my help text</span>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-label-hide.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-label-hide.html
@@ -1,5 +1,5 @@
-<div class="form__group form-choice">
-    <label class="control__label hide">Choice</label>
+<fieldset class="form__group form-choice">
+    <legend class="control__label hide">Choice</legend>
     <div class="controls">
         <label class="control__label">
             <input name="choice" value="foo" type="radio" class="form__control radio" />
@@ -14,4 +14,4 @@
             <span class="form-choice__label">Baz</span>
         </label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-label.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-label.html
@@ -1,5 +1,5 @@
-<div class="form__group form-choice">
-    <label class="control__label">Choice</label>
+<fieldset class="form__group form-choice">
+    <legend class="control__label">Choice</legend>
     <div class="controls">
         <label class="control__label">
             <input name="choice" value="foo" type="radio" class="form__control radio" />
@@ -14,4 +14,4 @@
             <span class="form-choice__label">Baz</span>
         </label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-multiple.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-multiple.html
@@ -1,4 +1,4 @@
-<div class="form__group form-choice">
+<fieldset class="form__group form-choice">
     <div class="controls">
         <label class="control__label">
             <input name="choice" value="foo" type="checkbox" class="form__control checkbox" />
@@ -13,4 +13,4 @@
             <span class="form-choice__label">Baz</span>
         </label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-few.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-optimize-few.html
@@ -1,4 +1,4 @@
-<div class="form__group form-choice">
+<fieldset class="form__group form-choice">
     <div class="controls">
         <label class="control__label">
             <input name="choice" value="one" type="radio" class="form__control radio" />
@@ -25,4 +25,4 @@
             <span class="form-choice__label">Six</span>
         </label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-required.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-required.html
@@ -1,33 +1,33 @@
-<div class="form__group form-choice">
-    <label class="control__label">foo&nbsp;<span class="required-indicator" data-toggle="tooltips" title="required">*</span></label>
+<fieldset class="form__group form-choice">
+    <legend class="control__label">foo&nbsp;<span class="required-indicator" data-toggle="tooltips" title="required">*</span></legend>
     <div class="controls">
         <label for="form_field_0" class="control__label">
-            <input 
-                id="form_field_0" 
-                name="form[field]" 
-                value="0" 
-                checked="checked" 
+            <input
+                id="form_field_0"
+                name="form[field]"
+                value="0"
+                checked="checked"
                 required aria-required="true"
-                type="radio" 
-                class="form__control radio" 
+                type="radio"
+                class="form__control radio"
             /><span class="form-choice__label">Foo</span></label>
         <label for="form_field_1" class="control__label">
-            <input 
-                id="form_field_1" 
-                name="form[field]" 
-                value="1" 
+            <input
+                id="form_field_1"
+                name="form[field]"
+                value="1"
                 required aria-required="true"
-                type="radio" 
-                class="form__control radio" 
+                type="radio"
+                class="form__control radio"
             /><span class="form-choice__label">Bar</span></label>
         <label for="form_field_2" class="control__label">
-            <input 
-                id="form_field_2" 
-                name="form[field]" 
-                value="2" 
+            <input
+                id="form_field_2"
+                name="form[field]"
+                value="2"
                 required aria-required="true"
-                type="radio" 
-                class="form__control radio" 
+                type="radio"
+                class="form__control radio"
             /><span class="form-choice__label">Baz</span></label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice.html
@@ -1,4 +1,4 @@
-<div class="form__group form-choice">
+<fieldset class="form__group form-choice">
     <div class="controls">
         <label class="control__label">
             <input name="choice" value="foo" type="radio" class="form__control radio" />
@@ -13,4 +13,4 @@
             <span class="form-choice__label">Baz</span>
         </label>
     </div>
-</div>
+</fieldset>

--- a/views/pulsar/v2/helpers/elem.html.twig
+++ b/views/pulsar/v2/helpers/elem.html.twig
@@ -113,6 +113,9 @@ name    | string | The name of this control
     {% if options.tag is defined and options.tag == 'span' %}
         {% set tag = 'span' %}
     {% endif %}
+    {% if options.tag is defined and options.tag == 'legend' %}
+        {% set tag = 'legend' %}
+    {% endif %}
 
     {% if options.label is not empty or options.guidance is not empty %}
         <{{ attributes(options

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -470,42 +470,92 @@ show-label | bool   | Control visibility of the `<label>` element without affect
             ])
         %}
 
+        {{
+            form.group({
+                'parent': options
+                    |only('bare class error error_ids guidance guidance-container help help_id id label required show-label')
+                    |exclude('multiple')
+                    |defaults({'class': 'form-choice'}),
+                'inputs': inputs
+            })
+        }}
+
     {% else %}
 
-        {% for input_options in options.options %}
-            {% set input_options = input_options|merge({
-                'bare': true,
-                'required-indicator': false,
-                'label': '<span class="form-choice__label">' ~ input_options.label ~ '</span>',
-                'aria-describedby': describedByIds|join(' ')
-            }) %}
+        {% set groupClass = 'form__group form-choice' %}
 
-            {% if options.error is defined and options.error is not empty %}
-                {% set input_options = input_options|merge({ 'has_error': true }) %}
-            {% endif %}
+        {% if options.error_ids is defined and options.error_ids is not empty %}
+            {% set groupClass = groupClass ~ ' has-error' %}
+        {% endif %}
 
-            {% if options.required is defined and options.required == true %}
-                {% set input_options = input_options|merge({ 'required': true }) %}
-            {% endif %}
+        {% set showLabel = true %}
+        {% if options['show-label'] is defined and options['show-label'] is not null and options['show-label'] == false %}
+            {% set showLabel = false %}
+        {% endif %}
 
-            {% if options.multiple %}
-                {% set inputs = inputs|merge([ form.checkbox_inline(input_options) ]) %}
-            {% else %}
-                {% set inputs = inputs|merge([ form.radio_inline(input_options) ]) %}
-            {% endif %}
-        {% endfor %}
+        {% if options.bare is not defined or options.bare != true %}
+        <fieldset{{
+            attributes(options
+                |only('class id')
+                |defaults({ 'class': groupClass })
+            )
+        -}}>
+
+            {{
+                elem.label({
+                    'guidance': options.guidance|default,
+                    'label': options.label|default,
+                    'required': options.required|default,
+                    'guidance-container': options['guidance-container']|default,
+                    'tag': 'legend',
+                    'show-label': showLabel
+                })
+            }}
+
+            <div class="controls">
+        {% endif %}
+
+                {% for input_options in options.options %}
+
+                    {% set input_options = input_options|merge({
+                        'bare': true,
+                        'required-indicator': false,
+                        'label': '<span class="form-choice__label">' ~ input_options.label ~ '</span>',
+                        'aria-describedby': describedByIds|join(' ')
+                    }) %}
+
+                    {% if options.error is defined and options.error is not empty %}
+                        {% set input_options = input_options|merge({ 'has_error': true }) %}
+                    {% endif %}
+
+                    {% if options.required is defined and options.required == true %}
+                        {% set input_options = input_options|merge({ 'required': true }) %}
+                    {% endif %}
+
+                    {% if options.multiple %}
+                        {{ form.checkbox_inline(input_options) }}
+                    {% else %}
+                        {{ form.radio_inline(input_options) }}
+                    {% endif %}
+
+                {% endfor %}
+
+                {% if options.error_ids is defined and options.error_ids is not empty %}
+                    {{ form.error({ 'value': options.error|default, 'error_ids':  options.error_ids }) }}
+                {% else %}
+                    {{ form.error({ 'value': options.error|default }) }}
+                {% endif %}
+
+                {% if options.help_id is defined and options.help_id is not empty %}
+                    {{ form.help({ 'value': options.help|default, 'id': options.help_id }) }}
+                {% endif %}
+
+        {% if options.bare is not defined or options.bare != true %}
+            </div>
+        </fieldset>
+        {% endif %}
 
     {% endif %}
-
-    {{
-        form.group({
-            'parent': options
-                |only('bare class error error_ids guidance guidance-container help help_id id label required show-label')
-                |exclude('multiple')
-                |defaults({'class': 'form-choice'}),
-            'inputs': inputs
-        })
-    }}
 
 {% endspaceless %}
 {% endmacro %}


### PR DESCRIPTION
This branch changes the behaviour of `form.choice()`. Previously when a `form.choice` helper, did not have the `many` option or contained 5 or less options the outputted radios/checkboxes were not grouped correctly (see #1077).

Previous mark up example:
```
<div class="form__group form-choice">
    <label for="19" class="control__label">Choice checkbox</label>
    <div class="controls">
        <label class="control__label">
            <input value="one" name="one" checked="" type="radio" class="form__control radio"> .   
            <span class="form-choice__label">Checkbox One</span>
        </label>
        <label class="control__label">
            <input value="two" name="one" type="radio" class="form__control radio">
            <span class="form-choice__label">Checkbox Two</span>
       </label>
       <label class="control__label">
           <input value="three" name="one" type="radio" class="form__control radio">
           <span class="form-choice__label">Checkbox Three</span>
       </label>
    </div>
</div>
```

New mark up example:
```
<fieldset class="form__group form-choice">
    <legend class="control__label">Choice radios</legend>
    <div class="controls">
        <label class="control__label">
            <input value="one" name="one" type="radio" class="form__control radio">
            <span class="form-choice__label">One</span>
        </label>
        <label class="control__label">
            <input value="two" name="one" type="radio" class="form__control radio">
            <span class="form-choice__label">Two</span>
        </label>
        <label class="control__label">
            <input value="three" name="one" type="radio" class="form__control radio">
            <span class="form-choice__label">Three</span>
        </label>
    </div>
</fieldset>
```

Resolves #1077 