### PR TITLE
Give panels a face lift

### DIFF
--- a/stylesheets/_component.panels.scss
+++ b/stylesheets/_component.panels.scss
@@ -7,18 +7,25 @@
     &__title {
         border: 0;
         clear: none;
-        font-size: $font-size-xlarge;
-        line-height: 32px;
+        font-size: $font-size-large * 1.1;
+        line-height: $font-size-large * 1.3;
         margin-bottom: 0;
-        padding: 8px 5px 0 10px;
+        padding: 12px $padding-large-horizontal;
+        background: rgba(0, 0, 0, .01);
+        border-bottom: 1px solid rgba(0, 0, 0, .1);
 
         i::before {
           width: 30px;
         }
+
+        .panel--padded & {
+            margin-top: -($padding-large-vertical * 2);
+            padding-top: 12px + ($padding-large-vertical * 2);
+        }
     }
 
     &__body {
-        padding: 10px $padding-base-horizontal;
+        padding: 10px $padding-large-horizontal;
 
         p,
         ul {
@@ -73,8 +80,8 @@
 
 .panel__icon {
     float: left;
-    font-size: 24px;
-    margin: 10px 10px 0 12px;
+    font-size: $font-size-large * 1.1;
+    margin: 14px 10px 0 $padding-large-horizontal;
 }
 
 @each $state, $state-color, $state-color-alt in $state-colors {
@@ -108,8 +115,8 @@
 }
 
 .panel--padded {
-    padding-top: 24px;
-    padding-bottom: 24px;
+    padding-top: ($padding-large-vertical * 2);
+    padding-bottom: ($padding-large-vertical * 2);
 }
 
 // Panels within form groups should respect their width
@@ -156,7 +163,7 @@
 
 .panel__actions--inline {
     display: inline-block;
-    margin: 0 0 0 10px;
+    margin: 0 0 0 $padding-large-horizontal;
 }
 
 .panel__actions--center {
@@ -165,7 +172,7 @@
 }
 
 .panel__actions--right {
-    margin: 10px 0 0;
+    margin: $padding-large-horizontal 0 0;
     text-align: right;
 }
 

--- a/stylesheets/_component.panels.scss
+++ b/stylesheets/_component.panels.scss
@@ -5,14 +5,14 @@
     position: relative;
 
     &__title {
+        background: rgba(0, 0, 0, .01);
         border: 0;
+        border-bottom: 1px solid rgba(0, 0, 0, .1);
         clear: none;
         font-size: $font-size-large * 1.1;
         line-height: $font-size-large * 1.3;
         margin-bottom: 0;
         padding: 12px $padding-large-horizontal;
-        background: rgba(0, 0, 0, .01);
-        border-bottom: 1px solid rgba(0, 0, 0, .1);
 
         i::before {
           width: 30px;
@@ -115,8 +115,8 @@
 }
 
 .panel--padded {
-    padding-top: ($padding-large-vertical * 2);
     padding-bottom: ($padding-large-vertical * 2);
+    padding-top: ($padding-large-vertical * 2);
 }
 
 // Panels within form groups should respect their width

--- a/views/lexicon/tabs/panels.html.twig
+++ b/views/lexicon/tabs/panels.html.twig
@@ -171,6 +171,14 @@
         })
     }}
 
+    {{
+        html.panel({
+            'title': 'A list of items being shown',
+            'icon': 'warning-sign',
+            'body': '<ul><li>Item 1</li><li>Item 2</li><li>A long item 3</li><li>Another item</li></ul>',
+        })
+    }}
+
     <section class="panel panel--scroll with-timeline u-margin-top-none" aria-labelledby="guid-scroll">
         <h2 class="panel__title" id="guid-scroll">Content Pending Approval</h2>
 


### PR DESCRIPTION
Reduce panel title size
Add a separator bar between title and content
Increase panel default padding

**Before**
![Screen Shot 2019-12-04 at 14 33 01](https://user-images.githubusercontent.com/9383439/70151101-05bd6500-16a3-11ea-83f3-143162d2ae25.png)

**After**
![Screen Shot 2019-12-04 at 14 23 40](https://user-images.githubusercontent.com/9383439/70151000-d9094d80-16a2-11ea-85ba-ac9e92731615.png)
