### PR TITLE
Bump jaduSelectWoo to v1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "dev": true,
       "requires": {
         "jsonparse": "0.0.5",
-        "through": "2.3.8"
+        "through": ">=2.2.7 <3"
       },
       "dependencies": {
         "jsonparse": {
@@ -46,7 +46,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.20",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -56,9 +56,9 @@
       "integrity": "sha1-eDPpg5oy3tdtJgIfNqQXB6Ug9ZM=",
       "dev": true,
       "requires": {
-        "ap": "0.2.0",
-        "balanced-match": "0.2.1",
-        "dot-parts": "1.0.1"
+        "ap": "~0.2.0",
+        "balanced-match": "~0.2.0",
+        "dot-parts": "~1.0.0"
       },
       "dependencies": {
         "balanced-match": {
@@ -71,7 +71,7 @@
     },
     "acorn": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
       "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
       "dev": true
     },
@@ -81,7 +81,7 @@
       "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3"
+        "acorn": "^5.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -98,7 +98,7 @@
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -115,9 +115,9 @@
       "integrity": "sha512-krFKvw/d1F17AN3XZbybIUzEY4YEPNiGo05AfP3dBlfVKrMHETKpgjpuZkSF8qDNt9UkQcqj7am8yJLseklCMg==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3",
-        "acorn-dynamic-import": "3.0.0",
-        "xtend": "4.0.1"
+        "acorn": "^5.7.1",
+        "acorn-dynamic-import": "^3.0.0",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -140,10 +140,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "aliasify": {
@@ -152,7 +152,7 @@
       "integrity": "sha1-A6oaX+W0ysYE47lnvEx86s+VcDA=",
       "dev": true,
       "requires": {
-        "browserify-transform-tools": "1.5.3"
+        "browserify-transform-tools": "~1.5.1"
       }
     },
     "align-text": {
@@ -161,9 +161,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "almond": {
@@ -201,8 +201,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "ap": {
@@ -223,15 +223,15 @@
       "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
       "dev": true,
       "requires": {
-        "archiver-utils": "1.3.0",
-        "async": "2.6.1",
-        "buffer-crc32": "0.2.13",
-        "glob": "7.1.3",
-        "lodash": "4.17.15",
-        "readable-stream": "2.3.6",
-        "tar-stream": "1.6.2",
-        "walkdir": "0.0.11",
-        "zip-stream": "1.2.0"
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "walkdir": "^0.0.11",
+        "zip-stream": "^1.1.0"
       },
       "dependencies": {
         "async": {
@@ -240,7 +240,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.15"
+            "lodash": "^4.17.10"
           }
         },
         "glob": {
@@ -249,12 +249,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -265,12 +265,12 @@
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "dev": true,
       "requires": {
-        "glob": "7.1.3",
-        "graceful-fs": "4.1.11",
-        "lazystream": "1.0.0",
-        "lodash": "4.17.15",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.3.6"
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       },
       "dependencies": {
         "glob": {
@@ -279,12 +279,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -295,8 +295,8 @@
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -305,7 +305,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -314,7 +314,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -371,7 +371,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -410,8 +410,8 @@
       "integrity": "sha1-c2vAq3lf60U0+t11l5fRBINXPic=",
       "dev": true,
       "requires": {
-        "chalk": "0.3.0",
-        "optimist": "0.6.1",
+        "chalk": "~0.3.0",
+        "optimist": "~0.6.0",
         "pad": "0.0.4"
       },
       "dependencies": {
@@ -423,12 +423,12 @@
         },
         "chalk": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
           "integrity": "sha1-HJhDdzfxGZ68wdTEj9Qbn5yOjyM=",
           "dev": true,
           "requires": {
-            "ansi-styles": "0.2.0",
-            "has-color": "0.1.7"
+            "ansi-styles": "~0.2.0",
+            "has-color": "~0.1.0"
           }
         }
       }
@@ -439,7 +439,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "asn1.js": {
@@ -448,9 +448,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -503,7 +503,7 @@
       "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.3"
       },
       "dependencies": {
         "acorn": {
@@ -562,10 +562,10 @@
       "integrity": "sha1-5kDEFK5Bmq4hwa1DyOoPPbgqVm0=",
       "dev": true,
       "requires": {
-        "browserslist": "0.4.0",
-        "caniuse-db": "1.0.30000887",
-        "num2fraction": "1.2.2",
-        "postcss": "4.1.16"
+        "browserslist": "~0.4.0",
+        "caniuse-db": "^1.0.30000214",
+        "num2fraction": "^1.1.0",
+        "postcss": "~4.1.12"
       }
     },
     "aws-sign2": {
@@ -586,8 +586,8 @@
       "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
       "dev": true,
       "requires": {
-        "follow-redirects": "1.5.8",
-        "is-buffer": "1.1.6"
+        "follow-redirects": "^1.2.5",
+        "is-buffer": "^1.1.5"
       }
     },
     "babel-code-frame": {
@@ -596,9 +596,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
@@ -607,25 +607,25 @@
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.6.0",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.15",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
       }
     },
     "babel-generator": {
@@ -634,14 +634,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.15",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -650,10 +650,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -662,10 +662,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.15"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-function-name": {
@@ -674,11 +674,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -687,8 +687,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -697,8 +697,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -707,8 +707,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -717,9 +717,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.15"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -728,11 +728,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -741,12 +741,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -755,8 +755,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-istanbul": {
@@ -765,22 +765,22 @@
       "integrity": "sha1-5yPwfJokMtiAVVILwi519cI5Fhw=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "handlebars": "4.0.12",
-        "js-yaml": "3.12.0",
-        "mkdirp": "0.5.1",
-        "multi-glob": "1.0.1",
-        "nopt": "3.0.6",
-        "object-assign": "4.1.1",
-        "once": "1.4.0",
-        "resolve": "1.8.1",
-        "source-map": "0.4.4",
-        "supports-color": "3.1.2",
-        "which": "1.2.14",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "multi-glob": "^1.0.1",
+        "nopt": "3.x",
+        "object-assign": "^4.0.1",
+        "once": "1.x",
+        "resolve": "^1.1.0",
+        "source-map": "0.4.x",
+        "supports-color": "3.1.x",
+        "which": "1.2.x",
+        "wordwrap": "1.0.x"
       },
       "dependencies": {
         "source-map": {
@@ -789,7 +789,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "supports-color": {
@@ -798,7 +798,7 @@
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -809,7 +809,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -818,12 +818,12 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
@@ -839,9 +839,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -850,7 +850,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -859,7 +859,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -868,11 +868,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.15"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -881,15 +881,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -898,8 +898,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -908,7 +908,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -917,8 +917,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -927,7 +927,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -936,9 +936,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -947,7 +947,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -956,9 +956,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -967,10 +967,10 @@
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -979,9 +979,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -990,9 +990,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1001,8 +1001,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1011,12 +1011,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1025,8 +1025,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1035,7 +1035,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1044,9 +1044,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1055,7 +1055,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1064,7 +1064,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1073,9 +1073,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1084,7 +1084,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1093,8 +1093,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-polyfill": {
@@ -1103,9 +1103,9 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       }
     },
     "babel-preset-es2015": {
@@ -1114,30 +1114,30 @@
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
       }
     },
     "babel-preset-es2017": {
@@ -1146,8 +1146,8 @@
       "integrity": "sha1-WXvq37n38gi8/YoS6bKym4svFNE=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1"
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.24.1"
       }
     },
     "babel-register": {
@@ -1156,13 +1156,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.7",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.15",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -1171,8 +1171,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -1189,11 +1189,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.15"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -1202,15 +1202,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.15"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -1219,20 +1219,20 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.15",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babelify": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
       "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "object-assign": "4.1.1"
+        "babel-core": "^6.0.14",
+        "object-assign": "^4.0.0"
       }
     },
     "babylon": {
@@ -1259,13 +1259,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1274,7 +1274,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -1283,7 +1283,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1292,7 +1292,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1301,9 +1301,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "isobject": {
@@ -1351,7 +1351,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "better-assert": {
@@ -1369,8 +1369,8 @@
       "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "dev": true,
       "requires": {
-        "buffers": "0.1.1",
-        "chainsaw": "0.1.0"
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
       }
     },
     "binary-extensions": {
@@ -1385,8 +1385,8 @@
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "bless": {
@@ -1407,7 +1407,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "bn.js": {
@@ -1422,10 +1422,10 @@
       "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
       "dev": true,
       "requires": {
-        "continuable-cache": "0.3.1",
-        "error": "7.0.2",
-        "raw-body": "1.1.7",
-        "safe-json-parse": "1.0.1"
+        "continuable-cache": "^0.3.1",
+        "error": "^7.0.0",
+        "raw-body": "~1.1.0",
+        "safe-json-parse": "~1.0.1"
       },
       "dependencies": {
         "bytes": {
@@ -1440,8 +1440,8 @@
           "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
           "dev": true,
           "requires": {
-            "bytes": "1.0.0",
-            "string_decoder": "0.10.31"
+            "bytes": "1",
+            "string_decoder": "0.10"
           }
         },
         "string_decoder": {
@@ -1464,7 +1464,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1474,9 +1474,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.3"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brorand": {
@@ -1491,7 +1491,7 @@
       "integrity": "sha1-B3Hav3ltMS8KfB8SgeAPdmDPcC8=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "through2": {
@@ -1500,8 +1500,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -1512,12 +1512,12 @@
       "integrity": "sha1-ja6VogykOz/qIB+qbPqoT/Sg1IQ=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.4",
-        "combine-source-map": "0.3.0",
-        "concat-stream": "1.4.11",
-        "defined": "1.0.0",
-        "through2": "0.5.1",
-        "umd": "3.0.3"
+        "JSONStream": "^1.0.3",
+        "combine-source-map": "~0.3.0",
+        "concat-stream": "~1.4.1",
+        "defined": "^1.0.0",
+        "through2": "~0.5.1",
+        "umd": "^3.0.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -1526,20 +1526,20 @@
           "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
           "dev": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           }
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -1554,8 +1554,8 @@
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "3.0.0"
+            "readable-stream": "~1.0.17",
+            "xtend": "~3.0.0"
           }
         },
         "xtend": {
@@ -1601,16 +1601,16 @@
       "integrity": "sha512-NqXek0cPNEayQm77VGnD+qrwcVBTKMIQ9bdP6IWDRUTU1Bk7tZeq5QR3OG5Rr36Rao1t+Vx1QnfolHvvr5qsTA==",
       "dev": true,
       "requires": {
-        "browser-sync-ui": "1.0.1",
+        "browser-sync-ui": "v1.0.1",
         "bs-recipes": "1.3.4",
         "chokidar": "1.7.0",
         "connect": "3.6.6",
-        "connect-history-api-fallback": "1.5.0",
-        "dev-ip": "1.0.1",
-        "easy-extender": "2.3.4",
+        "connect-history-api-fallback": "^1.5.0",
+        "dev-ip": "^1.0.1",
+        "easy-extender": "^2.3.4",
         "eazy-logger": "3.0.2",
-        "etag": "1.8.1",
-        "fresh": "0.5.2",
+        "etag": "^1.8.1",
+        "fresh": "^0.5.2",
         "fs-extra": "3.0.1",
         "http-proxy": "1.15.2",
         "immutable": "3.8.2",
@@ -1619,7 +1619,7 @@
         "opn": "5.3.0",
         "portscanner": "2.1.1",
         "qs": "6.2.3",
-        "raw-body": "2.3.3",
+        "raw-body": "^2.3.2",
         "resp-modifier": "6.0.2",
         "rx": "4.1.0",
         "serve-index": "1.9.1",
@@ -1637,70 +1637,70 @@
       "dev": true,
       "requires": {
         "async-each-series": "0.1.1",
-        "connect-history-api-fallback": "1.5.0",
-        "immutable": "3.8.2",
+        "connect-history-api-fallback": "^1.1.0",
+        "immutable": "^3.7.6",
         "server-destroy": "1.0.1",
         "socket.io-client": "2.0.4",
-        "stream-throttle": "0.1.3"
+        "stream-throttle": "^0.1.3"
       }
     },
     "browserify": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify/-/browserify-10.0.0.tgz",
       "integrity": "sha1-4Ber2ALGHu4NI7pNmUGL5DCBPvw=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.10.0",
-        "assert": "1.3.0",
-        "browser-pack": "4.0.4",
-        "browser-resolve": "1.11.3",
-        "browserify-zlib": "0.1.4",
-        "buffer": "3.6.0",
-        "builtins": "0.0.7",
+        "JSONStream": "~0.10.0",
+        "assert": "~1.3.0",
+        "browser-pack": "^4.0.0",
+        "browser-resolve": "^1.7.1",
+        "browserify-zlib": "~0.1.2",
+        "buffer": "^3.0.0",
+        "builtins": "~0.0.3",
         "commondir": "0.0.1",
-        "concat-stream": "1.4.11",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "0.0.1",
-        "crypto-browserify": "3.12.0",
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "deps-sort": "1.3.9",
-        "domain-browser": "1.1.7",
-        "duplexer2": "0.0.2",
-        "events": "1.0.2",
-        "glob": "4.5.3",
-        "has": "1.0.3",
-        "htmlescape": "1.1.1",
-        "http-browserify": "1.7.0",
-        "https-browserify": "0.0.1",
-        "inherits": "2.0.3",
-        "insert-module-globals": "6.6.3",
+        "concat-stream": "~1.4.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~0.0.1",
+        "crypto-browserify": "^3.0.0",
+        "deep-equal": "^1.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^1.3.5",
+        "domain-browser": "~1.1.0",
+        "duplexer2": "~0.0.2",
+        "events": "~1.0.0",
+        "glob": "^4.0.5",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "http-browserify": "^1.4.0",
+        "https-browserify": "~0.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^6.4.0",
         "isarray": "0.0.1",
-        "labeled-stream-splicer": "1.0.2",
-        "module-deps": "3.9.1",
-        "os-browserify": "0.1.2",
-        "parents": "1.0.1",
-        "path-browserify": "0.0.1",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "read-only-stream": "1.1.1",
-        "readable-stream": "1.1.14",
-        "resolve": "1.8.1",
+        "labeled-stream-splicer": "^1.0.0",
+        "module-deps": "^3.7.7",
+        "os-browserify": "~0.1.1",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^1.1.1",
+        "readable-stream": "^1.1.13",
+        "resolve": "^1.1.4",
         "shallow-copy": "0.0.1",
-        "shasum": "1.0.2",
-        "shell-quote": "0.0.1",
-        "stream-browserify": "1.0.0",
-        "string_decoder": "0.10.31",
-        "subarg": "1.0.0",
-        "syntax-error": "1.4.0",
-        "through2": "1.1.1",
-        "timers-browserify": "1.4.2",
-        "tty-browserify": "0.0.1",
-        "url": "0.10.3",
-        "util": "0.10.4",
-        "vm-browserify": "0.0.4",
-        "xtend": "4.0.1"
+        "shasum": "^1.0.0",
+        "shell-quote": "~0.0.1",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.0",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^1.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "~0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.1",
+        "vm-browserify": "~0.0.1",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "glob": {
@@ -1709,10 +1709,10 @@
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
           }
         },
         "minimatch": {
@@ -1721,19 +1721,19 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.0.0"
           }
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -1750,12 +1750,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cache-api": {
@@ -1764,9 +1764,9 @@
       "integrity": "sha1-liR+hT8Gj9bg1FzHPwuyzZd47wI=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "async": "^1.5.2",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "through2": {
@@ -1775,8 +1775,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -1787,9 +1787,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.2",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -1798,10 +1798,10 @@
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "browserify-incremental": {
@@ -1810,10 +1810,10 @@
       "integrity": "sha1-BxPLdYckemMqnwjPG9FpuHi2Koo=",
       "dev": true,
       "requires": {
-        "JSONStream": "0.10.0",
-        "browserify-cache-api": "3.0.1",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "JSONStream": "^0.10.0",
+        "browserify-cache-api": "^3.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "through2": {
@@ -1822,8 +1822,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -1834,18 +1834,18 @@
       "integrity": "sha1-haS0JdoffAngK6MqO0T2U104wlc=",
       "dev": true,
       "requires": {
-        "minimatch": "3.0.4",
-        "through": "2.3.8"
+        "minimatch": "^3.0.0",
+        "through": "^2.3.8"
       }
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-shim": {
@@ -1854,11 +1854,11 @@
       "integrity": "sha1-vxBXAmky0yU8de991xTzuHft7Gs=",
       "dev": true,
       "requires": {
-        "exposify": "0.5.0",
-        "mothership": "0.2.0",
-        "rename-function-calls": "0.1.1",
-        "resolve": "0.6.3",
-        "through": "2.3.8"
+        "exposify": "~0.5.0",
+        "mothership": "~0.2.0",
+        "rename-function-calls": "~0.1.0",
+        "resolve": "~0.6.1",
+        "through": "~2.3.4"
       },
       "dependencies": {
         "resolve": {
@@ -1875,13 +1875,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.4.1",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.1"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-transform-tools": {
@@ -1890,8 +1890,8 @@
       "integrity": "sha1-UJycZS+2sHvw0h787rsdgm+AdUs=",
       "dev": true,
       "requires": {
-        "falafel": "1.2.0",
-        "through": "2.3.8"
+        "falafel": "^1.0.1",
+        "through": "^2.3.7"
       }
     },
     "browserify-zlib": {
@@ -1900,16 +1900,16 @@
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
+        "pako": "~0.2.0"
       }
     },
     "browserslist": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
       "integrity": "sha1-O9SrkZncG5FQ1NbbpNnTqrvIbdQ=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000887"
+        "caniuse-db": "^1.0.30000153"
       }
     },
     "bs-recipes": {
@@ -1920,13 +1920,13 @@
     },
     "buffer": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
       "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
       "dev": true,
       "requires": {
         "base64-js": "0.0.8",
-        "ieee754": "1.1.12",
-        "isarray": "1.0.0"
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -1943,8 +1943,8 @@
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "1.1.0",
-        "buffer-fill": "1.0.0"
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -2013,15 +2013,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -2056,8 +2056,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -2092,8 +2092,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chai": {
@@ -2118,7 +2118,7 @@
       "integrity": "sha512-HBNyUy9giq6NEiO3Wzs+gjsE0++06QizfHaVUi1+UGkXsSJS/+4/xS7h5Jx7OML+69dqTIBaZnjlajzxzKiIaA==",
       "dev": true,
       "requires": {
-        "hiff": "0.3.0"
+        "hiff": "^0.3.0"
       }
     },
     "chainsaw": {
@@ -2127,20 +2127,20 @@
       "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "dev": true,
       "requires": {
-        "traverse": "0.3.9"
+        "traverse": ">=0.3.0 <0.4"
       }
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chartist": {
@@ -2154,16 +2154,16 @@
       "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
       "dev": true,
       "requires": {
-        "css-select": "1.0.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.10.1"
+        "css-select": "~1.0.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "~3.8.1",
+        "lodash": "^3.2.0"
       },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -2175,15 +2175,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.2.4",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.2.1"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "chownr": {
@@ -2199,8 +2199,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "class-utils": {
@@ -2209,10 +2209,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2221,7 +2221,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "isobject": {
@@ -2239,7 +2239,7 @@
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "7.1.3"
+        "glob": "^7.1.1"
       },
       "dependencies": {
         "glob": {
@@ -2248,12 +2248,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -2264,9 +2264,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "co": {
@@ -2293,8 +2293,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "collections": {
@@ -2303,20 +2303,20 @@
       "integrity": "sha1-dlcSXoSkCGotx5f/LWltgZpyD7U=",
       "dev": true,
       "requires": {
-        "mini-map": "1.0.0",
-        "pop-arrayify": "1.0.0",
-        "pop-clear": "1.0.0",
-        "pop-clone": "1.0.1",
-        "pop-compare": "1.0.0",
-        "pop-equals": "1.0.0",
-        "pop-has": "1.0.0",
-        "pop-hash": "1.0.1",
-        "pop-iterate": "1.0.1",
-        "pop-observe": "2.0.2",
-        "pop-swap": "1.0.0",
-        "pop-zip": "1.0.0",
+        "mini-map": "^1.0.0",
+        "pop-arrayify": "^1.0.0",
+        "pop-clear": "^1.0.0",
+        "pop-clone": "^1.0.1",
+        "pop-compare": "^1.0.0",
+        "pop-equals": "^1.0.0",
+        "pop-has": "^1.0.0",
+        "pop-hash": "^1.0.0",
+        "pop-iterate": "^1.0.1",
+        "pop-observe": "^2.0.2",
+        "pop-swap": "^1.0.0",
+        "pop-zip": "^1.0.0",
         "regexp-escape": "0.0.1",
-        "weak-map": "1.0.5"
+        "weak-map": "^1.0.4"
       }
     },
     "color-convert": {
@@ -2346,14 +2346,14 @@
       "integrity": "sha1-2edPWT2c1DgHMSy12EbUUe+qnrc=",
       "dev": true,
       "requires": {
-        "convert-source-map": "0.3.5",
-        "inline-source-map": "0.3.1",
-        "source-map": "0.1.43"
+        "convert-source-map": "~0.3.0",
+        "inline-source-map": "~0.3.0",
+        "source-map": "~0.1.31"
       },
       "dependencies": {
         "convert-source-map": {
           "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
           "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA=",
           "dev": true
         },
@@ -2363,7 +2363,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -2374,7 +2374,7 @@
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -2413,10 +2413,10 @@
       "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "crc32-stream": "2.0.0",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.3.6"
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       }
     },
     "concat-map": {
@@ -2431,21 +2431,21 @@
       "integrity": "sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14",
-        "typedarray": "0.0.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.9",
+        "typedarray": "~0.0.5"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -2464,7 +2464,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "1.3.2",
+        "parseurl": "~1.3.2",
         "utils-merge": "1.0.1"
       }
     },
@@ -2480,7 +2480,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "console-control-strings": {
@@ -2495,11 +2495,11 @@
       "integrity": "sha1-YiHbEHSgjYQP8wpcDLvzxgmnT4w=",
       "dev": true,
       "requires": {
-        "ansi_up": "1.3.0",
-        "brout": "1.2.0",
-        "browser-reload": "1.1.0",
-        "source-mapper": "2.1.0",
-        "through2": "2.0.3"
+        "ansi_up": "^1.3.0",
+        "brout": "^1.1.0",
+        "browser-reload": "^1.1.0",
+        "source-mapper": "^2.0.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "through2": {
@@ -2508,8 +2508,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -2538,7 +2538,7 @@
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.1"
       }
     },
     "cookie": {
@@ -2571,14 +2571,14 @@
       "integrity": "sha512-5MJtBUIfjeg3y7JZo8NCpHnWqODzNPKg1SC4gDDj20L8+7345U30NdAOeb4Gq3ILvnem9g64B9qYAMRVb6TBOg==",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.6.0",
-        "falafel": "2.1.0",
-        "minimist": "1.2.0",
-        "slash": "1.0.0",
-        "source-map": "0.4.4",
-        "split2": "0.2.1",
-        "stream-combiner2": "1.0.2",
-        "through2": "0.6.5"
+        "convert-source-map": "^1.1.0",
+        "falafel": "^2.1.0",
+        "minimist": "^1.1.1",
+        "slash": "^1.0.0",
+        "source-map": "~0.4.2",
+        "split2": "^0.2.1",
+        "stream-combiner2": "^1.0.2",
+        "through2": "~0.6.5"
       },
       "dependencies": {
         "acorn": {
@@ -2593,28 +2593,28 @@
           "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
           "dev": true,
           "requires": {
-            "acorn": "5.7.3",
-            "foreach": "2.0.5",
+            "acorn": "^5.0.0",
+            "foreach": "^2.0.5",
             "isarray": "0.0.1",
-            "object-keys": "1.0.12"
+            "object-keys": "^1.0.6"
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "source-map": {
@@ -2623,7 +2623,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "string_decoder": {
@@ -2638,8 +2638,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -2650,7 +2650,7 @@
       "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
       "dev": true,
       "requires": {
-        "buffer": "5.2.1"
+        "buffer": "^5.1.0"
       },
       "dependencies": {
         "base64-js": {
@@ -2665,8 +2665,8 @@
           "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
           "dev": true,
           "requires": {
-            "base64-js": "1.3.0",
-            "ieee754": "1.1.12"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
           }
         }
       }
@@ -2677,8 +2677,8 @@
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "dev": true,
       "requires": {
-        "crc": "3.8.0",
-        "readable-stream": "2.3.6"
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
       }
     },
     "create-ecdh": {
@@ -2687,8 +2687,8 @@
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.1"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -2697,11 +2697,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "md5.js": "1.3.4",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -2710,12 +2710,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-spawn": {
@@ -2724,8 +2724,8 @@
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.3",
-        "which": "1.2.14"
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
       },
       "dependencies": {
         "lru-cache": {
@@ -2734,8 +2734,8 @@
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         }
       }
@@ -2746,17 +2746,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.3",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.17",
-        "public-encrypt": "4.0.2",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "css-select": {
@@ -2765,10 +2765,10 @@
       "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "1.0.0",
-        "domutils": "1.4.3",
-        "nth-check": "1.0.1"
+        "boolbase": "~1.0.0",
+        "css-what": "1.0",
+        "domutils": "1.4",
+        "nth-check": "~1.0.0"
       }
     },
     "css-what": {
@@ -2789,7 +2789,7 @@
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
       "requires": {
-        "cssom": "0.3.4"
+        "cssom": "0.3.x"
       }
     },
     "currently-unhandled": {
@@ -2798,7 +2798,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "cycle": {
@@ -2814,7 +2814,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "datatables.net": {
@@ -2822,7 +2822,7 @@
       "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.19.tgz",
       "integrity": "sha512-+ljXcI6Pj3PTGy5pesp3E5Dr3x3AV45EZe0o1r0gKENN2gafBKXodVnk2ypKwl2tTmivjxbkiqoWnipTefyBTA==",
       "requires": {
-        "jquery": "3.4.1"
+        "jquery": ">=1.7"
       }
     },
     "datatables.net-buttons": {
@@ -2830,8 +2830,8 @@
       "resolved": "https://registry.npmjs.org/datatables.net-buttons/-/datatables.net-buttons-1.5.3.tgz",
       "integrity": "sha512-qGdYiquuIvoZSH0jkRTcVnS1LlCuJFOSlIX5wNmK+3267Ryq6r9llKFtgrIORkSlyy+M1TJMViFJxRSX5W62GA==",
       "requires": {
-        "datatables.net": "1.10.19",
-        "jquery": "3.4.1"
+        "datatables.net": "^1.10.15",
+        "jquery": ">=1.7"
       }
     },
     "datatables.net-buttons-dt": {
@@ -2840,8 +2840,8 @@
       "integrity": "sha512-EG8jwEpf5ll2vuDagmFL+95E1ZAH52hdNopy1xPx5XGuItw9J39BUTv91uPJDsuGfmxdYKuKET5voD2hvr2eOw==",
       "requires": {
         "datatables.net-buttons": "1.5.3",
-        "datatables.net-dt": "1.10.19",
-        "jquery": "3.4.1"
+        "datatables.net-dt": "^1.10.15",
+        "jquery": ">=1.7"
       }
     },
     "datatables.net-dt": {
@@ -2850,7 +2850,7 @@
       "integrity": "sha512-joFHYjLYvr9VnC9Fx3e+8jtXnQ/fP/mPFWt9p0NhZ3Zm5N0jlYyWhJQbnLkihOLuDcDFMaGdBQSvmIdTVdgGyw==",
       "requires": {
         "datatables.net": "1.10.19",
-        "jquery": "3.4.1"
+        "jquery": ">=1.7"
       }
     },
     "datatables.net-responsive": {
@@ -2858,8 +2858,8 @@
       "resolved": "https://registry.npmjs.org/datatables.net-responsive/-/datatables.net-responsive-2.2.3.tgz",
       "integrity": "sha512-8D6VtZcyuH3FG0Hn5A4LPZQEOX3+HrRFM7HjpmsQc/nQDBbdeBLkJX4Sh/o1nzFTSneuT1Wh/lYZHVPpjcN+Sw==",
       "requires": {
-        "datatables.net": "1.10.19",
-        "jquery": "3.4.1"
+        "datatables.net": "^1.10.15",
+        "jquery": ">=1.7"
       }
     },
     "datatables.net-responsive-dt": {
@@ -2867,9 +2867,9 @@
       "resolved": "https://registry.npmjs.org/datatables.net-responsive-dt/-/datatables.net-responsive-dt-2.2.3.tgz",
       "integrity": "sha512-NGxuii+3sWGG150AWmQ5NYCrTaFKUHo6GeizBR8o2Uuy68PnuNrSO27hyLvOYNLHQ9kALT66f/gTaBc2TdznFA==",
       "requires": {
-        "datatables.net-dt": "1.10.19",
+        "datatables.net-dt": "^1.10.15",
         "datatables.net-responsive": "2.2.3",
-        "jquery": "3.4.1"
+        "jquery": ">=1.7"
       }
     },
     "datatables.net-select": {
@@ -2877,8 +2877,8 @@
       "resolved": "https://registry.npmjs.org/datatables.net-select/-/datatables.net-select-1.2.7.tgz",
       "integrity": "sha512-C3XDi7wpruGjDXV36dc9hN/FrAX9GOFvBZ7+KfKJTBNkGFbbhdzHS91SMeGiwRXPYivAyxfPTcVVndVaO83uBQ==",
       "requires": {
-        "datatables.net": "1.10.19",
-        "jquery": "3.4.1"
+        "datatables.net": "^1.10.15",
+        "jquery": ">=1.7"
       }
     },
     "datatables.net-select-dt": {
@@ -2886,9 +2886,9 @@
       "resolved": "https://registry.npmjs.org/datatables.net-select-dt/-/datatables.net-select-dt-1.2.7.tgz",
       "integrity": "sha512-q8pMWJJRgewblXE7TnqlzEXMQe6GFmBKCARFeLBSoEpQLz/ael8a24uu5D48ZrTZX9/8EGESeQQzxckC2EfKlQ==",
       "requires": {
-        "datatables.net-dt": "1.10.19",
+        "datatables.net-dt": "^1.10.15",
         "datatables.net-select": "1.2.7",
-        "jquery": "3.4.1"
+        "jquery": ">=1.7"
       }
     },
     "date-now": {
@@ -2903,8 +2903,8 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
       }
     },
     "debug": {
@@ -2935,7 +2935,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "mimic-response": "1.0.1"
+        "mimic-response": "^1.0.0"
       }
     },
     "deep-eql": {
@@ -2972,8 +2972,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -2982,7 +2982,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2991,7 +2991,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -3000,9 +3000,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "isobject": {
@@ -3049,10 +3049,10 @@
       "integrity": "sha1-Kd//U+F7Nq7K51MK27v2IsLtGnE=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.4",
-        "shasum": "1.0.2",
-        "subarg": "1.0.0",
-        "through2": "1.1.1"
+        "JSONStream": "^1.0.3",
+        "shasum": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^1.0.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -3061,8 +3061,8 @@
           "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
           "dev": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           }
         }
       }
@@ -3073,8 +3073,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -3089,7 +3089,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "detect-libc": {
@@ -3105,8 +3105,8 @@
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3",
-        "defined": "1.0.0"
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -3135,9 +3135,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "dom-serializer": {
@@ -3146,8 +3146,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -3176,7 +3176,7 @@
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -3185,7 +3185,7 @@
       "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "dot-parts": {
@@ -3200,19 +3200,19 @@
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.9"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3229,8 +3229,8 @@
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "dev": true,
       "requires": {
-        "onetime": "1.1.0",
-        "set-immediate-shim": "1.0.1"
+        "onetime": "^1.0.0",
+        "set-immediate-shim": "^1.0.0"
       }
     },
     "easy-extender": {
@@ -3239,7 +3239,7 @@
       "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.15"
+        "lodash": "^4.17.10"
       }
     },
     "eazy-logger": {
@@ -3248,7 +3248,7 @@
       "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
       "dev": true,
       "requires": {
-        "tfunk": "3.1.0"
+        "tfunk": "^3.0.1"
       }
     },
     "ecc-jsbn": {
@@ -3258,8 +3258,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
@@ -3274,13 +3274,13 @@
       "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.5",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "encodeurl": {
@@ -3295,7 +3295,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "engine.io": {
@@ -3304,12 +3304,12 @@
       "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
       "dev": true,
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.4",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.2",
-        "ws": "3.3.3"
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.0",
+        "ws": "~3.3.1"
       },
       "dependencies": {
         "debug": {
@@ -3331,14 +3331,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.2",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "3.3.3",
-        "xmlhttprequest-ssl": "1.5.5",
+        "ws": "~3.3.1",
+        "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -3360,10 +3360,10 @@
       "dev": true,
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "0.0.7",
+        "arraybuffer.slice": "~0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "1.0.3"
+        "has-binary2": "~1.0.2"
       }
     },
     "entities": {
@@ -3378,8 +3378,8 @@
       "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "dev": true,
       "requires": {
-        "string-template": "0.2.1",
-        "xtend": "4.0.1"
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
       }
     },
     "error-ex": {
@@ -3388,12 +3388,12 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es6-promise": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
       "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw=",
       "dev": true
     },
@@ -3403,7 +3403,7 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.5"
+        "es6-promise": "^4.0.3"
       },
       "dependencies": {
         "es6-promise": {
@@ -3432,11 +3432,11 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
       },
       "dependencies": {
         "source-map": {
@@ -3446,7 +3446,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -3477,7 +3477,7 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
@@ -3499,8 +3499,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.2"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "exit": {
@@ -3515,7 +3515,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -3524,7 +3524,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.4"
+        "fill-range": "^2.1.0"
       }
     },
     "expand-template": {
@@ -3540,11 +3540,11 @@
       "integrity": "sha1-+S0AlMJls/VT4fpFagOhiD0QWcw=",
       "dev": true,
       "requires": {
-        "globo": "1.1.0",
-        "map-obj": "1.0.1",
-        "replace-requires": "1.0.4",
-        "through2": "0.4.2",
-        "transformify": "0.1.2"
+        "globo": "~1.1.0",
+        "map-obj": "~1.0.1",
+        "replace-requires": "~1.0.3",
+        "through2": "~0.4.0",
+        "transformify": "~0.1.1"
       },
       "dependencies": {
         "object-keys": {
@@ -3555,14 +3555,14 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3577,8 +3577,8 @@
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
           }
         },
         "xtend": {
@@ -3587,7 +3587,7 @@
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "dev": true,
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -3604,8 +3604,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3614,7 +3614,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -3625,7 +3625,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extract-zip": {
@@ -3646,10 +3646,10 @@
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         }
       }
@@ -3673,10 +3673,10 @@
       "integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
       "dev": true,
       "requires": {
-        "acorn": "1.2.2",
-        "foreach": "2.0.5",
+        "acorn": "^1.0.3",
+        "foreach": "^2.0.5",
         "isarray": "0.0.1",
-        "object-keys": "1.0.12"
+        "object-keys": "^1.0.6"
       }
     },
     "fast-deep-equal": {
@@ -3703,7 +3703,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": "0.7.0"
+        "websocket-driver": ">=0.5.1"
       }
     },
     "fd-slicer": {
@@ -3712,7 +3712,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "figures": {
@@ -3721,8 +3721,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-sync-cmp": {
@@ -3743,11 +3743,11 @@
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "3.1.0",
-        "repeat-element": "1.1.3",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "finalhandler": {
@@ -3757,12 +3757,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       }
     },
     "find-parent-dir": {
@@ -3777,8 +3777,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "findup-sync": {
@@ -3787,7 +3787,7 @@
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
       "requires": {
-        "glob": "5.0.15"
+        "glob": "~5.0.0"
       }
     },
     "follow-redirects": {
@@ -3796,7 +3796,7 @@
       "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0"
+        "debug": "=3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -3827,7 +3827,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -3848,9 +3848,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.20"
+        "mime-types": "^2.1.12"
       },
       "dependencies": {
         "combined-stream": {
@@ -3859,7 +3859,7 @@
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         }
       }
@@ -3870,7 +3870,7 @@
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "samsam": "1.x"
       }
     },
     "fragment-cache": {
@@ -3879,7 +3879,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -3900,9 +3900,9 @@
       "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "3.0.1",
-        "universalify": "0.1.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^3.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -3918,8 +3918,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.11.0",
-        "node-pre-gyp": "0.10.0"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -3945,8 +3945,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -3959,7 +3959,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -4023,7 +4023,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -4038,14 +4038,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -4054,12 +4054,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -4074,7 +4074,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -4083,7 +4083,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -4092,8 +4092,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -4112,7 +4112,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -4126,7 +4126,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -4139,8 +4139,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -4149,7 +4149,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -4172,9 +4172,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -4183,16 +4183,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -4201,8 +4201,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -4217,8 +4217,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -4227,10 +4227,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -4249,7 +4249,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -4270,8 +4270,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -4292,10 +4292,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -4312,13 +4312,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -4327,7 +4327,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -4370,9 +4370,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -4381,7 +4381,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -4389,7 +4389,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -4404,13 +4404,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -4425,7 +4425,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -4446,10 +4446,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "function-bind": {
@@ -4464,14 +4464,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.3"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "gaze": {
@@ -4480,7 +4480,7 @@
       "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "dev": true,
       "requires": {
-        "globule": "1.2.1"
+        "globule": "^1.0.0"
       }
     },
     "get-assigned-identifiers": {
@@ -4519,7 +4519,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "github-from-package": {
@@ -4535,11 +4535,11 @@
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
       "dev": true,
       "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -4548,8 +4548,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -4558,7 +4558,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "globals": {
@@ -4573,9 +4573,9 @@
       "integrity": "sha1-DSYJiVXepCLrIAGxBImLChAcqvM=",
       "dev": true,
       "requires": {
-        "accessory": "1.1.0",
-        "is-defined": "1.0.0",
-        "ternary": "1.0.0"
+        "accessory": "~1.1.0",
+        "is-defined": "~1.0.0",
+        "ternary": "~1.0.0"
       }
     },
     "globule": {
@@ -4584,9 +4584,9 @@
       "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
       "dev": true,
       "requires": {
-        "glob": "7.1.3",
-        "lodash": "4.17.15",
-        "minimatch": "3.0.4"
+        "glob": "~7.1.1",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2"
       },
       "dependencies": {
         "glob": {
@@ -4595,12 +4595,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -4623,23 +4623,23 @@
       "integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
       "dev": true,
       "requires": {
-        "coffeescript": "1.10.0",
-        "dateformat": "1.0.12",
-        "eventemitter2": "0.4.14",
-        "exit": "0.1.2",
-        "findup-sync": "0.3.0",
-        "glob": "7.0.6",
-        "grunt-cli": "1.2.0",
-        "grunt-known-options": "1.1.1",
-        "grunt-legacy-log": "2.0.0",
-        "grunt-legacy-util": "1.1.1",
-        "iconv-lite": "0.4.23",
-        "js-yaml": "3.5.5",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "coffeescript": "~1.10.0",
+        "dateformat": "~1.0.12",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.3.0",
+        "glob": "~7.0.0",
+        "grunt-cli": "~1.2.0",
+        "grunt-known-options": "~1.1.0",
+        "grunt-legacy-log": "~2.0.0",
+        "grunt-legacy-util": "~1.1.1",
+        "iconv-lite": "~0.4.13",
+        "js-yaml": "~3.5.2",
+        "minimatch": "~3.0.2",
+        "mkdirp": "~0.5.1",
+        "nopt": "~3.0.6",
+        "path-is-absolute": "~1.0.0",
+        "rimraf": "~2.6.2"
       },
       "dependencies": {
         "glob": {
@@ -4648,12 +4648,12 @@
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "grunt-cli": {
@@ -4662,10 +4662,10 @@
           "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
           "dev": true,
           "requires": {
-            "findup-sync": "0.3.0",
-            "grunt-known-options": "1.1.1",
-            "nopt": "3.0.6",
-            "resolve": "1.1.7"
+            "findup-sync": "~0.3.0",
+            "grunt-known-options": "~1.1.0",
+            "nopt": "~3.0.6",
+            "resolve": "~1.1.0"
           }
         },
         "js-yaml": {
@@ -4674,8 +4674,8 @@
           "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "2.7.3"
+            "argparse": "^1.0.2",
+            "esprima": "^2.6.0"
           }
         },
         "resolve": {
@@ -4692,7 +4692,7 @@
       "integrity": "sha1-TYiEnkVAVCecEeNEaZc0TwdNzDs=",
       "dev": true,
       "requires": {
-        "asciify": "1.3.5"
+        "asciify": "~1.3.0"
       }
     },
     "grunt-autoprefixer": {
@@ -4701,29 +4701,29 @@
       "integrity": "sha1-/kLiR7z6ucKSoSwGLa1PNb3pAsU=",
       "dev": true,
       "requires": {
-        "autoprefixer-core": "5.2.1",
-        "chalk": "1.0.0",
-        "diff": "1.3.2",
-        "postcss": "4.1.16"
+        "autoprefixer-core": "^5.1.7",
+        "chalk": "~1.0.0",
+        "diff": "~1.3.0",
+        "postcss": "^4.1.11"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
           "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
           "dev": true
         },
         "chalk": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "integrity": "sha1-s89O0P9Tl8mcdbj2edsvUoMfltw=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "1.0.3",
-            "strip-ansi": "2.0.1",
-            "supports-color": "1.3.1"
+            "ansi-styles": "^2.0.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^1.0.3",
+            "strip-ansi": "^2.0.1",
+            "supports-color": "^1.3.0"
           }
         },
         "diff": {
@@ -4738,8 +4738,8 @@
           "integrity": "sha1-wLWxYV2eOCsP9nFp2We0JeSMpTg=",
           "dev": true,
           "requires": {
-            "ansi-regex": "1.1.1",
-            "get-stdin": "4.0.1"
+            "ansi-regex": "^1.1.0",
+            "get-stdin": "^4.0.1"
           }
         },
         "strip-ansi": {
@@ -4748,7 +4748,7 @@
           "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "1.1.1"
+            "ansi-regex": "^1.0.0"
           }
         },
         "supports-color": {
@@ -4765,13 +4765,13 @@
       "integrity": "sha1-ahikDaGCDsRcvP6p0VXuK0yAr+Y=",
       "dev": true,
       "requires": {
-        "bless": "3.0.3",
-        "chalk": "0.5.1"
+        "bless": "~3.0.0",
+        "chalk": "~0.5.1"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
           "dev": true
         },
@@ -4783,15 +4783,15 @@
         },
         "chalk": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           }
         },
         "has-ansi": {
@@ -4800,7 +4800,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.0"
           }
         },
         "strip-ansi": {
@@ -4809,7 +4809,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.1"
           }
         },
         "supports-color": {
@@ -4826,7 +4826,7 @@
       "integrity": "sha1-oOnB/RzLXEVMJexRcBE///BqR3I=",
       "dev": true,
       "requires": {
-        "browser-sync": "2.24.7"
+        "browser-sync": "^2.6.4"
       }
     },
     "grunt-browserify": {
@@ -4835,13 +4835,13 @@
       "integrity": "sha1-R/2M+LrFj+LeaDr9xX9/OoDKeS0=",
       "dev": true,
       "requires": {
-        "async": "2.6.1",
-        "browserify": "16.2.3",
-        "browserify-incremental": "3.1.1",
-        "glob": "7.1.3",
-        "lodash": "4.17.15",
-        "resolve": "1.8.1",
-        "watchify": "3.11.0"
+        "async": "^2.5.0",
+        "browserify": "^16.0.0",
+        "browserify-incremental": "^3.1.1",
+        "glob": "^7.1.2",
+        "lodash": "^4.17.4",
+        "resolve": "^1.1.6",
+        "watchify": "^3.6.1"
       },
       "dependencies": {
         "JSONStream": {
@@ -4850,8 +4850,8 @@
           "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
           "dev": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           }
         },
         "assert": {
@@ -4886,7 +4886,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.15"
+            "lodash": "^4.17.10"
           }
         },
         "base64-js": {
@@ -4901,12 +4901,12 @@
           "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "combine-source-map": "0.8.0",
-            "defined": "1.0.0",
-            "safe-buffer": "5.1.2",
-            "through2": "2.0.3",
-            "umd": "3.0.3"
+            "JSONStream": "^1.0.3",
+            "combine-source-map": "~0.8.0",
+            "defined": "^1.0.0",
+            "safe-buffer": "^5.1.1",
+            "through2": "^2.0.0",
+            "umd": "^3.0.0"
           }
         },
         "browserify": {
@@ -4915,54 +4915,54 @@
           "integrity": "sha512-zQt/Gd1+W+IY+h/xX2NYMW4orQWhqSwyV+xsblycTtpOuB27h1fZhhNQuipJ4t79ohw4P4mMem0jp/ZkISQtjQ==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "assert": "1.4.1",
-            "browser-pack": "6.1.0",
-            "browser-resolve": "1.11.3",
-            "browserify-zlib": "0.2.0",
-            "buffer": "5.2.1",
-            "cached-path-relative": "1.0.1",
-            "concat-stream": "1.6.2",
-            "console-browserify": "1.1.0",
-            "constants-browserify": "1.0.0",
-            "crypto-browserify": "3.12.0",
-            "defined": "1.0.0",
-            "deps-sort": "2.0.0",
-            "domain-browser": "1.2.0",
-            "duplexer2": "0.1.4",
-            "events": "2.1.0",
-            "glob": "7.1.3",
-            "has": "1.0.3",
-            "htmlescape": "1.1.1",
-            "https-browserify": "1.0.0",
-            "inherits": "2.0.3",
-            "insert-module-globals": "7.2.0",
-            "labeled-stream-splicer": "2.0.1",
-            "mkdirp": "0.5.1",
-            "module-deps": "6.1.0",
-            "os-browserify": "0.3.0",
-            "parents": "1.0.1",
-            "path-browserify": "0.0.1",
-            "process": "0.11.10",
-            "punycode": "1.4.1",
-            "querystring-es3": "0.2.1",
-            "read-only-stream": "2.0.0",
-            "readable-stream": "2.3.6",
-            "resolve": "1.8.1",
-            "shasum": "1.0.2",
-            "shell-quote": "1.6.1",
-            "stream-browserify": "2.0.1",
-            "stream-http": "2.8.3",
-            "string_decoder": "1.1.1",
-            "subarg": "1.0.0",
-            "syntax-error": "1.4.0",
-            "through2": "2.0.3",
-            "timers-browserify": "1.4.2",
+            "JSONStream": "^1.0.3",
+            "assert": "^1.4.0",
+            "browser-pack": "^6.0.1",
+            "browser-resolve": "^1.11.0",
+            "browserify-zlib": "~0.2.0",
+            "buffer": "^5.0.2",
+            "cached-path-relative": "^1.0.0",
+            "concat-stream": "^1.6.0",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "~1.0.0",
+            "crypto-browserify": "^3.0.0",
+            "defined": "^1.0.0",
+            "deps-sort": "^2.0.0",
+            "domain-browser": "^1.2.0",
+            "duplexer2": "~0.1.2",
+            "events": "^2.0.0",
+            "glob": "^7.1.0",
+            "has": "^1.0.0",
+            "htmlescape": "^1.1.0",
+            "https-browserify": "^1.0.0",
+            "inherits": "~2.0.1",
+            "insert-module-globals": "^7.0.0",
+            "labeled-stream-splicer": "^2.0.0",
+            "mkdirp": "^0.5.0",
+            "module-deps": "^6.0.0",
+            "os-browserify": "~0.3.0",
+            "parents": "^1.0.1",
+            "path-browserify": "~0.0.0",
+            "process": "~0.11.0",
+            "punycode": "^1.3.2",
+            "querystring-es3": "~0.2.0",
+            "read-only-stream": "^2.0.0",
+            "readable-stream": "^2.0.2",
+            "resolve": "^1.1.4",
+            "shasum": "^1.0.0",
+            "shell-quote": "^1.6.1",
+            "stream-browserify": "^2.0.0",
+            "stream-http": "^2.0.0",
+            "string_decoder": "^1.1.1",
+            "subarg": "^1.0.0",
+            "syntax-error": "^1.1.1",
+            "through2": "^2.0.0",
+            "timers-browserify": "^1.0.1",
             "tty-browserify": "0.0.1",
-            "url": "0.11.0",
-            "util": "0.10.4",
-            "vm-browserify": "1.1.0",
-            "xtend": "4.0.1"
+            "url": "~0.11.0",
+            "util": "~0.10.1",
+            "vm-browserify": "^1.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "browserify-zlib": {
@@ -4971,7 +4971,7 @@
           "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
           "dev": true,
           "requires": {
-            "pako": "1.0.6"
+            "pako": "~1.0.5"
           }
         },
         "buffer": {
@@ -4980,8 +4980,8 @@
           "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
           "dev": true,
           "requires": {
-            "base64-js": "1.3.0",
-            "ieee754": "1.1.12"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
           }
         },
         "combine-source-map": {
@@ -4990,10 +4990,10 @@
           "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
           "dev": true,
           "requires": {
-            "convert-source-map": "1.1.3",
-            "inline-source-map": "0.6.2",
-            "lodash.memoize": "3.0.4",
-            "source-map": "0.5.7"
+            "convert-source-map": "~1.1.0",
+            "inline-source-map": "~0.6.0",
+            "lodash.memoize": "~3.0.3",
+            "source-map": "~0.5.3"
           }
         },
         "concat-stream": {
@@ -5002,10 +5002,10 @@
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "constants-browserify": {
@@ -5016,7 +5016,7 @@
         },
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
@@ -5026,10 +5026,10 @@
           "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "shasum": "1.0.2",
-            "subarg": "1.0.0",
-            "through2": "2.0.3"
+            "JSONStream": "^1.0.3",
+            "shasum": "^1.0.0",
+            "subarg": "^1.0.0",
+            "through2": "^2.0.0"
           }
         },
         "detective": {
@@ -5038,9 +5038,9 @@
           "integrity": "sha512-TFHMqfOvxlgrfVzTEkNBSh9SvSNX/HfF4OFI2QFGCyPm02EsyILqnUeb5P6q7JZ3SFNTBL5t2sePRgrN4epUWQ==",
           "dev": true,
           "requires": {
-            "acorn-node": "1.5.2",
-            "defined": "1.0.0",
-            "minimist": "1.2.0"
+            "acorn-node": "^1.3.0",
+            "defined": "^1.0.0",
+            "minimist": "^1.1.1"
           }
         },
         "domain-browser": {
@@ -5055,7 +5055,7 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6"
+            "readable-stream": "^2.0.2"
           }
         },
         "events": {
@@ -5070,12 +5070,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "https-browserify": {
@@ -5090,7 +5090,7 @@
           "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "~0.5.3"
           }
         },
         "insert-module-globals": {
@@ -5099,16 +5099,16 @@
           "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "acorn-node": "1.5.2",
-            "combine-source-map": "0.8.0",
-            "concat-stream": "1.6.2",
-            "is-buffer": "1.1.6",
-            "path-is-absolute": "1.0.1",
-            "process": "0.11.10",
-            "through2": "2.0.3",
-            "undeclared-identifiers": "1.1.2",
-            "xtend": "4.0.1"
+            "JSONStream": "^1.0.3",
+            "acorn-node": "^1.5.2",
+            "combine-source-map": "^0.8.0",
+            "concat-stream": "^1.6.1",
+            "is-buffer": "^1.1.0",
+            "path-is-absolute": "^1.0.1",
+            "process": "~0.11.0",
+            "through2": "^2.0.0",
+            "undeclared-identifiers": "^1.1.2",
+            "xtend": "^4.0.0"
           }
         },
         "isarray": {
@@ -5123,9 +5123,9 @@
           "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "isarray": "2.0.4",
-            "stream-splicer": "2.0.0"
+            "inherits": "^2.0.1",
+            "isarray": "^2.0.4",
+            "stream-splicer": "^2.0.0"
           }
         },
         "minimist": {
@@ -5140,21 +5140,21 @@
           "integrity": "sha512-NPs5N511VD1rrVJihSso/LiBShRbJALYBKzDW91uZYy7BpjnO4bGnZL3HjZ9yKcFdZUWwaYjDz9zxbuP7vKMuQ==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "browser-resolve": "1.11.3",
-            "cached-path-relative": "1.0.1",
-            "concat-stream": "1.6.2",
-            "defined": "1.0.0",
-            "detective": "5.1.0",
-            "duplexer2": "0.1.4",
-            "inherits": "2.0.3",
-            "parents": "1.0.1",
-            "readable-stream": "2.3.6",
-            "resolve": "1.8.1",
-            "stream-combiner2": "1.1.1",
-            "subarg": "1.0.0",
-            "through2": "2.0.3",
-            "xtend": "4.0.1"
+            "JSONStream": "^1.0.3",
+            "browser-resolve": "^1.7.0",
+            "cached-path-relative": "^1.0.0",
+            "concat-stream": "~1.6.0",
+            "defined": "^1.0.0",
+            "detective": "^5.0.2",
+            "duplexer2": "^0.1.2",
+            "inherits": "^2.0.1",
+            "parents": "^1.0.0",
+            "readable-stream": "^2.0.2",
+            "resolve": "^1.4.0",
+            "stream-combiner2": "^1.1.1",
+            "subarg": "^1.0.0",
+            "through2": "^2.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "os-browserify": {
@@ -5175,7 +5175,7 @@
           "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6"
+            "readable-stream": "^2.0.2"
           }
         },
         "shell-quote": {
@@ -5184,10 +5184,10 @@
           "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
           "dev": true,
           "requires": {
-            "array-filter": "0.0.1",
-            "array-map": "0.0.0",
-            "array-reduce": "0.0.0",
-            "jsonify": "0.0.0"
+            "array-filter": "~0.0.0",
+            "array-map": "~0.0.0",
+            "array-reduce": "~0.0.0",
+            "jsonify": "~0.0.0"
           }
         },
         "stream-browserify": {
@@ -5196,8 +5196,8 @@
           "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "~2.0.1",
+            "readable-stream": "^2.0.2"
           }
         },
         "stream-combiner2": {
@@ -5206,8 +5206,8 @@
           "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
           "dev": true,
           "requires": {
-            "duplexer2": "0.1.4",
-            "readable-stream": "2.3.6"
+            "duplexer2": "~0.1.0",
+            "readable-stream": "^2.0.2"
           }
         },
         "stream-splicer": {
@@ -5216,8 +5216,8 @@
           "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
           }
         },
         "through2": {
@@ -5226,8 +5226,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         },
         "url": {
@@ -5262,7 +5262,7 @@
       "integrity": "sha1-7+S792LcwTOWFAwsaL5ae6jD/z4=",
       "dev": true,
       "requires": {
-        "semver": "4.3.6"
+        "semver": "^4.3.3"
       },
       "dependencies": {
         "semver": {
@@ -5280,7 +5280,7 @@
       "dev": true,
       "requires": {
         "casperjs": "1.1.1",
-        "phantomjs-prebuilt": "2.1.16"
+        "phantomjs-prebuilt": "~2.1.4"
       }
     },
     "grunt-contrib-clean": {
@@ -5289,8 +5289,8 @@
       "integrity": "sha1-Vkq/LQN4qYOhW54/MO51tzjEBjg=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "rimraf": "2.6.2"
+        "async": "^1.5.2",
+        "rimraf": "^2.5.1"
       }
     },
     "grunt-contrib-compress": {
@@ -5299,12 +5299,12 @@
       "integrity": "sha1-Ac7/ucY39S5wgfRjdQmD0KOw+nM=",
       "dev": true,
       "requires": {
-        "archiver": "1.3.0",
-        "chalk": "1.1.3",
-        "iltorb": "1.3.10",
-        "lodash": "4.17.15",
-        "pretty-bytes": "4.0.2",
-        "stream-buffers": "2.2.0"
+        "archiver": "^1.3.0",
+        "chalk": "^1.1.1",
+        "iltorb": "^1.0.13",
+        "lodash": "^4.7.0",
+        "pretty-bytes": "^4.0.2",
+        "stream-buffers": "^2.1.0"
       }
     },
     "grunt-contrib-copy": {
@@ -5313,32 +5313,32 @@
       "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "file-sync-cmp": "0.1.1"
+        "chalk": "^1.1.1",
+        "file-sync-cmp": "^0.1.0"
       }
     },
     "grunt-contrib-jshint": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz",
       "integrity": "sha1-Np2QmyWTxA6L55lAshNAhQx5Oaw=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "hooker": "0.2.3",
-        "jshint": "2.9.6"
+        "chalk": "^1.1.1",
+        "hooker": "^0.2.3",
+        "jshint": "~2.9.4"
       }
     },
     "grunt-contrib-uglify": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-1.0.2.tgz",
       "integrity": "sha1-rmekb5FT7dTLEYE6Vetpxw19svs=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "lodash": "4.17.15",
-        "maxmin": "1.1.0",
-        "uglify-js": "2.6.4",
-        "uri-path": "1.0.0"
+        "chalk": "^1.0.0",
+        "lodash": "^4.0.1",
+        "maxmin": "^1.1.0",
+        "uglify-js": "~2.6.2",
+        "uri-path": "^1.0.0"
       },
       "dependencies": {
         "async": {
@@ -5359,21 +5359,21 @@
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           }
         },
         "uglify-js": {
           "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
+          "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
           "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
           "dev": true,
           "requires": {
-            "async": "0.2.10",
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "async": "~0.2.6",
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           }
         },
         "window-size": {
@@ -5394,9 +5394,9 @@
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -5408,10 +5408,10 @@
       "integrity": "sha512-yGweN+0DW5yM+oo58fRu/XIRrPcn3r4tQx+nL7eMRwjpvk+rQY6R8o94BPK0i2UhTg9FN21hS+m8vR8v9vXfeg==",
       "dev": true,
       "requires": {
-        "async": "2.6.1",
-        "gaze": "1.1.3",
-        "lodash": "4.17.15",
-        "tiny-lr": "1.1.1"
+        "async": "^2.6.0",
+        "gaze": "^1.1.0",
+        "lodash": "^4.17.10",
+        "tiny-lr": "^1.1.1"
       },
       "dependencies": {
         "async": {
@@ -5420,7 +5420,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.15"
+            "lodash": "^4.17.10"
           }
         }
       }
@@ -5438,11 +5438,11 @@
       "dev": true,
       "requires": {
         "async": "2.0.1",
-        "fs-extra": "0.30.0",
+        "fs-extra": "^0.30.0",
         "graceful-fs": "4.1.5",
         "q": "0.9.3",
         "q-io": "2.0.2",
-        "url-safe": "2.0.0"
+        "url-safe": "^2.0.0"
       },
       "dependencies": {
         "async": {
@@ -5451,7 +5451,7 @@
           "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "dev": true,
           "requires": {
-            "lodash": "4.17.15"
+            "lodash": "^4.8.0"
           }
         },
         "fs-extra": {
@@ -5460,11 +5460,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.5",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "graceful-fs": {
@@ -5475,11 +5475,11 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           },
           "dependencies": {
             "graceful-fs": {
@@ -5511,10 +5511,10 @@
       "integrity": "sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
-        "grunt-legacy-log-utils": "2.0.1",
-        "hooker": "0.2.3",
-        "lodash": "4.17.15"
+        "colors": "~1.1.2",
+        "grunt-legacy-log-utils": "~2.0.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.5"
       }
     },
     "grunt-legacy-log-utils": {
@@ -5523,8 +5523,8 @@
       "integrity": "sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "lodash": "4.17.15"
+        "chalk": "~2.4.1",
+        "lodash": "~4.17.10"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5533,7 +5533,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5542,9 +5542,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -5559,7 +5559,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5570,13 +5570,13 @@
       "integrity": "sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "exit": "0.1.2",
-        "getobject": "0.1.0",
-        "hooker": "0.2.3",
-        "lodash": "4.17.15",
-        "underscore.string": "3.3.4",
-        "which": "1.3.1"
+        "async": "~1.5.2",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.10",
+        "underscore.string": "~3.3.4",
+        "which": "~1.3.0"
       },
       "dependencies": {
         "which": {
@@ -5585,7 +5585,7 @@
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -5596,11 +5596,11 @@
       "integrity": "sha1-np7c3Z/S3UDgwYHJQ3HVcqpe6tI=",
       "dev": true,
       "requires": {
-        "eventemitter2": "0.4.14",
-        "phantomjs-prebuilt": "2.1.16",
-        "rimraf": "2.6.2",
-        "semver": "5.5.1",
-        "temporary": "0.0.8"
+        "eventemitter2": "^0.4.9",
+        "phantomjs-prebuilt": "^2.1.3",
+        "rimraf": "^2.5.2",
+        "semver": "^5.1.0",
+        "temporary": "^0.0.8"
       }
     },
     "grunt-mocha": {
@@ -5609,14 +5609,14 @@
       "integrity": "sha1-l1MSM8IVOmo4Q2DhTk+FGusfm1M=",
       "dev": true,
       "requires": {
-        "grunt-lib-phantomjs": "1.1.0",
-        "lodash": "3.10.1",
-        "mocha": "2.5.3"
+        "grunt-lib-phantomjs": "^1.0.2",
+        "lodash": "^3.9.0",
+        "mocha": ">=2.5.3"
       },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -5628,9 +5628,9 @@
       "integrity": "sha1-BSk5kGFhENtrwK0V5sBZL/4YrDE=",
       "dev": true,
       "requires": {
-        "semver": "5.5.1",
-        "stack-parser": "0.0.1",
-        "which": "1.2.14"
+        "semver": "^5.1.0",
+        "stack-parser": "^0.0.1",
+        "which": "^1.2.4"
       }
     },
     "grunt-phpunit": {
@@ -5645,8 +5645,8 @@
       "integrity": "sha512-svkNCJ/i4fdtmJvXeHP4iMFi2cF8LV3griq+YAJELsjnQztpzUjaAHwBIK+6zlqDT2yq0SqHHZTEs4rrlMA9XQ==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "rfg-api": "0.4.0"
+        "async": "^1.4.2",
+        "rfg-api": "^0.4.0"
       }
     },
     "grunt-sass": {
@@ -5655,9 +5655,9 @@
       "integrity": "sha1-+4e2yqxG+zLUUXf9Lktv90aMGRk=",
       "dev": true,
       "requires": {
-        "each-async": "1.1.1",
-        "node-sass": "3.13.1",
-        "object-assign": "4.1.1"
+        "each-async": "^1.0.0",
+        "node-sass": "^3.7.0",
+        "object-assign": "^4.0.1"
       }
     },
     "grunt-sass-replace": {
@@ -5666,7 +5666,7 @@
       "integrity": "sha1-zIz7Zy6RiaaG4v0vLKJGyeqSqoA=",
       "dev": true,
       "requires": {
-        "grunt-string-replace": "1.3.1"
+        "grunt-string-replace": "^1.3.0"
       }
     },
     "grunt-scss-lint": {
@@ -5675,15 +5675,15 @@
       "integrity": "sha1-LhnN1DDM0lRgj12PviHOm7Lr2cU=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "lodash": "3.10.1",
-        "which": "1.2.14",
-        "xmlbuilder": "2.6.5"
+        "chalk": "^1.0.0",
+        "lodash": "^3.6.0",
+        "which": "^1.1.1",
+        "xmlbuilder": "^2.6.2"
       },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
@@ -5693,7 +5693,7 @@
           "integrity": "sha1-b/etYPty0idk8AehZLd/K/FABSY=",
           "dev": true,
           "requires": {
-            "lodash": "3.10.1"
+            "lodash": "^3.5.0"
           }
         }
       }
@@ -5704,8 +5704,8 @@
       "integrity": "sha1-YzoDvHhIKg4OH5339kWBH8H7sWI=",
       "dev": true,
       "requires": {
-        "async": "2.6.1",
-        "chalk": "1.1.3"
+        "async": "^2.0.0",
+        "chalk": "^1.0.0"
       },
       "dependencies": {
         "async": {
@@ -5714,7 +5714,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.15"
+            "lodash": "^4.17.10"
           }
         }
       }
@@ -5731,8 +5731,8 @@
       "integrity": "sha1-Zs+LEBBHInuVus5uodoMF37Vwi8=",
       "dev": true,
       "requires": {
-        "browserify-zlib": "0.1.4",
-        "concat-stream": "1.4.11"
+        "browserify-zlib": "^0.1.4",
+        "concat-stream": "^1.4.1"
       }
     },
     "handlebars": {
@@ -5741,10 +5741,10 @@
       "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
       "dev": true,
       "requires": {
-        "async": "2.6.1",
-        "optimist": "0.6.1",
-        "source-map": "0.6.1",
-        "uglify-js": "3.4.9"
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       },
       "dependencies": {
         "async": {
@@ -5753,7 +5753,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.15"
+            "lodash": "^4.17.10"
           }
         },
         "source-map": {
@@ -5776,8 +5776,8 @@
       "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.3.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -5786,7 +5786,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -5795,7 +5795,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary2": {
@@ -5839,7 +5839,7 @@
       "integrity": "sha1-khZ1qxMNvZdo/I2o8ajiQt+kF3Q=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.3"
       }
     },
     "has-unicode": {
@@ -5854,9 +5854,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -5873,8 +5873,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -5883,7 +5883,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5892,7 +5892,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5903,7 +5903,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -5914,8 +5914,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
@@ -5924,8 +5924,8 @@
       "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "hasha": {
@@ -5934,8 +5934,8 @@
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
-        "is-stream": "1.1.0",
-        "pinkie-promise": "2.0.1"
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "he": {
@@ -5958,7 +5958,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -5970,9 +5970,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.5",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "home-or-tmp": {
@@ -5981,8 +5981,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hooker": {
@@ -6003,7 +6003,7 @@
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "1.0.4"
+        "whatwg-encoding": "^1.0.1"
       }
     },
     "htmlescape": {
@@ -6018,11 +6018,11 @@
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
       },
       "dependencies": {
         "domutils": {
@@ -6031,8 +6031,8 @@
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "dev": true,
           "requires": {
-            "dom-serializer": "0.1.0",
-            "domelementtype": "1.3.0"
+            "dom-serializer": "0",
+            "domelementtype": "1"
           }
         },
         "entities": {
@@ -6043,14 +6043,14 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -6067,8 +6067,8 @@
       "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
       "dev": true,
       "requires": {
-        "Base64": "0.2.1",
-        "inherits": "2.0.3"
+        "Base64": "~0.2.0",
+        "inherits": "~2.0.1"
       }
     },
     "http-errors": {
@@ -6077,10 +6077,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       },
       "dependencies": {
         "statuses": {
@@ -6103,8 +6103,8 @@
       "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
       }
     },
     "http-signature": {
@@ -6113,9 +6113,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -6130,7 +6130,7 @@
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ieee754": {
@@ -6146,10 +6146,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "detect-libc": "0.2.0",
-        "nan": "2.11.0",
-        "node-gyp": "3.8.0",
-        "prebuild-install": "2.5.3"
+        "detect-libc": "^0.2.0",
+        "nan": "^2.6.2",
+        "node-gyp": "^3.6.2",
+        "prebuild-install": "^2.3.0"
       }
     },
     "immutable": {
@@ -6170,7 +6170,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "indexof": {
@@ -6185,8 +6185,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -6208,7 +6208,7 @@
       "integrity": "sha1-pSi1FOaJ/OkNswiehw2S9Sestes=",
       "dev": true,
       "requires": {
-        "source-map": "0.3.0"
+        "source-map": "~0.3.0"
       },
       "dependencies": {
         "source-map": {
@@ -6217,7 +6217,7 @@
           "integrity": "sha1-hYb7mloAXltQHiHNGLbyG0V60fk=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -6228,14 +6228,14 @@
       "integrity": "sha1-IGOOKaMPntHKLjqCX7wsulJG3fw=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.4",
-        "combine-source-map": "0.6.1",
-        "concat-stream": "1.4.11",
-        "is-buffer": "1.1.6",
-        "lexical-scope": "1.2.0",
-        "process": "0.11.10",
-        "through2": "1.1.1",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "combine-source-map": "~0.6.1",
+        "concat-stream": "~1.4.1",
+        "is-buffer": "^1.1.0",
+        "lexical-scope": "^1.2.0",
+        "process": "~0.11.0",
+        "through2": "^1.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -6244,8 +6244,8 @@
           "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
           "dev": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           }
         },
         "combine-source-map": {
@@ -6254,15 +6254,15 @@
           "integrity": "sha1-m0oJwxYDPXaODxHgKfonMOB5rZY=",
           "dev": true,
           "requires": {
-            "convert-source-map": "1.1.3",
-            "inline-source-map": "0.5.0",
-            "lodash.memoize": "3.0.4",
-            "source-map": "0.4.4"
+            "convert-source-map": "~1.1.0",
+            "inline-source-map": "~0.5.0",
+            "lodash.memoize": "~3.0.3",
+            "source-map": "~0.4.2"
           }
         },
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
@@ -6272,7 +6272,7 @@
           "integrity": "sha1-Skxd2OT7Xps82mDIIt+tyu5m4K8=",
           "dev": true,
           "requires": {
-            "source-map": "0.4.4"
+            "source-map": "~0.4.0"
           }
         },
         "source-map": {
@@ -6281,7 +6281,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -6292,7 +6292,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -6307,7 +6307,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-arrayish": {
@@ -6322,7 +6322,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.12.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -6333,11 +6333,11 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -6346,7 +6346,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-defined": {
@@ -6361,9 +6361,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -6386,7 +6386,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -6407,7 +6407,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -6416,7 +6416,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -6425,7 +6425,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-number": {
@@ -6434,7 +6434,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-number-like": {
@@ -6443,7 +6443,7 @@
       "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
       "dev": true,
       "requires": {
-        "lodash.isfinite": "3.3.2"
+        "lodash.isfinite": "^3.3.2"
       }
     },
     "is-plain-object": {
@@ -6452,7 +6452,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -6546,20 +6546,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.12",
-        "js-yaml": "3.12.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.2.14",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "resolve": {
@@ -6574,7 +6574,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -6591,13 +6591,13 @@
       "dependencies": {
         "commander": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
           "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
           "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
           "dev": true
         }
@@ -6628,7 +6628,7 @@
       "resolved": "https://registry.npmjs.org/jquery-sticky/-/jquery-sticky-1.0.4.tgz",
       "integrity": "sha1-L+jQPckEaFNA2qEsvdHKDJIbCaw=",
       "requires": {
-        "jquery": "3.4.1"
+        "jquery": "*"
       }
     },
     "jquery-ui": {
@@ -6654,8 +6654,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -6679,25 +6679,25 @@
       "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
       "dev": true,
       "requires": {
-        "abab": "1.0.4",
-        "acorn": "4.0.13",
-        "acorn-globals": "3.1.0",
-        "array-equal": "1.0.0",
-        "content-type-parser": "1.0.2",
-        "cssom": "0.3.4",
-        "cssstyle": "0.2.37",
-        "escodegen": "1.8.1",
-        "html-encoding-sniffer": "1.0.2",
-        "nwmatcher": "1.4.4",
-        "parse5": "1.5.1",
-        "request": "2.88.0",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.4.3",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.4",
-        "whatwg-url": "4.8.0",
-        "xml-name-validator": "2.0.1"
+        "abab": "^1.0.3",
+        "acorn": "^4.0.4",
+        "acorn-globals": "^3.1.0",
+        "array-equal": "^1.0.0",
+        "content-type-parser": "^1.0.1",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": ">= 0.2.37 < 0.3.0",
+        "escodegen": "^1.6.1",
+        "html-encoding-sniffer": "^1.0.1",
+        "nwmatcher": ">= 1.3.9 < 2.0.0",
+        "parse5": "^1.5.1",
+        "request": "^2.79.0",
+        "sax": "^1.2.1",
+        "symbol-tree": "^3.2.1",
+        "tough-cookie": "^2.3.2",
+        "webidl-conversions": "^4.0.0",
+        "whatwg-encoding": "^1.0.1",
+        "whatwg-url": "^4.3.0",
+        "xml-name-validator": "^2.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -6726,17 +6726,17 @@
       "integrity": "sha512-KO9SIAKTlJQOM4lE64GQUtGBRpTOuvbrRrSZw3AhUxMNG266nX9hK2cKA4SBhXOj0irJGyNyGSLT62HGOVDEOA==",
       "dev": true,
       "requires": {
-        "cli": "1.0.1",
-        "console-browserify": "1.1.0",
-        "exit": "0.1.2",
-        "htmlparser2": "3.8.3",
-        "lodash": "4.17.15",
-        "minimatch": "3.0.4",
-        "phantom": "4.0.12",
-        "phantomjs-prebuilt": "2.1.16",
-        "shelljs": "0.3.0",
-        "strip-json-comments": "1.0.4",
-        "unicode-5.2.0": "0.7.5"
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2",
+        "phantom": "~4.0.1",
+        "phantomjs-prebuilt": "~2.1.7",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x",
+        "unicode-5.2.0": "^0.7.5"
       },
       "dependencies": {
         "strip-json-comments": {
@@ -6765,7 +6765,7 @@
       "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -6786,7 +6786,7 @@
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -6818,7 +6818,7 @@
       "resolved": "https://registry.npmjs.org/jstree/-/jstree-3.3.8.tgz",
       "integrity": "sha512-0/nhGxVLSGfGQyVg+q59ocqSEKWRDKHoA8wNrcOIvlzCCw19tzvcMNGJ19hf+U0b7fycABowkny7fQPcLgUwwA==",
       "requires": {
-        "jquery": "3.4.1"
+        "jquery": ">=1.9.1"
       }
     },
     "kew": {
@@ -6833,7 +6833,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -6842,7 +6842,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "labeled-stream-splicer": {
@@ -6851,9 +6851,9 @@
       "integrity": "sha1-RhUzFTd4SYHo/SZOHzpDTE4N3WU=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "stream-splicer": "1.3.2"
+        "inherits": "^2.0.1",
+        "isarray": "~0.0.1",
+        "stream-splicer": "^1.1.0"
       }
     },
     "lazy-cache": {
@@ -6868,7 +6868,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.5"
       }
     },
     "lcid": {
@@ -6877,7 +6877,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "levn": {
@@ -6886,8 +6886,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lexical-scope": {
@@ -6896,7 +6896,7 @@
       "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
       "dev": true,
       "requires": {
-        "astw": "2.2.0"
+        "astw": "^2.0.0"
       }
     },
     "limiter": {
@@ -6919,15 +6919,15 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "localtunnel": {
@@ -6957,19 +6957,19 @@
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.3",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^4.2.0"
           }
         }
       }
@@ -6991,8 +6991,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -7007,7 +7007,7 @@
       "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
       "dev": true,
       "requires": {
-        "lodash.keys": "3.1.2"
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._bindcallback": {
@@ -7022,9 +7022,9 @@
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "dev": true,
       "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       }
     },
     "lodash._createwrapper": {
@@ -7033,7 +7033,7 @@
       "integrity": "sha1-30U+ZkFjIXuJWkVAZa8cR6DqPE0=",
       "dev": true,
       "requires": {
-        "lodash._root": "3.0.1"
+        "lodash._root": "^3.0.0"
       }
     },
     "lodash._getnative": {
@@ -7072,9 +7072,9 @@
       "integrity": "sha1-+V9IY419i7tYVPkIJmUnmZ+/pLs=",
       "dev": true,
       "requires": {
-        "lodash._createwrapper": "3.2.0",
-        "lodash._replaceholders": "3.0.0",
-        "lodash.restparam": "3.6.1"
+        "lodash._createwrapper": "^3.0.0",
+        "lodash._replaceholders": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       }
     },
     "lodash.clonedeep": {
@@ -7089,8 +7089,8 @@
       "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
       "dev": true,
       "requires": {
-        "lodash.assign": "3.2.0",
-        "lodash.restparam": "3.6.1"
+        "lodash.assign": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       },
       "dependencies": {
         "lodash.assign": {
@@ -7099,9 +7099,9 @@
           "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
           "dev": true,
           "requires": {
-            "lodash._baseassign": "3.2.0",
-            "lodash._createassigner": "3.1.1",
-            "lodash.keys": "3.1.2"
+            "lodash._baseassign": "^3.0.0",
+            "lodash._createassigner": "^3.0.0",
+            "lodash.keys": "^3.0.0"
           }
         }
       }
@@ -7112,10 +7112,10 @@
       "integrity": "sha1-b9fvt5aRrs1n/erCdhyY5wHWw5o=",
       "dev": true,
       "requires": {
-        "lodash._arrayeach": "3.0.0",
-        "lodash._baseeach": "3.0.4",
-        "lodash._bindcallback": "3.0.1",
-        "lodash.isarray": "3.0.4"
+        "lodash._arrayeach": "^3.0.0",
+        "lodash._baseeach": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.isarguments": {
@@ -7142,9 +7142,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.memoize": {
@@ -7177,7 +7177,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "loud-rejection": {
@@ -7186,8 +7186,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -7214,7 +7214,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "match-stream": {
@@ -7223,20 +7223,20 @@
       "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
       "dev": true,
       "requires": {
-        "buffers": "0.1.1",
-        "readable-stream": "1.0.34"
+        "buffers": "~0.1.1",
+        "readable-stream": "~1.0.0"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -7253,9 +7253,9 @@
       "integrity": "sha1-pXozgESR+64girqPaDgEN6vC3KU=",
       "dev": true,
       "requires": {
-        "findup-sync": "0.3.0",
-        "micromatch": "2.3.11",
-        "resolve": "1.1.7",
+        "findup-sync": "~0.3.0",
+        "micromatch": "^2.3.7",
+        "resolve": "~1.1.6",
         "stack-trace": "0.0.9"
       },
       "dependencies": {
@@ -7285,10 +7285,10 @@
       "integrity": "sha1-cTZehKmd2Piz99X94vANHn9zvmE=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "figures": "1.7.0",
-        "gzip-size": "1.0.0",
-        "pretty-bytes": "1.0.4"
+        "chalk": "^1.0.0",
+        "figures": "^1.0.1",
+        "gzip-size": "^1.0.0",
+        "pretty-bytes": "^1.0.0"
       },
       "dependencies": {
         "pretty-bytes": {
@@ -7297,8 +7297,8 @@
           "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
+            "get-stdin": "^4.0.1",
+            "meow": "^3.1.0"
           }
         }
       }
@@ -7309,8 +7309,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "meow": {
@@ -7319,21 +7319,21 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -7345,10 +7345,10 @@
       "integrity": "sha1-wGmaZoageovOGsBrYulGLC5mqso=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "cheerio": "0.19.0",
-        "mkdirp": "0.5.1",
-        "underscore": "1.9.1"
+        "async": "*",
+        "cheerio": "*",
+        "mkdirp": "*",
+        "underscore": "*"
       }
     },
     "micromatch": {
@@ -7357,19 +7357,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "miller-rabin": {
@@ -7378,8 +7378,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -7400,7 +7400,7 @@
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "dev": true,
       "requires": {
-        "mime-db": "1.36.0"
+        "mime-db": "~1.36.0"
       }
     },
     "mimeparse": {
@@ -7422,12 +7422,12 @@
       "integrity": "sha512-wCCeyM9tZCla5AP9KdR+GAaNUL5zOwXYTQAUQVO+GmeuajQHXKJEQJfGumUfygZ6KbmhvuViuwOIZ0EUlZMMpw==",
       "dev": true,
       "requires": {
-        "brout": "1.2.0",
-        "listen": "1.0.1",
-        "resolve": "1.8.1",
-        "saucelabs": "1.5.0",
-        "source-mapper": "2.1.0",
-        "through2": "2.0.3"
+        "brout": "^1.1.0",
+        "listen": "^1.0.0",
+        "resolve": "^1.8.1",
+        "saucelabs": "^1.5.0",
+        "source-mapper": "^2.0.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "through2": {
@@ -7436,8 +7436,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -7454,17 +7454,17 @@
       "integrity": "sha1-yJ+SjgtpTUqqbeE50JFuuKiuC7I=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.4.11",
-        "convert-source-map": "1.6.0",
-        "lodash.bind": "3.1.0",
-        "lodash.defaults": "3.1.2",
-        "lodash.foreach": "3.0.3",
-        "mkdirp": "0.5.1",
-        "source-map": "0.4.4",
-        "through": "2.3.8",
-        "tmp": "0.0.25",
-        "transform-filter": "0.1.1",
-        "uglify-js": "2.8.29"
+        "concat-stream": "^1.4.7",
+        "convert-source-map": "^1.0.0",
+        "lodash.bind": "^3.0.0",
+        "lodash.defaults": "^3.0.0",
+        "lodash.foreach": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "source-map": "^0.4.2",
+        "through": "^2.3.6",
+        "tmp": "^0.0.25",
+        "transform-filter": "^0.1.1",
+        "uglify-js": "^2.4.16"
       },
       "dependencies": {
         "camelcase": {
@@ -7479,8 +7479,8 @@
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           }
         },
@@ -7490,7 +7490,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "uglify-js": {
@@ -7499,9 +7499,9 @@
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "source-map": {
@@ -7530,9 +7530,9 @@
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -7556,12 +7556,12 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -7571,8 +7571,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -7581,14 +7581,14 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -7601,12 +7601,12 @@
       "integrity": "sha512-mc0xkHFGxnW4B49la2LG8qaHBIiLArqG9zkgP+byp/kmWby1/Bi8CIpwBKANu91SkZ/c4Qk+0JnYM5u1PXEQYw==",
       "dev": true,
       "requires": {
-        "brout": "1.2.0",
-        "listen": "1.0.1",
-        "mocha": "4.1.0",
-        "resolve": "1.8.1",
-        "supports-color": "3.2.3",
-        "through2": "2.0.3"
+        "brout": "^1.1.0",
+        "listen": "^1.0.0",
+        "mocha": "^4.0.1",
+        "resolve": "^1.1.6",
+        "supports-color": "^3.1.2",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "commander": {
@@ -7636,12 +7636,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "growl": {
@@ -7680,7 +7680,7 @@
               "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
               "dev": true,
               "requires": {
-                "has-flag": "2.0.0"
+                "has-flag": "^2.0.0"
               }
             }
           }
@@ -7691,7 +7691,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           },
           "dependencies": {
             "has-flag": {
@@ -7708,15 +7708,15 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
     },
     "mocha": {
       "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "resolved": "http://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
       "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
       "dev": true,
       "requires": {
@@ -7734,13 +7734,13 @@
       "dependencies": {
         "commander": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
           "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
           "dev": true
         },
         "debug": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
@@ -7765,8 +7765,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "inherits": "2",
+            "minimatch": "0.3"
           }
         },
         "minimatch": {
@@ -7775,8 +7775,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         },
         "ms": {
@@ -7799,20 +7799,20 @@
       "integrity": "sha512-PdPPfM5O3dO9LVw634f40FC9Ea6EDk+UB55BL+ypCMocDy7vzrHaPpe6/+IvJ9y+tE25mMr2jXl1WOlgvRCpCg==",
       "dev": true,
       "requires": {
-        "brout": "1.2.0",
-        "browserify": "15.2.0",
-        "consolify": "2.2.0",
-        "coverify": "1.5.0",
-        "glob": "7.1.3",
-        "min-wd": "2.12.0",
-        "mocaccino": "3.0.0",
-        "mocha": "4.1.0",
-        "puppeteer": "1.8.0",
-        "resolve": "1.8.1",
-        "source-mapper": "2.1.0",
-        "subarg": "1.0.0",
-        "through2": "2.0.3",
-        "watchify": "3.11.0"
+        "brout": "^1.1.0",
+        "browserify": "^15.2.0",
+        "consolify": "^2.1.0",
+        "coverify": "^1.4.1",
+        "glob": "^7.1.2",
+        "min-wd": "^2.11.0",
+        "mocaccino": "^3.0.0",
+        "mocha": "^4.1.0",
+        "puppeteer": "^1.6.2",
+        "resolve": "^1.5.0",
+        "source-mapper": "^2.1.0",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0",
+        "watchify": "^3.7.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -7821,8 +7821,8 @@
           "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
           "dev": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           }
         },
         "assert": {
@@ -7863,12 +7863,12 @@
           "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "combine-source-map": "0.8.0",
-            "defined": "1.0.0",
-            "safe-buffer": "5.1.2",
-            "through2": "2.0.3",
-            "umd": "3.0.3"
+            "JSONStream": "^1.0.3",
+            "combine-source-map": "~0.8.0",
+            "defined": "^1.0.0",
+            "safe-buffer": "^5.1.1",
+            "through2": "^2.0.0",
+            "umd": "^3.0.0"
           }
         },
         "browserify": {
@@ -7877,54 +7877,54 @@
           "integrity": "sha512-IHYyFPm2XjJCL+VV0ZtFv8wn/sAHVOm83q3yfSn8YWbZ9jcybgPKxSDdiuMU+35jUL1914l74RnXXPD9Iyo9yg==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "assert": "1.4.1",
-            "browser-pack": "6.1.0",
-            "browser-resolve": "1.11.3",
-            "browserify-zlib": "0.2.0",
-            "buffer": "5.2.1",
-            "cached-path-relative": "1.0.1",
-            "concat-stream": "1.5.2",
-            "console-browserify": "1.1.0",
-            "constants-browserify": "1.0.0",
-            "crypto-browserify": "3.12.0",
-            "defined": "1.0.0",
-            "deps-sort": "2.0.0",
-            "domain-browser": "1.1.7",
-            "duplexer2": "0.1.4",
-            "events": "1.1.1",
-            "glob": "7.1.3",
-            "has": "1.0.3",
-            "htmlescape": "1.1.1",
-            "https-browserify": "1.0.0",
-            "inherits": "2.0.3",
-            "insert-module-globals": "7.2.0",
-            "labeled-stream-splicer": "2.0.1",
-            "mkdirp": "0.5.1",
-            "module-deps": "5.0.1",
-            "os-browserify": "0.3.0",
-            "parents": "1.0.1",
-            "path-browserify": "0.0.1",
-            "process": "0.11.10",
-            "punycode": "1.4.1",
-            "querystring-es3": "0.2.1",
-            "read-only-stream": "2.0.0",
-            "readable-stream": "2.3.6",
-            "resolve": "1.8.1",
-            "shasum": "1.0.2",
-            "shell-quote": "1.6.1",
-            "stream-browserify": "2.0.1",
-            "stream-http": "2.8.3",
-            "string_decoder": "1.0.3",
-            "subarg": "1.0.0",
-            "syntax-error": "1.4.0",
-            "through2": "2.0.3",
-            "timers-browserify": "1.4.2",
-            "tty-browserify": "0.0.1",
-            "url": "0.11.0",
-            "util": "0.10.4",
-            "vm-browserify": "0.0.4",
-            "xtend": "4.0.1"
+            "JSONStream": "^1.0.3",
+            "assert": "^1.4.0",
+            "browser-pack": "^6.0.1",
+            "browser-resolve": "^1.11.0",
+            "browserify-zlib": "~0.2.0",
+            "buffer": "^5.0.2",
+            "cached-path-relative": "^1.0.0",
+            "concat-stream": "~1.5.1",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "~1.0.0",
+            "crypto-browserify": "^3.0.0",
+            "defined": "^1.0.0",
+            "deps-sort": "^2.0.0",
+            "domain-browser": "~1.1.0",
+            "duplexer2": "~0.1.2",
+            "events": "~1.1.0",
+            "glob": "^7.1.0",
+            "has": "^1.0.0",
+            "htmlescape": "^1.1.0",
+            "https-browserify": "^1.0.0",
+            "inherits": "~2.0.1",
+            "insert-module-globals": "^7.0.0",
+            "labeled-stream-splicer": "^2.0.0",
+            "mkdirp": "^0.5.0",
+            "module-deps": "^5.0.1",
+            "os-browserify": "~0.3.0",
+            "parents": "^1.0.1",
+            "path-browserify": "~0.0.0",
+            "process": "~0.11.0",
+            "punycode": "^1.3.2",
+            "querystring-es3": "~0.2.0",
+            "read-only-stream": "^2.0.0",
+            "readable-stream": "^2.0.2",
+            "resolve": "^1.1.4",
+            "shasum": "^1.0.0",
+            "shell-quote": "^1.6.1",
+            "stream-browserify": "^2.0.0",
+            "stream-http": "^2.0.0",
+            "string_decoder": "~1.0.0",
+            "subarg": "^1.0.0",
+            "syntax-error": "^1.1.1",
+            "through2": "^2.0.0",
+            "timers-browserify": "^1.0.1",
+            "tty-browserify": "~0.0.0",
+            "url": "~0.11.0",
+            "util": "~0.10.1",
+            "vm-browserify": "~0.0.1",
+            "xtend": "^4.0.0"
           }
         },
         "browserify-zlib": {
@@ -7933,7 +7933,7 @@
           "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
           "dev": true,
           "requires": {
-            "pako": "1.0.6"
+            "pako": "~1.0.5"
           }
         },
         "buffer": {
@@ -7942,8 +7942,8 @@
           "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
           "dev": true,
           "requires": {
-            "base64-js": "1.3.0",
-            "ieee754": "1.1.12"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
           }
         },
         "combine-source-map": {
@@ -7952,10 +7952,10 @@
           "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
           "dev": true,
           "requires": {
-            "convert-source-map": "1.1.3",
-            "inline-source-map": "0.6.2",
-            "lodash.memoize": "3.0.4",
-            "source-map": "0.5.7"
+            "convert-source-map": "~1.1.0",
+            "inline-source-map": "~0.6.0",
+            "lodash.memoize": "~3.0.3",
+            "source-map": "~0.5.3"
           }
         },
         "commander": {
@@ -7970,23 +7970,23 @@
           "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.0.6",
-            "typedarray": "0.0.6"
+            "inherits": "~2.0.1",
+            "readable-stream": "~2.0.0",
+            "typedarray": "~0.0.5"
           },
           "dependencies": {
             "readable-stream": {
               "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
               }
             },
             "string_decoder": {
@@ -8005,7 +8005,7 @@
         },
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
@@ -8024,10 +8024,10 @@
           "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "shasum": "1.0.2",
-            "subarg": "1.0.0",
-            "through2": "2.0.3"
+            "JSONStream": "^1.0.3",
+            "shasum": "^1.0.0",
+            "subarg": "^1.0.0",
+            "through2": "^2.0.0"
           }
         },
         "detective": {
@@ -8036,9 +8036,9 @@
           "integrity": "sha512-TFHMqfOvxlgrfVzTEkNBSh9SvSNX/HfF4OFI2QFGCyPm02EsyILqnUeb5P6q7JZ3SFNTBL5t2sePRgrN4epUWQ==",
           "dev": true,
           "requires": {
-            "acorn-node": "1.5.2",
-            "defined": "1.0.0",
-            "minimist": "1.2.0"
+            "acorn-node": "^1.3.0",
+            "defined": "^1.0.0",
+            "minimist": "^1.1.1"
           }
         },
         "diff": {
@@ -8053,7 +8053,7 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6"
+            "readable-stream": "^2.0.2"
           }
         },
         "events": {
@@ -8068,12 +8068,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "growl": {
@@ -8100,7 +8100,7 @@
           "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "~0.5.3"
           }
         },
         "insert-module-globals": {
@@ -8109,16 +8109,16 @@
           "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "acorn-node": "1.5.2",
-            "combine-source-map": "0.8.0",
-            "concat-stream": "1.6.2",
-            "is-buffer": "1.1.6",
-            "path-is-absolute": "1.0.1",
-            "process": "0.11.10",
-            "through2": "2.0.3",
-            "undeclared-identifiers": "1.1.2",
-            "xtend": "4.0.1"
+            "JSONStream": "^1.0.3",
+            "acorn-node": "^1.5.2",
+            "combine-source-map": "^0.8.0",
+            "concat-stream": "^1.6.1",
+            "is-buffer": "^1.1.0",
+            "path-is-absolute": "^1.0.1",
+            "process": "~0.11.0",
+            "through2": "^2.0.0",
+            "undeclared-identifiers": "^1.1.2",
+            "xtend": "^4.0.0"
           },
           "dependencies": {
             "concat-stream": {
@@ -8127,10 +8127,10 @@
               "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
               "dev": true,
               "requires": {
-                "buffer-from": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
               }
             }
           }
@@ -8147,9 +8147,9 @@
           "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "isarray": "2.0.4",
-            "stream-splicer": "2.0.0"
+            "inherits": "^2.0.1",
+            "isarray": "^2.0.4",
+            "stream-splicer": "^2.0.0"
           },
           "dependencies": {
             "isarray": {
@@ -8190,12 +8190,12 @@
               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "dev": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             }
           }
@@ -8206,21 +8206,21 @@
           "integrity": "sha512-sigq/hm/L+Z5IGi1DDl0x2ptkw7S86aFh213QhPLD8v9Opv90IHzKIuWJrRa5bJ77DVKHco2CfIEuThcT/vDJA==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "browser-resolve": "1.11.3",
-            "cached-path-relative": "1.0.1",
-            "concat-stream": "1.6.2",
-            "defined": "1.0.0",
-            "detective": "5.1.0",
-            "duplexer2": "0.1.4",
-            "inherits": "2.0.3",
-            "parents": "1.0.1",
-            "readable-stream": "2.3.6",
-            "resolve": "1.8.1",
-            "stream-combiner2": "1.1.1",
-            "subarg": "1.0.0",
-            "through2": "2.0.3",
-            "xtend": "4.0.1"
+            "JSONStream": "^1.0.3",
+            "browser-resolve": "^1.7.0",
+            "cached-path-relative": "^1.0.0",
+            "concat-stream": "~1.6.0",
+            "defined": "^1.0.0",
+            "detective": "^5.0.2",
+            "duplexer2": "^0.1.2",
+            "inherits": "^2.0.1",
+            "parents": "^1.0.0",
+            "readable-stream": "^2.0.2",
+            "resolve": "^1.1.3",
+            "stream-combiner2": "^1.1.1",
+            "subarg": "^1.0.0",
+            "through2": "^2.0.0",
+            "xtend": "^4.0.0"
           },
           "dependencies": {
             "concat-stream": {
@@ -8229,10 +8229,10 @@
               "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
               "dev": true,
               "requires": {
-                "buffer-from": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
               }
             }
           }
@@ -8261,7 +8261,7 @@
           "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6"
+            "readable-stream": "^2.0.2"
           }
         },
         "shell-quote": {
@@ -8270,10 +8270,10 @@
           "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
           "dev": true,
           "requires": {
-            "array-filter": "0.0.1",
-            "array-map": "0.0.0",
-            "array-reduce": "0.0.0",
-            "jsonify": "0.0.0"
+            "array-filter": "~0.0.0",
+            "array-map": "~0.0.0",
+            "array-reduce": "~0.0.0",
+            "jsonify": "~0.0.0"
           }
         },
         "stream-browserify": {
@@ -8282,8 +8282,8 @@
           "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "~2.0.1",
+            "readable-stream": "^2.0.2"
           }
         },
         "stream-combiner2": {
@@ -8292,8 +8292,8 @@
           "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
           "dev": true,
           "requires": {
-            "duplexer2": "0.1.4",
-            "readable-stream": "2.3.6"
+            "duplexer2": "~0.1.0",
+            "readable-stream": "^2.0.2"
           }
         },
         "stream-splicer": {
@@ -8302,8 +8302,8 @@
           "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
           }
         },
         "string_decoder": {
@@ -8312,7 +8312,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         },
         "supports-color": {
@@ -8321,7 +8321,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         },
         "through2": {
@@ -8330,8 +8330,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         },
         "url": {
@@ -8360,13 +8360,13 @@
       "integrity": "sha1-tCKyy8E4osPzRQqxWeZzPIc/vHs=",
       "dev": true,
       "requires": {
-        "istanbul": "0.4.5",
-        "lodash": "2.4.2",
-        "minimatch": "3.0.4",
-        "resolve": "1.8.1",
-        "split2": "2.2.0",
-        "stream-combiner2": "1.1.1",
-        "through2": "2.0.3"
+        "istanbul": "^0.4.2",
+        "lodash": "^2.4.1",
+        "minimatch": "^3.0.0",
+        "resolve": "^1.1.6",
+        "split2": "^2.1.1",
+        "stream-combiner2": "^1.1.1",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "duplexer2": {
@@ -8375,12 +8375,12 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6"
+            "readable-stream": "^2.0.2"
           }
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
@@ -8390,7 +8390,7 @@
           "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
           "dev": true,
           "requires": {
-            "through2": "2.0.3"
+            "through2": "^2.0.2"
           }
         },
         "stream-combiner2": {
@@ -8399,8 +8399,8 @@
           "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
           "dev": true,
           "requires": {
-            "duplexer2": "0.1.4",
-            "readable-stream": "2.3.6"
+            "duplexer2": "~0.1.0",
+            "readable-stream": "^2.0.2"
           }
         },
         "through2": {
@@ -8409,8 +8409,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -8421,20 +8421,20 @@
       "integrity": "sha1-6nXK+RmQkNJbDVUStaysuW5/h/M=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.4",
-        "browser-resolve": "1.11.3",
-        "concat-stream": "1.4.11",
-        "defined": "1.0.0",
-        "detective": "4.7.1",
+        "JSONStream": "^1.0.3",
+        "browser-resolve": "^1.7.0",
+        "concat-stream": "~1.4.5",
+        "defined": "^1.0.0",
+        "detective": "^4.0.0",
         "duplexer2": "0.0.2",
-        "inherits": "2.0.3",
-        "parents": "1.0.1",
-        "readable-stream": "1.1.14",
-        "resolve": "1.8.1",
-        "stream-combiner2": "1.0.2",
-        "subarg": "1.0.0",
-        "through2": "1.1.1",
-        "xtend": "4.0.1"
+        "inherits": "^2.0.1",
+        "parents": "^1.0.0",
+        "readable-stream": "^1.1.13",
+        "resolve": "^1.1.3",
+        "stream-combiner2": "~1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^1.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -8443,20 +8443,20 @@
           "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
           "dev": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           }
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -8478,7 +8478,7 @@
       "integrity": "sha1-k9SKL7w+UOKl/I7VhvW8RMZfmpk=",
       "dev": true,
       "requires": {
-        "find-parent-dir": "0.3.0"
+        "find-parent-dir": "~0.3.0"
       }
     },
     "ms": {
@@ -8493,14 +8493,14 @@
       "integrity": "sha1-5n0qtEKdJ2BubrTbNQlK/JF4h1A=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "glob": "5.0.15",
-        "lodash": "3.10.1"
+        "async": "1.x",
+        "glob": "5.x",
+        "lodash": "3.x"
       },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -8512,10 +8512,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
       }
     },
     "nan": {
@@ -8530,17 +8530,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -8588,7 +8588,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "semver": "5.5.1"
+        "semver": "^5.4.1"
       }
     },
     "node-gyp": {
@@ -8597,18 +8597,18 @@
       "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
       "dev": true,
       "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.3",
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.5",
-        "request": "2.88.0",
-        "rimraf": "2.6.2",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.2.14"
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
       },
       "dependencies": {
         "glob": {
@@ -8617,12 +8617,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "semver": {
@@ -8639,22 +8639,22 @@
       "integrity": "sha1-ckD7v/I5YwS0IjUn7TAgWJwAT8I=",
       "dev": true,
       "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.3",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.3",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.11.0",
-        "node-gyp": "3.8.0",
-        "npmlog": "4.1.2",
-        "request": "2.88.0",
-        "sass-graph": "2.2.4"
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.3.2",
+        "node-gyp": "^3.3.1",
+        "npmlog": "^4.0.0",
+        "request": "^2.61.0",
+        "sass-graph": "^2.1.1"
       },
       "dependencies": {
         "glob": {
@@ -8663,12 +8663,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -8686,7 +8686,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -8695,10 +8695,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.7.1",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.1",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -8707,7 +8707,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize.css": {
@@ -8721,10 +8721,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.5",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -8733,7 +8733,7 @@
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
@@ -8778,9 +8778,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -8789,7 +8789,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -8812,7 +8812,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -8829,8 +8829,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -8839,7 +8839,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -8865,12 +8865,12 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -8886,7 +8886,7 @@
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "dev": true,
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "optimist": {
@@ -8895,8 +8895,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -8913,12 +8913,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-browserify": {
@@ -8935,11 +8935,11 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -8954,8 +8954,8 @@
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "outpipe": {
@@ -8964,7 +8964,7 @@
       "integrity": "sha1-UM+GFjZeh+Ax4ppeyTOaPaRyX6I=",
       "dev": true,
       "requires": {
-        "shell-quote": "1.6.1"
+        "shell-quote": "^1.4.2"
       },
       "dependencies": {
         "shell-quote": {
@@ -8973,10 +8973,10 @@
           "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
           "dev": true,
           "requires": {
-            "array-filter": "0.0.1",
-            "array-map": "0.0.0",
-            "array-reduce": "0.0.0",
-            "jsonify": "0.0.0"
+            "array-filter": "~0.0.0",
+            "array-map": "~0.0.0",
+            "array-reduce": "~0.0.0",
+            "jsonify": "~0.0.0"
           }
         }
       }
@@ -9011,7 +9011,7 @@
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
       "dev": true,
       "requires": {
-        "path-platform": "0.11.15"
+        "path-platform": "~0.11.15"
       }
     },
     "parse-asn1": {
@@ -9020,11 +9020,11 @@
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.17"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-glob": {
@@ -9033,10 +9033,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -9045,7 +9045,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "parse5": {
@@ -9060,7 +9060,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseuri": {
@@ -9069,7 +9069,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -9102,7 +9102,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -9138,9 +9138,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pbkdf2": {
@@ -9149,11 +9149,11 @@
       "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "pend": {
@@ -9175,9 +9175,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "phantomjs-prebuilt": "2.1.16",
-        "split": "1.0.1",
-        "winston": "2.4.4"
+        "phantomjs-prebuilt": "^2.1.16",
+        "split": "^1.0.1",
+        "winston": "^2.4.0"
       }
     },
     "phantomjs-prebuilt": {
@@ -9186,15 +9186,15 @@
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.5",
-        "extract-zip": "1.6.7",
-        "fs-extra": "1.0.0",
-        "hasha": "2.2.0",
-        "kew": "0.7.0",
-        "progress": "1.1.8",
-        "request": "2.88.0",
-        "request-progress": "2.0.1",
-        "which": "1.2.14"
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
       },
       "dependencies": {
         "es6-promise": {
@@ -9209,9 +9209,9 @@
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0"
           }
         },
         "jsonfile": {
@@ -9220,7 +9220,7 @@
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         }
       }
@@ -9248,7 +9248,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pop-arrayify": {
@@ -9269,8 +9269,8 @@
       "integrity": "sha1-YY1GJJfpbQb5zaMVsyXMo6JjYDg=",
       "dev": true,
       "requires": {
-        "mini-map": "1.0.0",
-        "pop-equals": "1.0.0"
+        "mini-map": "^1.0.0",
+        "pop-equals": "^1.0.0"
       }
     },
     "pop-compare": {
@@ -9285,7 +9285,7 @@
       "integrity": "sha1-kEFPj9pxo3+IHR5eOi4C7ww7fgs=",
       "dev": true,
       "requires": {
-        "mini-map": "1.0.0"
+        "mini-map": "^1.0.0"
       }
     },
     "pop-has": {
@@ -9294,7 +9294,7 @@
       "integrity": "sha1-myJrWblgq2XqsLQS3VVw3OkOZRw=",
       "dev": true,
       "requires": {
-        "pop-equals": "1.0.0"
+        "pop-equals": "^1.0.0"
       }
     },
     "pop-hash": {
@@ -9303,7 +9303,7 @@
       "integrity": "sha1-vNaUVL0vmd7SC1/Iork9a1+rRMw=",
       "dev": true,
       "requires": {
-        "weak-map": "1.0.5"
+        "weak-map": "^1.0.5"
       }
     },
     "pop-iterate": {
@@ -9318,9 +9318,9 @@
       "integrity": "sha1-WstaxvJMfG/6ssMhUbCtt0Du82M=",
       "dev": true,
       "requires": {
-        "pop-equals": "1.0.0",
-        "pop-has": "1.0.0",
-        "pop-swap": "1.0.0"
+        "pop-equals": "^1.0.0",
+        "pop-has": "^1.0.0",
+        "pop-swap": "^1.0.0"
       }
     },
     "pop-swap": {
@@ -9342,7 +9342,7 @@
       "dev": true,
       "requires": {
         "async": "1.5.2",
-        "is-number-like": "1.0.8"
+        "is-number-like": "^1.0.3"
       }
     },
     "posix-character-classes": {
@@ -9353,13 +9353,13 @@
     },
     "postcss": {
       "version": "4.1.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
+      "resolved": "http://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
       "integrity": "sha1-TESbTIr53zyvbTf44eV10DYXWNw=",
       "dev": true,
       "requires": {
-        "es6-promise": "2.3.0",
-        "js-base64": "2.1.9",
-        "source-map": "0.4.4"
+        "es6-promise": "~2.3.0",
+        "js-base64": "~2.1.8",
+        "source-map": "~0.4.2"
       },
       "dependencies": {
         "source-map": {
@@ -9368,7 +9368,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -9380,21 +9380,21 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "1.1.1",
+        "detect-libc": "^1.0.3",
+        "expand-template": "^1.0.2",
         "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.4.4",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "2.0.1",
-        "rc": "1.2.8",
-        "simple-get": "2.8.1",
-        "tar-fs": "1.16.3",
-        "tunnel-agent": "0.6.0",
-        "which-pm-runs": "1.0.0"
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-abi": "^2.2.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.1.6",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
       },
       "dependencies": {
         "detect-libc": {
@@ -9406,7 +9406,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true,
           "optional": true
@@ -9479,11 +9479,11 @@
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "pullstream": {
@@ -9492,22 +9492,22 @@
       "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
       "dev": true,
       "requires": {
-        "over": "0.0.5",
-        "readable-stream": "1.0.34",
-        "setimmediate": "1.0.5",
-        "slice-stream": "1.0.0"
+        "over": ">= 0.0.5 < 1",
+        "readable-stream": "~1.0.31",
+        "setimmediate": ">= 1.0.2 < 2",
+        "slice-stream": ">= 1.0.0 < 2"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -9525,8 +9525,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "punycode": {
@@ -9541,14 +9541,14 @@
       "integrity": "sha512-wJ7Fxs03l4dy/ZXQACUKBBobIuJaS4NHq44q7/QinpAXFMwJMJFEIPjzoksVzUhZxQe+RXnjXH69mg13yMh0BA==",
       "dev": true,
       "requires": {
-        "debug": "3.2.5",
-        "extract-zip": "1.6.7",
-        "https-proxy-agent": "2.2.1",
-        "mime": "2.3.1",
-        "progress": "2.0.0",
-        "proxy-from-env": "1.0.0",
-        "rimraf": "2.6.2",
-        "ws": "5.2.2"
+        "debug": "^3.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.0",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^5.1.1"
       },
       "dependencies": {
         "agent-base": {
@@ -9557,7 +9557,7 @@
           "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
           "dev": true,
           "requires": {
-            "es6-promisify": "5.0.0"
+            "es6-promisify": "^5.0.0"
           }
         },
         "debug": {
@@ -9566,7 +9566,7 @@
           "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "https-proxy-agent": {
@@ -9575,8 +9575,8 @@
           "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
           "dev": true,
           "requires": {
-            "agent-base": "4.2.1",
-            "debug": "3.2.5"
+            "agent-base": "^4.1.0",
+            "debug": "^3.1.0"
           }
         },
         "mime": {
@@ -9603,7 +9603,7 @@
           "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
           "dev": true,
           "requires": {
-            "async-limiter": "1.0.0"
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -9620,12 +9620,12 @@
       "integrity": "sha1-GTNM5KlL2r/42dMBXz07csm+O/U=",
       "dev": true,
       "requires": {
-        "collections": "2.0.3",
-        "mime": "1.4.1",
-        "mimeparse": "0.1.4",
-        "q": "2.0.3",
-        "qs": "0.6.6",
-        "url2": "1.0.4"
+        "collections": "^2.0.1",
+        "mime": "^1.2.11",
+        "mimeparse": "^0.1.4",
+        "q": "^2.0.1",
+        "qs": "^0.6.6",
+        "url2": "^1.0.1"
       },
       "dependencies": {
         "q": {
@@ -9634,9 +9634,9 @@
           "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
           "dev": true,
           "requires": {
-            "asap": "2.0.6",
-            "pop-iterate": "1.0.1",
-            "weak-map": "1.0.5"
+            "asap": "^2.0.0",
+            "pop-iterate": "^1.0.1",
+            "weak-map": "^1.0.5"
           }
         },
         "qs": {
@@ -9671,9 +9671,9 @@
       "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0",
-        "kind-of": "6.0.2",
-        "math-random": "1.0.1"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -9696,7 +9696,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -9705,8 +9705,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.2"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -9734,15 +9734,15 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true,
           "optional": true
@@ -9755,20 +9755,20 @@
       "integrity": "sha1-Xad8eZ7ROI0++IoYRxu1kk+KC6E=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14",
-        "readable-wrap": "1.0.0"
+        "readable-stream": "^1.0.31",
+        "readable-wrap": "^1.0.0"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -9785,9 +9785,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -9796,8 +9796,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -9806,13 +9806,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -9829,19 +9829,19 @@
       "integrity": "sha1-O1ohHGMeEjA6VJkcgGwX564ga/8=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "^1.1.13-1"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -9858,9 +9858,9 @@
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "micromatch": "3.1.10",
-        "readable-stream": "2.3.6"
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -9881,16 +9881,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.3",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -9899,7 +9899,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -9910,13 +9910,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -9925,7 +9925,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -9934,7 +9934,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -9943,7 +9943,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -9952,7 +9952,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -9963,7 +9963,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -9972,7 +9972,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -9983,9 +9983,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               }
             },
             "kind-of": {
@@ -10002,14 +10002,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -10018,7 +10018,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -10027,7 +10027,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -10038,10 +10038,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -10050,7 +10050,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -10061,7 +10061,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -10070,7 +10070,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -10079,9 +10079,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "is-number": {
@@ -10090,7 +10090,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -10099,7 +10099,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -10122,19 +10122,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.13",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         }
       }
@@ -10145,8 +10145,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "regenerate": {
@@ -10167,9 +10167,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -10178,7 +10178,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -10187,8 +10187,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexp-escape": {
@@ -10203,9 +10203,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.4.0",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -10220,7 +10220,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -10243,7 +10243,7 @@
       "integrity": "sha1-f4M2nAB6MAf2q+MDPM+BaGoQjgE=",
       "dev": true,
       "requires": {
-        "detective": "3.1.0"
+        "detective": "~3.1.0"
       },
       "dependencies": {
         "detective": {
@@ -10252,7 +10252,7 @@
           "integrity": "sha1-d3gkRKt1K4jKG+Lp0KA5Xx2iXu0=",
           "dev": true,
           "requires": {
-            "escodegen": "1.1.0",
+            "escodegen": "~1.1.0",
             "esprima-fb": "3001.1.0-dev-harmony-fb"
           }
         },
@@ -10262,10 +10262,10 @@
           "integrity": "sha1-xmOSP24gqtSNDA+knzHG1PSTYM8=",
           "dev": true,
           "requires": {
-            "esprima": "1.0.4",
-            "estraverse": "1.5.1",
-            "esutils": "1.0.0",
-            "source-map": "0.1.43"
+            "esprima": "~1.0.4",
+            "estraverse": "~1.5.0",
+            "esutils": "~1.0.0",
+            "source-map": "~0.1.30"
           },
           "dependencies": {
             "esprima": {
@@ -10301,7 +10301,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -10324,7 +10324,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "replace-requires": {
@@ -10333,10 +10333,10 @@
       "integrity": "sha1-AUtzMLa54lV7cQQ7ZvsCZgw79mc=",
       "dev": true,
       "requires": {
-        "detective": "4.7.1",
-        "has-require": "1.2.2",
-        "patch-text": "1.0.2",
-        "xtend": "4.0.1"
+        "detective": "^4.5.0",
+        "has-require": "~1.2.1",
+        "patch-text": "~1.0.2",
+        "xtend": "~4.0.0"
       }
     },
     "request": {
@@ -10345,26 +10345,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.7",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.1.0",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.20",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       },
       "dependencies": {
         "qs": {
@@ -10381,7 +10381,7 @@
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
-        "throttleit": "1.0.0"
+        "throttleit": "^1.0.0"
       }
     },
     "require-directory": {
@@ -10396,8 +10396,8 @@
       "integrity": "sha1-Wxf6WcoyUkJk/T0i0+QNlP6qRFg=",
       "dev": true,
       "requires": {
-        "browserify-transform-tools": "1.7.0",
-        "glob": "7.1.3"
+        "browserify-transform-tools": "^1.6.0",
+        "glob": "^7.0.5"
       },
       "dependencies": {
         "acorn": {
@@ -10412,8 +10412,8 @@
           "integrity": "sha1-g+J3Ih9jJZvtLn6yooOpcKUB9MQ=",
           "dev": true,
           "requires": {
-            "falafel": "2.1.0",
-            "through": "2.3.8"
+            "falafel": "^2.0.0",
+            "through": "^2.3.7"
           }
         },
         "falafel": {
@@ -10422,10 +10422,10 @@
           "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
           "dev": true,
           "requires": {
-            "acorn": "5.7.3",
-            "foreach": "2.0.5",
+            "acorn": "^5.0.0",
+            "foreach": "^2.0.5",
             "isarray": "0.0.1",
-            "object-keys": "1.0.12"
+            "object-keys": "^1.0.6"
           }
         },
         "glob": {
@@ -10434,12 +10434,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -10462,7 +10462,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-url": {
@@ -10477,8 +10477,8 @@
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "minimatch": "3.0.4"
+        "debug": "^2.2.0",
+        "minimatch": "^3.0.2"
       }
     },
     "ret": {
@@ -10493,11 +10493,11 @@
       "integrity": "sha512-teNyrr6FCxXNKBvwy2qCRVMo52EaAVeeMkVwHgycCaW6qZa0HC6cA1cNpm8D0yKbACh7wqVuSaUvAGnRH3SztQ==",
       "dev": true,
       "requires": {
-        "axios": "0.18.0",
-        "fstream": "1.0.11",
-        "metaparser": "1.0.7",
-        "mkdirp": "0.5.1",
-        "unzip2": "0.2.5"
+        "axios": "^0.18.0",
+        "fstream": "^1.0.2",
+        "metaparser": "^1.0.7",
+        "mkdirp": "^0.5.0",
+        "unzip2": "^0.2.5"
       },
       "dependencies": {
         "axios": {
@@ -10506,8 +10506,8 @@
           "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
           "dev": true,
           "requires": {
-            "follow-redirects": "1.5.8",
-            "is-buffer": "1.1.6"
+            "follow-redirects": "^1.3.0",
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -10518,7 +10518,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -10527,7 +10527,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.0.5"
       },
       "dependencies": {
         "glob": {
@@ -10536,12 +10536,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -10552,8 +10552,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rx": {
@@ -10580,7 +10580,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -10601,10 +10601,10 @@
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
-        "glob": "7.1.3",
-        "lodash": "4.17.15",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^7.0.0"
       },
       "dependencies": {
         "glob": {
@@ -10613,12 +10613,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "yargs": {
@@ -10627,19 +10627,19 @@
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.3",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
           }
         },
         "yargs-parser": {
@@ -10648,7 +10648,7 @@
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         }
       }
@@ -10659,7 +10659,7 @@
       "integrity": "sha512-jlX3FGdWvYf4Q3LFfFWS1QvPg3IGCGWxIc8QBFdPTbpTJnt/v17FHXYVAn7C8sHf1yUXo2c7yIM0isDryfYtHQ==",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "2.2.1"
+        "https-proxy-agent": "^2.2.1"
       },
       "dependencies": {
         "agent-base": {
@@ -10668,7 +10668,7 @@
           "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
           "dev": true,
           "requires": {
-            "es6-promisify": "5.0.0"
+            "es6-promisify": "^5.0.0"
           }
         },
         "debug": {
@@ -10677,7 +10677,7 @@
           "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "https-proxy-agent": {
@@ -10686,8 +10686,8 @@
           "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
           "dev": true,
           "requires": {
-            "agent-base": "4.2.1",
-            "debug": "3.2.5"
+            "agent-base": "^4.1.0",
+            "debug": "^3.1.0"
           }
         },
         "ms": {
@@ -10710,8 +10710,8 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.1.9",
-        "source-map": "0.4.4"
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
       },
       "dependencies": {
         "source-map": {
@@ -10720,16 +10720,17 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
     },
     "select2": {
-      "version": "github:jadu/selectWoo#4101fb37341154e12af6f880c0ade5596dcaeb08",
+      "version": "github:jadu/selectWoo#9e93093268d02065f19959764ff859ba4918e134",
+      "from": "github:jadu/selectWoo#jadu-1.1.2",
       "requires": {
-        "almond": "0.3.3",
-        "jquery-mousewheel": "3.1.13"
+        "almond": "~0.3.1",
+        "jquery-mousewheel": "~3.1.13"
       }
     },
     "semver": {
@@ -10745,18 +10746,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "statuses": {
@@ -10773,13 +10774,13 @@
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.4",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.3",
-        "mime-types": "2.1.20",
-        "parseurl": "1.3.2"
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
       }
     },
     "serve-static": {
@@ -10788,9 +10789,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -10818,10 +10819,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -10830,7 +10831,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -10853,8 +10854,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shallow-copy": {
@@ -10865,12 +10866,12 @@
     },
     "shasum": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "0.0.1",
-        "sha.js": "2.4.11"
+        "json-stable-stringify": "~0.0.0",
+        "sha.js": "~2.4.4"
       }
     },
     "shell-quote": {
@@ -10910,9 +10911,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "sinon": {
@@ -10921,14 +10922,14 @@
       "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
       "dev": true,
       "requires": {
-        "diff": "3.5.0",
+        "diff": "^3.1.0",
         "formatio": "1.2.0",
-        "lolex": "1.6.0",
-        "native-promise-only": "0.8.1",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.3.0",
+        "lolex": "^1.6.0",
+        "native-promise-only": "^0.8.1",
+        "path-to-regexp": "^1.7.0",
+        "samsam": "^1.1.3",
         "text-encoding": "0.6.4",
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       },
       "dependencies": {
         "diff": {
@@ -10957,14 +10958,14 @@
       "integrity": "sha1-fa75oej54wXNV8pc65znND1X+do=",
       "dev": true,
       "requires": {
-        "babel-preset-es2015": "6.24.1",
-        "babelify": "7.3.0",
-        "lodash": "3.10.1"
+        "babel-preset-es2015": "^6.16.0",
+        "babelify": "^7.0.0",
+        "lodash": "^3.10.1"
       },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -10982,19 +10983,19 @@
       "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "~1.0.31"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -11011,14 +11012,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.1"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -11027,7 +11028,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -11036,7 +11037,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -11047,9 +11048,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -11058,7 +11059,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -11067,7 +11068,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -11076,7 +11077,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -11085,9 +11086,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "isobject": {
@@ -11110,7 +11111,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       }
     },
     "socket.io": {
@@ -11119,12 +11120,12 @@
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "engine.io": "3.2.0",
-        "has-binary2": "1.0.3",
-        "socket.io-adapter": "1.1.1",
+        "debug": "~3.1.0",
+        "engine.io": "~3.2.0",
+        "has-binary2": "~1.0.2",
+        "socket.io-adapter": "~1.1.0",
         "socket.io-client": "2.1.1",
-        "socket.io-parser": "3.2.0"
+        "socket.io-parser": "~3.2.0"
       },
       "dependencies": {
         "debug": {
@@ -11144,14 +11145,14 @@
           "requires": {
             "component-emitter": "1.2.1",
             "component-inherit": "0.0.3",
-            "debug": "3.1.0",
-            "engine.io-parser": "2.1.2",
+            "debug": "~3.1.0",
+            "engine.io-parser": "~2.1.1",
             "has-cors": "1.1.0",
             "indexof": "0.0.1",
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
-            "ws": "3.3.3",
-            "xmlhttprequest-ssl": "1.5.5",
+            "ws": "~3.3.1",
+            "xmlhttprequest-ssl": "~1.5.4",
             "yeast": "0.1.2"
           }
         },
@@ -11171,15 +11172,15 @@
             "base64-arraybuffer": "0.1.5",
             "component-bind": "1.0.0",
             "component-emitter": "1.2.1",
-            "debug": "3.1.0",
-            "engine.io-client": "3.2.1",
-            "has-binary2": "1.0.3",
+            "debug": "~3.1.0",
+            "engine.io-client": "~3.2.0",
+            "has-binary2": "~1.0.2",
             "has-cors": "1.1.0",
             "indexof": "0.0.1",
             "object-component": "0.0.3",
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
-            "socket.io-parser": "3.2.0",
+            "socket.io-parser": "~3.2.0",
             "to-array": "0.1.4"
           }
         },
@@ -11190,7 +11191,7 @@
           "dev": true,
           "requires": {
             "component-emitter": "1.2.1",
-            "debug": "3.1.0",
+            "debug": "~3.1.0",
             "isarray": "2.0.1"
           }
         }
@@ -11212,14 +11213,14 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "2.6.9",
-        "engine.io-client": "3.1.6",
+        "debug": "~2.6.4",
+        "engine.io-client": "~3.1.0",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "3.1.3",
+        "socket.io-parser": "~3.1.1",
         "to-array": "0.1.4"
       }
     },
@@ -11230,8 +11231,8 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "3.1.0",
-        "has-binary2": "1.0.3",
+        "debug": "~3.1.0",
+        "has-binary2": "~1.0.2",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -11264,11 +11265,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "2.1.2",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -11277,7 +11278,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "source-map-url": {
@@ -11292,9 +11293,9 @@
       "integrity": "sha512-84lrzK66JD4v1BCeMsyQtjpTQ21pxE4gIaFL87wQra/cpLk2FpPT5ux9gw5dvWTNZnSFDKMrA22phedGNhPzQg==",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.6.0",
-        "source-map": "0.5.7",
-        "through2": "2.0.3"
+        "convert-source-map": "^1.1.3",
+        "source-map": "~0.5.3",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "through2": {
@@ -11303,8 +11304,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -11315,8 +11316,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.1"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -11331,8 +11332,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.1"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -11353,7 +11354,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split-string": {
@@ -11362,7 +11363,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "split2": {
@@ -11371,19 +11372,19 @@
       "integrity": "sha1-At2smtwD7Au3jBKC7Aecpuha6QA=",
       "dev": true,
       "requires": {
-        "through2": "0.6.5"
+        "through2": "~0.6.1"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -11398,8 +11399,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -11416,15 +11417,15 @@
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack-parser": {
@@ -11446,8 +11447,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -11456,7 +11457,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -11473,20 +11474,20 @@
       "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14"
+        "inherits": "~2.0.1",
+        "readable-stream": "^1.0.27-1"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -11509,20 +11510,20 @@
       "integrity": "sha1-unKmtQy/q/qVD8i8h2BL0B62BnE=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.0.2",
-        "through2": "0.5.1"
+        "duplexer2": "~0.0.2",
+        "through2": "~0.5.1"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -11537,8 +11538,8 @@
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "3.0.0"
+            "readable-stream": "~1.0.17",
+            "xtend": "~3.0.0"
           }
         },
         "xtend": {
@@ -11555,11 +11556,11 @@
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-splicer": {
@@ -11569,23 +11570,23 @@
       "dev": true,
       "requires": {
         "indexof": "0.0.1",
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "readable-stream": "1.1.14",
-        "readable-wrap": "1.0.0",
-        "through2": "1.1.1"
+        "inherits": "^2.0.1",
+        "isarray": "~0.0.1",
+        "readable-stream": "^1.1.13-1",
+        "readable-wrap": "^1.0.0",
+        "through2": "^1.0.0"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -11602,8 +11603,8 @@
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
       "dev": true,
       "requires": {
-        "commander": "2.17.1",
-        "limiter": "1.1.3"
+        "commander": "^2.2.0",
+        "limiter": "^1.0.5"
       }
     },
     "string-template": {
@@ -11618,9 +11619,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -11629,7 +11630,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -11638,7 +11639,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -11647,7 +11648,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-indent": {
@@ -11656,7 +11657,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -11672,12 +11673,12 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.1.0"
       },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -11701,7 +11702,7 @@
       "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "dev": true,
       "requires": {
-        "acorn-node": "1.5.2"
+        "acorn-node": "^1.2.0"
       }
     },
     "tar": {
@@ -11710,9 +11711,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "tar-fs": {
@@ -11722,10 +11723,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "chownr": "1.1.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.6.2"
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
       },
       "dependencies": {
         "pump": {
@@ -11735,8 +11736,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -11747,13 +11748,13 @@
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "dev": true,
       "requires": {
-        "bl": "1.2.2",
-        "buffer-alloc": "1.2.0",
-        "end-of-stream": "1.4.1",
-        "fs-constants": "1.0.0",
-        "readable-stream": "2.3.6",
-        "to-buffer": "1.1.1",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
       }
     },
     "temporary": {
@@ -11762,7 +11763,7 @@
       "integrity": "sha1-oYqYHSi6jKNgJ/s8MFOMPst0CsA=",
       "dev": true,
       "requires": {
-        "package": "1.0.1"
+        "package": ">= 1.0.0 < 1.2.0"
       }
     },
     "ternary": {
@@ -11783,8 +11784,8 @@
       "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "object-path": "0.9.2"
+        "chalk": "^1.1.1",
+        "object-path": "^0.9.0"
       }
     },
     "throttleit": {
@@ -11795,7 +11796,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -11805,20 +11806,20 @@
       "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14",
-        "xtend": "4.0.1"
+        "readable-stream": ">=1.1.13-1 <1.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -11834,7 +11835,7 @@
       "resolved": "https://registry.npmjs.org/timepicker/-/timepicker-1.11.15.tgz",
       "integrity": "sha512-itCpFBnpCqsiAAuSsdRFjF7tb8Tpqm7btYN1P0Rea9yqcLI1M60F/OGDHegjxT+ZD5mt5Pv7pZqrPySf6gcpBg==",
       "requires": {
-        "jquery": "3.4.1"
+        "jquery": ">=1.7"
       }
     },
     "timers-browserify": {
@@ -11843,7 +11844,7 @@
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
-        "process": "0.11.10"
+        "process": "~0.11.0"
       }
     },
     "tiny-lr": {
@@ -11852,12 +11853,12 @@
       "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
       "dev": true,
       "requires": {
-        "body": "5.1.0",
-        "debug": "3.2.5",
-        "faye-websocket": "0.10.0",
-        "livereload-js": "2.3.0",
-        "object-assign": "4.1.1",
-        "qs": "6.5.2"
+        "body": "^5.1.0",
+        "debug": "^3.1.0",
+        "faye-websocket": "~0.10.0",
+        "livereload-js": "^2.3.0",
+        "object-assign": "^4.1.0",
+        "qs": "^6.4.0"
       },
       "dependencies": {
         "debug": {
@@ -11866,7 +11867,7 @@
           "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -11925,7 +11926,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "to-regex": {
@@ -11934,10 +11935,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -11946,8 +11947,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -11956,7 +11957,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         }
       }
@@ -11967,8 +11968,8 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "1.1.29",
-        "punycode": "1.4.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
       }
     },
     "tr46": {
@@ -11983,8 +11984,8 @@
       "integrity": "sha1-gG+FG25ECyN4j9OMoEMbUCAlulk=",
       "dev": true,
       "requires": {
-        "multimatch": "2.1.0",
-        "through": "2.3.8"
+        "multimatch": "^2.0.0",
+        "through": "^2.3.6"
       }
     },
     "transformify": {
@@ -11993,19 +11994,19 @@
       "integrity": "sha1-mk9CoVRDPdcnuAV1Qoo8nlSJ6/E=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.9"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -12046,7 +12047,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -12062,7 +12063,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -12090,8 +12091,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "2.17.1",
-        "source-map": "0.6.1"
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -12115,11 +12116,11 @@
       "integrity": "sha1-SH4IClp3mIgOaOkN75sGaB+xO9I=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.1.3",
-        "extend": "1.3.0",
-        "minimatch": "3.0.4",
-        "through": "2.3.8",
-        "uglify-js": "2.8.29"
+        "convert-source-map": "~1.1.0",
+        "extend": "^1.2.1",
+        "minimatch": "^3.0.2",
+        "through": "~2.3.4",
+        "uglify-js": "2.x.x"
       },
       "dependencies": {
         "camelcase": {
@@ -12134,14 +12135,14 @@
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           }
         },
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
@@ -12157,9 +12158,9 @@
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           }
         },
         "window-size": {
@@ -12180,9 +12181,9 @@
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -12206,10 +12207,10 @@
       "integrity": "sha512-13EaeocO4edF/3JKime9rD7oB6QI8llAGhgn5fKOPyfkJbRb6NFv9pYV6dFEmpa4uRjKeBqLZP8GpuzqHlKDMQ==",
       "dev": true,
       "requires": {
-        "acorn-node": "1.5.2",
-        "get-assigned-identifiers": "1.2.0",
-        "simple-concat": "1.0.0",
-        "xtend": "4.0.1"
+        "acorn-node": "^1.3.0",
+        "get-assigned-identifiers": "^1.2.0",
+        "simple-concat": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "underscore": {
@@ -12224,8 +12225,8 @@
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
       }
     },
     "unicode-5.2.0": {
@@ -12240,10 +12241,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -12252,7 +12253,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -12261,10 +12262,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -12287,8 +12288,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -12297,9 +12298,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -12339,12 +12340,12 @@
       "integrity": "sha1-TveleaeMFcUfVQ9qBT2xlBSciZI=",
       "dev": true,
       "requires": {
-        "binary": "0.3.0",
-        "fstream": "0.1.31",
-        "match-stream": "0.0.2",
-        "pullstream": "0.4.1",
-        "readable-stream": "1.0.34",
-        "setimmediate": "1.0.5"
+        "binary": "~0.3.0",
+        "fstream": "~0.1.21",
+        "match-stream": "~0.0.2",
+        "pullstream": "~0.4.0",
+        "readable-stream": "~1.0.0",
+        "setimmediate": "~1.0.1"
       },
       "dependencies": {
         "fstream": {
@@ -12353,10 +12354,10 @@
           "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "3.0.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "~3.0.2",
+            "inherits": "~2.0.0",
+            "mkdirp": "0.5",
+            "rimraf": "2"
           }
         },
         "graceful-fs": {
@@ -12365,19 +12366,19 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.6"
+            "natives": "^1.1.0"
           }
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -12489,8 +12490,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -12499,9 +12500,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vide": {
@@ -12509,7 +12510,7 @@
       "resolved": "https://registry.npmjs.org/vide/-/vide-0.5.1.tgz",
       "integrity": "sha1-suO6ZcL2xqSe+NySFX8t6DBPOEw=",
       "requires": {
-        "jquery": "3.4.1"
+        "jquery": "*"
       }
     },
     "vm-browserify": {
@@ -12533,13 +12534,13 @@
       "integrity": "sha512-7jWG0c3cKKm2hKScnSAMUEUjRJKXUShwMPk0ASVhICycQhwND3IMAdhJYmc1mxxKzBUJTSF5HZizfrKrS6BzkA==",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "browserify": "16.2.3",
-        "chokidar": "1.7.0",
-        "defined": "1.0.0",
-        "outpipe": "1.1.1",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "anymatch": "^1.3.0",
+        "browserify": "^16.1.0",
+        "chokidar": "^1.0.0",
+        "defined": "^1.0.0",
+        "outpipe": "^1.1.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -12548,8 +12549,8 @@
           "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
           "dev": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           }
         },
         "assert": {
@@ -12590,12 +12591,12 @@
           "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "combine-source-map": "0.8.0",
-            "defined": "1.0.0",
-            "safe-buffer": "5.1.2",
-            "through2": "2.0.3",
-            "umd": "3.0.3"
+            "JSONStream": "^1.0.3",
+            "combine-source-map": "~0.8.0",
+            "defined": "^1.0.0",
+            "safe-buffer": "^5.1.1",
+            "through2": "^2.0.0",
+            "umd": "^3.0.0"
           }
         },
         "browserify": {
@@ -12604,54 +12605,54 @@
           "integrity": "sha512-zQt/Gd1+W+IY+h/xX2NYMW4orQWhqSwyV+xsblycTtpOuB27h1fZhhNQuipJ4t79ohw4P4mMem0jp/ZkISQtjQ==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "assert": "1.4.1",
-            "browser-pack": "6.1.0",
-            "browser-resolve": "1.11.3",
-            "browserify-zlib": "0.2.0",
-            "buffer": "5.2.1",
-            "cached-path-relative": "1.0.1",
-            "concat-stream": "1.6.2",
-            "console-browserify": "1.1.0",
-            "constants-browserify": "1.0.0",
-            "crypto-browserify": "3.12.0",
-            "defined": "1.0.0",
-            "deps-sort": "2.0.0",
-            "domain-browser": "1.2.0",
-            "duplexer2": "0.1.4",
-            "events": "2.1.0",
-            "glob": "7.1.3",
-            "has": "1.0.3",
-            "htmlescape": "1.1.1",
-            "https-browserify": "1.0.0",
-            "inherits": "2.0.3",
-            "insert-module-globals": "7.2.0",
-            "labeled-stream-splicer": "2.0.1",
-            "mkdirp": "0.5.1",
-            "module-deps": "6.1.0",
-            "os-browserify": "0.3.0",
-            "parents": "1.0.1",
-            "path-browserify": "0.0.1",
-            "process": "0.11.10",
-            "punycode": "1.4.1",
-            "querystring-es3": "0.2.1",
-            "read-only-stream": "2.0.0",
-            "readable-stream": "2.3.6",
-            "resolve": "1.8.1",
-            "shasum": "1.0.2",
-            "shell-quote": "1.6.1",
-            "stream-browserify": "2.0.1",
-            "stream-http": "2.8.3",
-            "string_decoder": "1.1.1",
-            "subarg": "1.0.0",
-            "syntax-error": "1.4.0",
-            "through2": "2.0.3",
-            "timers-browserify": "1.4.2",
+            "JSONStream": "^1.0.3",
+            "assert": "^1.4.0",
+            "browser-pack": "^6.0.1",
+            "browser-resolve": "^1.11.0",
+            "browserify-zlib": "~0.2.0",
+            "buffer": "^5.0.2",
+            "cached-path-relative": "^1.0.0",
+            "concat-stream": "^1.6.0",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "~1.0.0",
+            "crypto-browserify": "^3.0.0",
+            "defined": "^1.0.0",
+            "deps-sort": "^2.0.0",
+            "domain-browser": "^1.2.0",
+            "duplexer2": "~0.1.2",
+            "events": "^2.0.0",
+            "glob": "^7.1.0",
+            "has": "^1.0.0",
+            "htmlescape": "^1.1.0",
+            "https-browserify": "^1.0.0",
+            "inherits": "~2.0.1",
+            "insert-module-globals": "^7.0.0",
+            "labeled-stream-splicer": "^2.0.0",
+            "mkdirp": "^0.5.0",
+            "module-deps": "^6.0.0",
+            "os-browserify": "~0.3.0",
+            "parents": "^1.0.1",
+            "path-browserify": "~0.0.0",
+            "process": "~0.11.0",
+            "punycode": "^1.3.2",
+            "querystring-es3": "~0.2.0",
+            "read-only-stream": "^2.0.0",
+            "readable-stream": "^2.0.2",
+            "resolve": "^1.1.4",
+            "shasum": "^1.0.0",
+            "shell-quote": "^1.6.1",
+            "stream-browserify": "^2.0.0",
+            "stream-http": "^2.0.0",
+            "string_decoder": "^1.1.1",
+            "subarg": "^1.0.0",
+            "syntax-error": "^1.1.1",
+            "through2": "^2.0.0",
+            "timers-browserify": "^1.0.1",
             "tty-browserify": "0.0.1",
-            "url": "0.11.0",
-            "util": "0.10.4",
-            "vm-browserify": "1.1.0",
-            "xtend": "4.0.1"
+            "url": "~0.11.0",
+            "util": "~0.10.1",
+            "vm-browserify": "^1.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "browserify-zlib": {
@@ -12660,7 +12661,7 @@
           "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
           "dev": true,
           "requires": {
-            "pako": "1.0.6"
+            "pako": "~1.0.5"
           }
         },
         "buffer": {
@@ -12669,8 +12670,8 @@
           "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
           "dev": true,
           "requires": {
-            "base64-js": "1.3.0",
-            "ieee754": "1.1.12"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
           }
         },
         "combine-source-map": {
@@ -12679,10 +12680,10 @@
           "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
           "dev": true,
           "requires": {
-            "convert-source-map": "1.1.3",
-            "inline-source-map": "0.6.2",
-            "lodash.memoize": "3.0.4",
-            "source-map": "0.5.7"
+            "convert-source-map": "~1.1.0",
+            "inline-source-map": "~0.6.0",
+            "lodash.memoize": "~3.0.3",
+            "source-map": "~0.5.3"
           }
         },
         "concat-stream": {
@@ -12691,10 +12692,10 @@
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "constants-browserify": {
@@ -12705,7 +12706,7 @@
         },
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
@@ -12715,10 +12716,10 @@
           "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "shasum": "1.0.2",
-            "subarg": "1.0.0",
-            "through2": "2.0.3"
+            "JSONStream": "^1.0.3",
+            "shasum": "^1.0.0",
+            "subarg": "^1.0.0",
+            "through2": "^2.0.0"
           }
         },
         "detective": {
@@ -12727,9 +12728,9 @@
           "integrity": "sha512-TFHMqfOvxlgrfVzTEkNBSh9SvSNX/HfF4OFI2QFGCyPm02EsyILqnUeb5P6q7JZ3SFNTBL5t2sePRgrN4epUWQ==",
           "dev": true,
           "requires": {
-            "acorn-node": "1.5.2",
-            "defined": "1.0.0",
-            "minimist": "1.2.0"
+            "acorn-node": "^1.3.0",
+            "defined": "^1.0.0",
+            "minimist": "^1.1.1"
           }
         },
         "domain-browser": {
@@ -12744,7 +12745,7 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6"
+            "readable-stream": "^2.0.2"
           }
         },
         "events": {
@@ -12759,12 +12760,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "https-browserify": {
@@ -12779,7 +12780,7 @@
           "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "~0.5.3"
           }
         },
         "insert-module-globals": {
@@ -12788,16 +12789,16 @@
           "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "acorn-node": "1.5.2",
-            "combine-source-map": "0.8.0",
-            "concat-stream": "1.6.2",
-            "is-buffer": "1.1.6",
-            "path-is-absolute": "1.0.1",
-            "process": "0.11.10",
-            "through2": "2.0.3",
-            "undeclared-identifiers": "1.1.2",
-            "xtend": "4.0.1"
+            "JSONStream": "^1.0.3",
+            "acorn-node": "^1.5.2",
+            "combine-source-map": "^0.8.0",
+            "concat-stream": "^1.6.1",
+            "is-buffer": "^1.1.0",
+            "path-is-absolute": "^1.0.1",
+            "process": "~0.11.0",
+            "through2": "^2.0.0",
+            "undeclared-identifiers": "^1.1.2",
+            "xtend": "^4.0.0"
           }
         },
         "isarray": {
@@ -12812,9 +12813,9 @@
           "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "isarray": "2.0.4",
-            "stream-splicer": "2.0.0"
+            "inherits": "^2.0.1",
+            "isarray": "^2.0.4",
+            "stream-splicer": "^2.0.0"
           }
         },
         "minimist": {
@@ -12829,21 +12830,21 @@
           "integrity": "sha512-NPs5N511VD1rrVJihSso/LiBShRbJALYBKzDW91uZYy7BpjnO4bGnZL3HjZ9yKcFdZUWwaYjDz9zxbuP7vKMuQ==",
           "dev": true,
           "requires": {
-            "JSONStream": "1.3.4",
-            "browser-resolve": "1.11.3",
-            "cached-path-relative": "1.0.1",
-            "concat-stream": "1.6.2",
-            "defined": "1.0.0",
-            "detective": "5.1.0",
-            "duplexer2": "0.1.4",
-            "inherits": "2.0.3",
-            "parents": "1.0.1",
-            "readable-stream": "2.3.6",
-            "resolve": "1.8.1",
-            "stream-combiner2": "1.1.1",
-            "subarg": "1.0.0",
-            "through2": "2.0.3",
-            "xtend": "4.0.1"
+            "JSONStream": "^1.0.3",
+            "browser-resolve": "^1.7.0",
+            "cached-path-relative": "^1.0.0",
+            "concat-stream": "~1.6.0",
+            "defined": "^1.0.0",
+            "detective": "^5.0.2",
+            "duplexer2": "^0.1.2",
+            "inherits": "^2.0.1",
+            "parents": "^1.0.0",
+            "readable-stream": "^2.0.2",
+            "resolve": "^1.4.0",
+            "stream-combiner2": "^1.1.1",
+            "subarg": "^1.0.0",
+            "through2": "^2.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "os-browserify": {
@@ -12864,7 +12865,7 @@
           "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6"
+            "readable-stream": "^2.0.2"
           }
         },
         "shell-quote": {
@@ -12873,10 +12874,10 @@
           "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
           "dev": true,
           "requires": {
-            "array-filter": "0.0.1",
-            "array-map": "0.0.0",
-            "array-reduce": "0.0.0",
-            "jsonify": "0.0.0"
+            "array-filter": "~0.0.0",
+            "array-map": "~0.0.0",
+            "array-reduce": "~0.0.0",
+            "jsonify": "~0.0.0"
           }
         },
         "stream-browserify": {
@@ -12885,8 +12886,8 @@
           "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "~2.0.1",
+            "readable-stream": "^2.0.2"
           }
         },
         "stream-combiner2": {
@@ -12895,8 +12896,8 @@
           "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
           "dev": true,
           "requires": {
-            "duplexer2": "0.1.4",
-            "readable-stream": "2.3.6"
+            "duplexer2": "~0.1.0",
+            "readable-stream": "^2.0.2"
           }
         },
         "stream-splicer": {
@@ -12905,8 +12906,8 @@
           "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
           }
         },
         "through2": {
@@ -12915,8 +12916,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         },
         "url": {
@@ -12963,8 +12964,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.13",
-        "websocket-extensions": "0.1.3"
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
@@ -12988,8 +12989,8 @@
       "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
       "dev": true,
       "requires": {
-        "tr46": "0.0.3",
-        "webidl-conversions": "3.0.1"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       },
       "dependencies": {
         "webidl-conversions": {
@@ -13006,7 +13007,7 @@
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -13028,7 +13029,7 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "window-size": {
@@ -13044,12 +13045,12 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "stack-trace": "0.0.10"
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
       },
       "dependencies": {
         "async": {
@@ -13076,12 +13077,12 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -13096,9 +13097,9 @@
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.2",
-        "ultron": "1.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     },
     "xml-name-validator": {
@@ -13137,20 +13138,20 @@
       "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.3",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "window-size": "0.2.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "4.2.1"
+        "camelcase": "^3.0.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.2",
+        "which-module": "^1.0.0",
+        "window-size": "^0.2.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^4.1.0"
       }
     },
     "yargs-parser": {
@@ -13159,7 +13160,7 @@
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0"
+        "camelcase": "^3.0.0"
       }
     },
     "yauzl": {
@@ -13168,7 +13169,7 @@
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {
-        "fd-slicer": "1.0.1"
+        "fd-slicer": "~1.0.1"
       }
     },
     "yeast": {
@@ -13183,10 +13184,10 @@
       "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "dev": true,
       "requires": {
-        "archiver-utils": "1.3.0",
-        "compress-commons": "1.2.2",
-        "lodash": "4.17.15",
-        "readable-stream": "2.3.6"
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "moment": "^2.24.0",
     "normalize.css": "^8.0.1",
     "pikaday": "^1.8.0",
-    "select2": "github:jadu/selectWoo#jadu-1.1.1",
+    "select2": "github:jadu/selectWoo#jadu-1.1.2",
     "spectrum-colorpicker": "^1.8.0",
     "timepicker": "^1.11.15",
     "vide": "^0.5.1"


### PR DESCRIPTION
Pull in latest jaduSelectWoo (1.1.2) which resolves JQ3 deprecated event shorthand.