### PR TITLE
Repeater a11y fixes

### DIFF
--- a/js/FocusManagementService.js
+++ b/js/FocusManagementService.js
@@ -1,0 +1,42 @@
+const $ = require('jquery'); // might not need
+
+class FocusManagementService {
+    /**
+     * Focus Management Service
+     */
+    constructor () {
+        this.$element = null;
+        this.focusableElementList = 'a[href], input, select, textarea, button';
+    }
+
+    /**
+     * Store element that focus will be returned to
+     * @param element {HTMLElement}
+     */
+    storeElement ($element) {
+        this.$element = $element;
+    }
+
+    /**
+     * Return focus to original element
+     */
+    returnFocusToElement () {
+        this.$element.focus();
+    }
+
+    /**
+     * Move focus to first focuable element in a collection
+     * @param jquery? or do we want to jqery in here?
+     */
+    focusFirstFocusableElement ($collection) {
+        const $focusableElements = $collection
+            .find(this.focusableElementList)
+            .not('[tabindex=-1], [disabled], :hidden, [aria-hidden]');
+
+        if ($focusableElements.length) {
+            $focusableElements.first().focus();
+        }
+    }
+}
+
+module.exports = FocusManagementService;

--- a/js/FocusManagementService.js
+++ b/js/FocusManagementService.js
@@ -1,5 +1,3 @@
-const $ = require('jquery'); // might not need
-
 class FocusManagementService {
     /**
      * Focus Management Service

--- a/js/FocusManagementService.js
+++ b/js/FocusManagementService.js
@@ -9,7 +9,7 @@ class FocusManagementService {
 
     /**
      * Store element that focus will be returned to
-     * @param element {HTMLElement}
+     * @param {jQuery} $element - jQuery wrapper of the element
      */
     storeElement ($element) {
         this.$element = $element;
@@ -24,7 +24,7 @@ class FocusManagementService {
 
     /**
      * Move focus to first focuable element in a collection
-     * @param jquery? or do we want to jqery in here?
+     * @param {jQuery} $collection - jQuery collection of elements
      */
     focusFirstFocusableElement ($collection) {
         const $focusableElements = $collection

--- a/js/Repeater/RepeaterComponent.js
+++ b/js/Repeater/RepeaterComponent.js
@@ -341,9 +341,7 @@ class Repeater {
      * @param event
      */
     handleEditGroup (repeaterId, event) {
-        const edit = this.queryService.get('preview-root')
-            .querySelector(`[${this.queryService.getAttr('edit-id')}="${repeaterId}"]`);
-        const $edit = $(edit);
+        const $edit = $(this.queryService.get('preview-root').querySelector(`[${this.queryService.getAttr('edit-id')}="${repeaterId}"]`));
 
         event.preventDefault();
         this.repeaterPreviewService.toggleUi();
@@ -390,8 +388,8 @@ class Repeater {
         // Enable "add group" button if we have not exceeded max saved entries
         if (this.savedEntries < this.maxSavedGroups) {
             $(this.queryService.get('add-group-button'))
-            .removeClass('disabled')
-            .removeAttr('disabled');
+                .removeClass('disabled')
+                .removeAttr('disabled');
         }
 
         // Update "add group" button text and add placeholder if we have removed all entries

--- a/js/Repeater/RepeaterComponent.js
+++ b/js/Repeater/RepeaterComponent.js
@@ -16,6 +16,7 @@ class Repeater {
      * @param repeaterDataService {RepeaterDataService}
      * @param repeaterPlaceholderService {RepeaterPlaceholderService}
      * @param formFieldResetService {FormFieldResetService}
+     * @param focusManagementService {FocusManagementService}
      */
     constructor (
         repeater,
@@ -30,7 +31,8 @@ class Repeater {
         pseudoRadioInputService,
         repeaterDataService,
         repeaterPlaceholderService,
-        formFieldResetService
+        formFieldResetService,
+        focusManagementService
     ) {
         this.pulsarFormComponent = pulsarFormComponent;
         this.queryService = queryService;
@@ -44,6 +46,7 @@ class Repeater {
         this.repeaterDataService = repeaterDataService;
         this.repeaterPlaceholderService = repeaterPlaceholderService;
         this.formFieldResetService = formFieldResetService;
+        this.focusManagementService = focusManagementService;
 
         this.repeater = repeater;
         this.repeaterEntries = 0;
@@ -57,13 +60,13 @@ class Repeater {
      */
     init (initialState = []) {
         // Preview UI HTML that is dynamically added to preview rows
-        this.previewUiHTML = `           
-            <a ${this.queryService.getAttr('edit-group')} ${this.queryService.getAttr('preview-ui')} href="#edit" class="remove__control alt-link margin-right">
-                <i class="icon-pencil"><span class="hide">Edit</span></i>
-            </a>
-            <a ${this.queryService.getAttr('delete-group')} ${this.queryService.getAttr('preview-ui')} href="#delete" class="remove__control alt-link">
-                <i class="icon-remove-sign"><span class="hide">Delete</span></i>
-            </a>
+        this.previewUiHTML = `
+            <button ${this.queryService.getAttr('edit-group')} ${this.queryService.getAttr('preview-ui')} class="btn btn--outline btn--inverse">
+                Edit
+            </button>
+            <button ${this.queryService.getAttr('delete-group')} ${this.queryService.getAttr('preview-ui')} class="btn btn--outline btn--inverse">
+                Delete
+            </button>
         `;
 
         const maxItemsAttr = this.repeater.getAttribute(this.queryService.getAttr('max-saved-groups'));
@@ -122,9 +125,19 @@ class Repeater {
      * @param event
      */
     handleAddGroup (event) {
+        const $addGroupForm = $(this.queryService.get('add-group-form'));
+
         event.preventDefault();
-        $(this.queryService.get('add-group-form')).show();
-        $(this.queryService.get('add-group-button')).addClass('disabled');
+        $addGroupForm.show();
+        $(this.queryService.get('add-group-button'))
+            .addClass('disabled')
+            .attr('disabled', true);
+
+        // Shift focus to the first focusable element in the form
+        this.focusManagementService.focusFirstFocusableElement($addGroupForm);
+
+        // Capture triggering element so we can return focus when closed
+        this.focusManagementService.storeElement($(event.target));
     }
 
     /**
@@ -205,7 +218,9 @@ class Repeater {
         this.savedEntries++;
 
         if (this.savedEntries < this.maxSavedGroups) {
-            $(this.queryService.get('add-group-button')).removeClass('disabled');
+            $(this.queryService.get('add-group-button'))
+                .removeClass('disabled')
+                .removeAttr('disabled');
 
             // Update add new group text
             this.queryService.get('add-group-button')
@@ -298,8 +313,11 @@ class Repeater {
             );
         });
 
-        // create unique for/id
+        // Create unique for/id
         this.uniqueIdService.uniquifyFors(preview.nextElementSibling);
+
+        // Create unique IDs for selectWoo elements
+        this.uniqueIdService.uniquifySelectWoo(group);
 
         // Refresh radio state
         this.pseudoRadioInputService.refresh();
@@ -325,11 +343,20 @@ class Repeater {
     handleEditGroup (repeaterId, event) {
         const edit = this.queryService.get('preview-root')
             .querySelector(`[${this.queryService.getAttr('edit-id')}="${repeaterId}"]`);
+        const $edit = $(edit);
 
         event.preventDefault();
         this.repeaterPreviewService.toggleUi();
-        $(this.queryService.get('add-group-button')).addClass('disabled');
-        $(edit).show();
+        $(this.queryService.get('add-group-button'))
+            .addClass('disabled')
+            .attr('disabled', true);
+        $edit.show();
+
+        // Shift focus to the first focusable element in the form
+        this.focusManagementService.focusFirstFocusableElement($edit);
+
+        // Capture triggering element so we can return focus when closed
+        this.focusManagementService.storeElement($(event.target));
     }
 
     /**
@@ -353,7 +380,6 @@ class Repeater {
         event.preventDefault();
 
         // Remove DOM
-        
         $(preview).remove();
         $(edit).remove();
         $(saved).remove();
@@ -363,7 +389,9 @@ class Repeater {
 
         // Enable "add group" button if we have not exceeded max saved entries
         if (this.savedEntries < this.maxSavedGroups) {
-            $(this.queryService.get('add-group-button')).removeClass('disabled');
+            $(this.queryService.get('add-group-button'))
+            .removeClass('disabled')
+            .removeAttr('disabled');
         }
 
         // Update "add group" button text and add placeholder if we have removed all entries
@@ -382,7 +410,12 @@ class Repeater {
      */
     handleCancelGroup (event) {
         if (this.savedEntries < this.maxSavedGroups) {
-            $(this.queryService.get('add-group-button')).removeClass('disabled');
+            $(this.queryService.get('add-group-button'))
+                .removeClass('disabled')
+                .removeAttr('disabled');
+
+            // Return focus to triggering element
+            this.focusManagementService.returnFocusToElement();
         }
 
         event.preventDefault();
@@ -425,8 +458,13 @@ class Repeater {
 
         // Enable "add group" button if we have not exceeded max saved entries
         if (this.savedEntries < this.maxSavedGroups) {
-            $(this.queryService.get('add-group-button')).removeClass('disabled');
+            $(this.queryService.get('add-group-button'))
+                .removeClass('disabled')
+                .removeAttr('disabled');
         }
+
+        // Return focus to triggering element
+        this.focusManagementService.returnFocusToElement();
 
         // Hide edit group form
         $(group).hide();
@@ -458,7 +496,9 @@ class Repeater {
 
         // Enable "add group" button if we have not exceeded max saved entries
         if (this.savedEntries < this.maxSavedGroups) {
-            $(this.queryService.get('add-group-button')).removeClass('disabled');
+            $(this.queryService.get('add-group-button'))
+                .removeClass('disabled')
+                .removeAttr('disabled');
         }
 
         // Update any colour pickers that might exist
@@ -466,6 +506,9 @@ class Repeater {
 
         // Hide edit group
         $(group).hide();
+
+        // Return focus to triggering element
+        this.focusManagementService.returnFocusToElement();
     }
 
     /**

--- a/js/Repeater/RepeaterPreviewService.js
+++ b/js/Repeater/RepeaterPreviewService.js
@@ -100,10 +100,10 @@ class RepeaterPreviewService {
                 let $previewUi = $(preview).find(this.queryService.getQuery('preview-ui'));
                 $previewUi.toggleClass('disabled');
 
-                if ($previewUi.attr('disabled')) {
-                    $previewUi.removeAttr('disabled');
+                if ($previewUi.prop('disabled') !== false) {
+                    $previewUi.prop('disabled', false);
                 } else {
-                    $previewUi.attr('disabled', true);
+                    $previewUi.prop('disabled', true);
                 }
             });
     }

--- a/js/Repeater/RepeaterPreviewService.js
+++ b/js/Repeater/RepeaterPreviewService.js
@@ -97,7 +97,14 @@ class RepeaterPreviewService {
                     true;
             })
             .forEach(preview => {
-                $(preview).find(this.queryService.getQuery('preview-ui')).toggleClass('disabled');
+                let $previewUi = $(preview).find(this.queryService.getQuery('preview-ui'));
+                $previewUi.toggleClass('disabled');
+
+                if ($previewUi.attr('disabled')) {
+                    $previewUi.removeAttr('disabled');
+                } else {
+                    $previewUi.attr('disabled', true);
+                }
             });
     }
 

--- a/js/Repeater/repeaterComponentFactory.js
+++ b/js/Repeater/repeaterComponentFactory.js
@@ -12,6 +12,7 @@ const Repeater = require('./RepeaterComponent');
 const RepeaterPlaceholderService = require('./RepeaterPlaceholderService');
 const FormFieldResetService = require('../utilities/FormFieldResetService');
 const config = require('./repeaterConfig');
+const FocusManagementService = require('../FocusManagementService')
 
 /**
  * Create a repeater component instance
@@ -59,6 +60,8 @@ function repeaterComponentFactory (
         queryService
     );
     const formFieldResetService = new FormFieldResetService();
+    const focusManagementService = new FocusManagementService();
+
 
     return new Repeater(
         repeater,
@@ -73,7 +76,8 @@ function repeaterComponentFactory (
         pseudoRadioInputService,
         repeaterDataService,
         repeaterPlaceholderService,
-        formFieldResetService
+        formFieldResetService,
+        focusManagementService
     );
 }
 

--- a/js/utilities/UniqueIdService.js
+++ b/js/utilities/UniqueIdService.js
@@ -40,6 +40,37 @@ class UniqueIdService {
                 element.setAttribute('id', hash);
             });
     }
+
+    /**
+     * Update selectWoo child elements with unique IDs
+     * @param group {HTMLElement}
+     */
+    uniquifySelectWoo (group) {
+        const orginalSelect = group.querySelector('select.js-select2');
+        const orginalSelectId = orginalSelect.getAttribute('id');
+
+        [].slice.call(group.querySelectorAll('.select2-container'))
+            .forEach(select2Container => {
+                if (select2Container.querySelector('.select2-selection--multiple')) {
+                    const selectWooSummary = select2Container.querySelector('.select2-selections');
+                    const selectWooSearch = select2Container.querySelector('.select2-search__field');
+                    const newSelectWooSummaryId = 'select2-' + orginalSelectId + '-summary';
+
+                    selectWooSummary.setAttribute('id', newSelectWooSummaryId);
+                    selectWooSearch.setAttribute('aria-describedby', newSelectWooSummaryId);
+                }
+
+                if (select2Container.querySelector('.select2-selection--single')) {
+                    const selectWooSingleSelection = select2Container.querySelector('.select2-selection--single');
+                    const selectWooSingleSelectionRendered = select2Container.querySelector('.select2-selection__rendered');
+                    const newSelectWooSingleSelectionRenderedId = 'select2-' + orginalSelectId + '-container';
+
+                    selectWooSingleSelectionRendered.setAttribute('id', newSelectWooSingleSelectionRenderedId);
+                    selectWooSingleSelection.setAttribute('aria-controls', newSelectWooSingleSelectionRenderedId)
+                    selectWooSingleSelection.setAttribute('aria-owns', newSelectWooSingleSelectionRenderedId)
+                }
+            });
+    }
 }
 
 module.exports = UniqueIdService;

--- a/js/utilities/UniqueIdService.js
+++ b/js/utilities/UniqueIdService.js
@@ -51,7 +51,7 @@ class UniqueIdService {
 
         [].slice.call(group.querySelectorAll('.select2-container'))
             .forEach(select2Container => {
-                if (select2Container.querySelector('.select2-selection--multiple')) {
+                if (select2Container.querySelector('.select2-selection--multiple') !== null) {
                     const selectWooSummary = select2Container.querySelector('.select2-selections');
                     const selectWooSearch = select2Container.querySelector('.select2-search__field');
                     const newSelectWooSummaryId = 'select2-' + orginalSelectId + '-summary';
@@ -60,7 +60,7 @@ class UniqueIdService {
                     selectWooSearch.setAttribute('aria-describedby', newSelectWooSummaryId);
                 }
 
-                if (select2Container.querySelector('.select2-selection--single')) {
+                if (select2Container.querySelector('.select2-selection--single') !== null) {
                     const selectWooSingleSelection = select2Container.querySelector('.select2-selection--single');
                     const selectWooSingleSelectionRendered = select2Container.querySelector('.select2-selection__rendered');
                     const newSelectWooSingleSelectionRenderedId = 'select2-' + orginalSelectId + '-container';

--- a/tests/js/web/FocusManagementServiceTest.js
+++ b/tests/js/web/FocusManagementServiceTest.js
@@ -31,7 +31,7 @@ describe('FocusManagementService', () => {
         it('should store the element', () => {
             focusManagementService.storeElement($link);
 
-            expect(focusManagementService.$element === $link).to.be.true;
+            expect(focusManagementService.$element).to.equal($link)
         });
     });
 
@@ -85,7 +85,7 @@ describe('FocusManagementService', () => {
         });
 
         it('should not focus the first element if it has tabindex="-1"', () => {
-            let $tabIndexZeroElement = $('<a href="#" tabindex="-1">Can not focus me</a>').prependTo($body);
+            const $tabIndexZeroElement = $('<a href="#" tabindex="-1">Can not focus me</a>').prependTo($body);
 
             focusManagementService.focusFirstFocusableElement($body);
 
@@ -93,7 +93,7 @@ describe('FocusManagementService', () => {
         });
 
         it('should not focus the first element if it has the disabled attribute', () => {
-            let $disabledInput = $('<input type="text" disabled/>').prependTo($body);
+            const $disabledInput = $('<input type="text" disabled/>').prependTo($body);
 
             focusManagementService.focusFirstFocusableElement($body);
 
@@ -101,7 +101,7 @@ describe('FocusManagementService', () => {
         });
 
         it('should not focus the first element if it has type hidden', () => {
-            let $hiddenInput = $('<input type="hidden"/>').prependTo($body);
+            const $hiddenInput = $('<input type="hidden"/>').prependTo($body);
 
             focusManagementService.focusFirstFocusableElement($body);
 
@@ -109,7 +109,7 @@ describe('FocusManagementService', () => {
         });
 
         it('should not focus the first element if it has the aria-hidden attribute', () => {
-            let $ariaHiddenlink= $('<a href="#" aria-hidden="true">Can not focus me</a>').prependTo($body);
+            const $ariaHiddenlink= $('<a href="#" aria-hidden="true">Can not focus me</a>').prependTo($body);
 
             focusManagementService.focusFirstFocusableElement($body);
 

--- a/tests/js/web/FocusManagementServiceTest.js
+++ b/tests/js/web/FocusManagementServiceTest.js
@@ -1,0 +1,119 @@
+import $ from 'jquery';
+import FocusManagementService from '../../../js/FocusManagementService'
+
+describe('FocusManagementService', () => {
+    let $html;
+    let $body;
+    let $link;
+    let $input;
+    let $select;
+    let $textarea;
+    let $button;
+    let focusManagementService;
+
+    beforeEach(() => {
+        $html = $('html');
+        $body = $('body');
+        $link = $('<a href="#">Link</a>').appendTo($body);
+        $input = $('<input type="text"/>');
+        $select = $('<select><option value="one">One</option></select>');
+        $textarea = $('<textarea>text</textarea>');
+        $button = $('<button>Button</button>');
+
+        focusManagementService = new FocusManagementService();
+    });
+
+    afterEach(() => {
+        $body.empty();
+    });
+
+    describe('storeElement()', () => {
+        it('should store the element', () => {
+            focusManagementService.storeElement($link);
+
+            expect(focusManagementService.$element === $link).to.be.true;
+        });
+    });
+
+    describe('returnFocusToElement()', () => {
+        it('should return focus to the stored the element', () => {
+            focusManagementService.storeElement($link);
+
+            focusManagementService.returnFocusToElement();
+
+            expect($link.is(':focus')).to.be.true;
+        });
+    });
+
+    describe('focusFirstFocusableElement()', () => {
+        it('should focus the first focusable element, if the element is a link ', () => {
+            focusManagementService.focusFirstFocusableElement($body);
+
+            expect($link.is(':focus')).to.be.true;
+        });
+
+        it('should focus the first focusable element, if the element is a input ', () => {
+            $input.prependTo($body);
+
+            focusManagementService.focusFirstFocusableElement($body);
+
+            expect($input.is(':focus')).to.be.true;
+        });
+
+        it('should focus the first focusable element, if the element is a select ', () => {
+            $select.prependTo($body);
+
+            focusManagementService.focusFirstFocusableElement($body);
+
+            expect($select.is(':focus')).to.be.true;
+        });
+
+        it('should focus the first focusable element, if the element is a textarea ', () => {
+            $textarea.prependTo($body);
+
+            focusManagementService.focusFirstFocusableElement($body);
+
+            expect($textarea.is(':focus')).to.be.true;
+        });
+
+        it('should focus the first focusable element, if the element is a button ', () => {
+            $button.prependTo($body);
+
+            focusManagementService.focusFirstFocusableElement($body);
+
+            expect($button.is(':focus')).to.be.true;
+        });
+
+        it('should not focus the first element if it has tabindex="-1"', () => {
+            let $tabIndexZeroElement = $('<a href="#" tabindex="-1">Can not focus me</a>').prependTo($body);
+
+            focusManagementService.focusFirstFocusableElement($body);
+
+            expect($link.is(':focus')).to.be.true;
+        });
+
+        it('should not focus the first element if it has the disabled attribute', () => {
+            let $disabledInput = $('<input type="text" disabled/>').prependTo($body);
+
+            focusManagementService.focusFirstFocusableElement($body);
+
+            expect($link.is(':focus')).to.be.true;
+        });
+
+        it('should not focus the first element if it has type hidden', () => {
+            let $hiddenInput = $('<input type="hidden"/>').prependTo($body);
+
+            focusManagementService.focusFirstFocusableElement($body);
+
+            expect($link.is(':focus')).to.be.true;
+        });
+
+        it('should not focus the first element if it has the aria-hidden attribute', () => {
+            let $ariaHiddenlink= $('<a href="#" aria-hidden="true">Can not focus me</a>').prependTo($body);
+
+            focusManagementService.focusFirstFocusableElement($body);
+
+            expect($link.is(':focus')).to.be.true;
+        });
+    });
+});

--- a/tests/js/web/Repeater/RepeaterPreviewServiceTest.js
+++ b/tests/js/web/Repeater/RepeaterPreviewServiceTest.js
@@ -212,10 +212,12 @@ describe('RepeaterPreviewService', () => {
             repeaterPreviewService.toggleUi(1);
 
             expect(root.children[1].firstElementChild.className).to.equal('disabled');
+            expect(root.children[1].firstElementChild.getAttribute('disabled')).to.equal('disabled');
 
             repeaterPreviewService.toggleUi(1);
 
             expect(root.children[1].firstElementChild.className).to.equal('');
+            expect(root.children[1].firstElementChild.getAttribute('disabled')).to.be.undefined;
         });
     });
 

--- a/tests/js/web/Repeater/RepeaterPreviewServiceTest.js
+++ b/tests/js/web/Repeater/RepeaterPreviewServiceTest.js
@@ -171,13 +171,13 @@ describe('RepeaterPreviewService', () => {
                 <div id="html">
                     <div id="ui">
                         <div>
-                            <div data-preview-id="0" data-preview-ui class="disabled"></div>
+                            <button data-preview-id="0" data-preview-ui class="disabled">button</button>
                         </div>
                         <div>
-                            <div data-preview-id="1" data-preview-ui class=""></div>
+                            <button data-preview-id="1" data-preview-ui class="">button</button>
                         </div>
                         <div>
-                            <div data-preview-id="2" data-preview-ui class=""></div>
+                            <button data-preview-id="2" data-preview-ui class="">button</button>
                         </div>
                     </div>
                 </div>
@@ -204,7 +204,7 @@ describe('RepeaterPreviewService', () => {
             expect(root.children[2].firstElementChild.className).to.equal('');
         });
 
-        it('should disable a specific preview IU element by ID', () => {
+        it('should disable a specific preview UI element by ID', () => {
             queryServiceStub.getAttr.withArgs('preview-id').returns('data-preview-id');
             queryServiceStub.getQuery.withArgs('preview-ui').returns('[data-preview-ui]');
             queryServiceStub.get.returns([].slice.call(root.children));
@@ -212,12 +212,12 @@ describe('RepeaterPreviewService', () => {
             repeaterPreviewService.toggleUi(1);
 
             expect(root.children[1].firstElementChild.className).to.equal('disabled');
-            expect(root.children[1].firstElementChild.getAttribute('disabled')).to.equal('disabled');
+            expect(root.children[1].firstElementChild.disabled).to.be.true;
 
             repeaterPreviewService.toggleUi(1);
 
             expect(root.children[1].firstElementChild.className).to.equal('');
-            expect(root.children[1].firstElementChild.getAttribute('disabled')).to.be.null;
+            expect(root.children[1].firstElementChild.disabled).to.be.false;
         });
     });
 

--- a/tests/js/web/Repeater/RepeaterPreviewServiceTest.js
+++ b/tests/js/web/Repeater/RepeaterPreviewServiceTest.js
@@ -217,7 +217,7 @@ describe('RepeaterPreviewService', () => {
             repeaterPreviewService.toggleUi(1);
 
             expect(root.children[1].firstElementChild.className).to.equal('');
-            expect(root.children[1].firstElementChild.getAttribute('disabled')).to.be.undefined;
+            expect(root.children[1].firstElementChild.getAttribute('disabled')).to.be.null;
         });
     });
 

--- a/tests/js/web/utilities/UniqueIdServiceTest.js
+++ b/tests/js/web/utilities/UniqueIdServiceTest.js
@@ -4,6 +4,8 @@ const HashService = require('../../../../js/utilities/HashService');
 describe('UniqueIdService', () => {
     let uniqueIdServive;
     let $root;
+    let $groupMultiSelect;
+    let $groupSingleSelect
     let hashServiceStub;
 
     beforeEach(() => {
@@ -11,16 +13,46 @@ describe('UniqueIdService', () => {
             <div id="root">
                 <label for="foo">foo</label>
                 <input id="foo">
-                
+
                 <label for="foo">foo</label>
                 <input id="foo">
 
                 <label for="bar">bar</label>
                 <input id="bar">
-                
+
                 <label for="no_id_on_page">baz</label>
             </div>
         `);
+
+        $groupMultiSelect = $(`
+            <div id="group-multi-select">
+                <select class="js-select2" id="example-select" multiple>
+                    <option>one</option>
+                    <option>two</option>
+                </select>
+                <span class="select2 select2-container">
+                    <span class="select2-selection select2-selection--multiple">
+                        <input class="select2-search__field" type="text" aria-describedby="select2-example-select-summary">
+                    </span>
+                    <span id="select2-example-select-summary" class="select2-selections"></span>
+                </span>
+            </div>
+        `);
+
+        $groupSingleSelect = $(`
+            <div id="group-single-select">
+                <select class="js-select2" id="example-select">
+                    <option>one</option>
+                    <option>two</option>
+                </select>
+                <span class="select2 select2-container">
+                    <span class="select2-selection select2-selection--single" aria-controls="select2-example-select-container" aria-owns="select2-example-select-container">
+                        <span class="select2-selection__rendered" id="select2-example-select-container">one</span>
+                    </span>
+                </span>
+            </div>
+        `);
+
         hashServiceStub = sinon.createStubInstance(HashService);
         uniqueIdServive = new UniqueIdService(hashServiceStub);
     });
@@ -65,6 +97,47 @@ describe('UniqueIdService', () => {
             expect($root.find('[id="foo_100"]')).to.have.length.of(1);
             expect($root.find('[id="foo_101"]')).to.have.length.of(1);
             expect($root.find('[id="foo_102"]')).to.have.length.of(1);
+        });
+    });
+
+    describe('uniquifySelectWoo', () => {
+        beforeEach(() => {
+            hashServiceStub.generate.onFirstCall().returns('foo_100');
+        });
+
+        it('should update the select woo selection summary with a unique ID when type is multiple', () => {
+            uniqueIdServive.uniquifyIds($groupMultiSelect[0]);
+            uniqueIdServive.uniquifySelectWoo($groupMultiSelect[0]);
+
+            expect($groupMultiSelect.find('.select2-selections').attr('id')).to.equal('select2-foo_100-summary');
+        });
+
+        it('should update the select woo selection search input aria-describedby ID when type is multiple', () => {
+            uniqueIdServive.uniquifyIds($groupMultiSelect[0]);
+            uniqueIdServive.uniquifySelectWoo($groupMultiSelect[0]);
+
+            expect($groupMultiSelect.find('.select2-search__field').attr('aria-describedby')).to.equal('select2-foo_100-summary');
+        });
+
+        it('should update the select woo selection rendered with a unique ID when type is single', () => {
+            uniqueIdServive.uniquifyIds($groupSingleSelect[0]);
+            uniqueIdServive.uniquifySelectWoo($groupSingleSelect[0]);
+
+            expect($groupSingleSelect.find('.select2-selection__rendered').attr('id')).to.equal('select2-foo_100-container');
+        });
+
+        it('should update the select woo selection rendered container aria-controls ID when type is single', () => {
+            uniqueIdServive.uniquifyIds($groupSingleSelect[0]);
+            uniqueIdServive.uniquifySelectWoo($groupSingleSelect[0]);
+
+            expect($groupSingleSelect.find('.select2-selection--single').attr('aria-controls')).to.equal('select2-foo_100-container');
+        });
+
+        it('should update the select woo selection rendered container aria-owns ID when type is single', () => {
+            uniqueIdServive.uniquifyIds($groupSingleSelect[0]);
+            uniqueIdServive.uniquifySelectWoo($groupSingleSelect[0]);
+
+            expect($groupSingleSelect.find('.select2-selection--single').attr('aria-owns')).to.equal('select2-foo_100-container');
         });
     });
 });

--- a/views/lexicon/forms/repeater.html.twig
+++ b/views/lexicon/forms/repeater.html.twig
@@ -17,6 +17,7 @@
             'max-entries': 3,
             'add-new-group-text': 'Add',
             'add-another-group-text': 'Add another',
+            'actions-column-text': 'Actions',
             'values': [
                 [{ name: 'text', value: 'Mike' }, { name: 'select2multi', value: ['food_gravy'] }],
                 [{ name: 'text', value: 'James' }, { name: 'select2multi', value: ['food_gravy', 'food_pizza'] }],

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -2410,12 +2410,13 @@ add-another-group-text  | string | The text content of the add another new entry
             }}
             <div class="controls">
                 <table class="table table--full table--horizontal repeatable__table">
+                    <caption class="hide">{{ options.label|default }}</caption>
                     <thead class="repeater__preview-headings">
                         <tr>
                             {% for heading in options.headings %}
                                 <th data-repeater-for-name="{{ heading.name }}">{{ heading.label }}</th>
                             {% endfor %}
-                            <th rowspan="1" colspan="1"></th>
+                            <th rowspan="1" colspan="1" class="shrink-to-fit"></th>
                         </tr>
                     </thead>
                     <tbody class="repeater__preview-data" data-repeater-preview-root>

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -2382,6 +2382,7 @@ headings                | Array  | An array of heading config objects: { name: s
 max-entries             | int    | Maximum (inclusive) number of entries that can be added
 add-new-group-text      | string | The text content of the add new entry button
 add-another-group-text  | string | The text content of the add another new entry button
+actions-column-text     | string | The text content of the actions column header
 
 0#}
 {% macro repeater_start(options) %}
@@ -2417,7 +2418,7 @@ add-another-group-text  | string | The text content of the add another new entry
                             {% for heading in options.headings %}
                                 <th data-repeater-for-name="{{ heading.name }}">{{ heading.label }}</th>
                             {% endfor %}
-                            <th rowspan="1" colspan="1" class="shrink-to-fit"></th>
+                            <th rowspan="1" colspan="1" class="shrink-to-fit">{{ options['actions-column-text']|default('Actions') }}</th>
                         </tr>
                     </thead>
                     <tbody class="repeater__preview-data" data-repeater-preview-root>

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -2405,7 +2405,8 @@ add-another-group-text  | string | The text content of the add another new entry
             {{
                 elem.label({
                     'label': options.label,
-                    'required': options.required|default(false)
+                    'required': options.required|default(false),
+                    'tag': 'span'
                 })
             }}
             <div class="controls">


### PR DESCRIPTION
This resolves various issues found in the repeater component, including:

1. Focus management for add, edit, save and close button actions
2. Changing add, save, cancel and edit buttons from links (`<a href="save">`) to `<button>`'s
3. Properly disabling the add button rather than just visually disabling it
4. Fixing issues where select2 child element IDs weren't unique after being cloned
5. Validation failures
6. Added a visually hidden caption to the repeater table
7. Adds actions column th text

Should be noted that SiteImprove still throws errors relating to hidden inputs not having a label. As their container has `display: none` this is not an issue and cannot be read by AT (confirmed in standard SRs).

Resolves #1071 