### PR TITLE
Bump rule heading and link styles to meet AA contrast

### DIFF
--- a/stylesheets/_component.rules.scss
+++ b/stylesheets/_component.rules.scss
@@ -27,15 +27,16 @@
     }
 
     [href].conditional-block__link--when {
-        color: #1292c9;
+        color: color(primary, dark);
     }
 
-    [href].conditional-block__link--and {
-        color: #646464;
+    [href].conditional-block__link--and,
+    [href].conditional-block__link--or {
+        color: color(gray, dark);
     }
 
     [href].conditional-block__link--then {
-        color: #459a8c;
+        color: color(success, dark);
     }
 }
 
@@ -109,19 +110,19 @@
 }
 
 .rule-block__header--when {
-    box-shadow: inset 4px 0 0 0 #128fc5;
-    color: #128fc5;
+    box-shadow: inset 4px 0 0 0 color(primary, dark);
+    color: color(primary, dark);
 }
 
 .rule-block__header--then {
-    box-shadow: inset 4px 0 0 0 #459a8c;
-    color: #459a8c;
+    box-shadow: inset 4px 0 0 0 color(success, dark);
+    color: color(success, dark);
 }
 
 .rule-block__header--and,
 .rule-block__header--or {
-    box-shadow: inset 4px 0 0 0 #646464;
-    color: #646464;
+    box-shadow: inset 4px 0 0 0 color(gray, dark);
+    color: color(gray, dark);
 }
 
 .rule-block__heading {
@@ -255,7 +256,7 @@ td.table__form .rules + .form__group:last-of-type {
     }
 
     .rule-block__heading {
-        color: color(danger);
+        color: color(danger, dark);
     }
 
     .help-block {

--- a/stylesheets/_utility.states.scss
+++ b/stylesheets/_utility.states.scss
@@ -18,27 +18,15 @@ $danger-to-text-color: black;
 
 .has-success:not(.form__group) {
     background-color: lighten(color(success), 50) !important;
-
-    &:hover {
-        background-color: lighten(color(success), 47) !important;
-    }
 }
 
 .has-warning:not(.form__group) {
     background-color: lighten(color(warning), 20) !important;
-
-    &:hover {
-        background-color: lighten(color(warning), 17) !important;
-    }
 }
 
 .has-error:not(.form__group),
 .has-danger:not(.form__group) {
     background-color: color(danger, light) !important;
-
-    &:hover {
-        background-color: darken(color(danger, light), 5) !important;
-    }
 }
 
 @each $state, $state-color, $state-color-alt in $state-colors {


### PR DESCRIPTION
Rule block headings and conditional links colours have been darkened to meet AA contrast.

Also removed generic state hover styles on `.has-error`, `has-warning` and `has-success` to prevent contrast failures of other components on hover.

Fixes #1085 

![comparison](https://user-images.githubusercontent.com/756393/71103371-eb5ead80-21b1-11ea-865b-5b59fdd3f851.png)
