### PR TITLE
Switch off link border for button links within tables

### DIFF
--- a/stylesheets/_component.tables.scss
+++ b/stylesheets/_component.tables.scss
@@ -18,6 +18,10 @@
         }
     }
 
+    [href].btn {
+        border-bottom: 0;
+    }
+
     tbody > tr:hover {
         background-color: color(background, light);
     }


### PR DESCRIPTION
This change removes the link border from links with button styling to keep both variants consistent.

**Before**
![Screenshot 2020-02-03 at 12 13 27](https://user-images.githubusercontent.com/18653/73652343-a669da00-467e-11ea-85e9-406d100f4daa.png)

**After**
![Screenshot 2020-02-03 at 12 13 15](https://user-images.githubusercontent.com/18653/73652356-ae297e80-467e-11ea-9cbb-58fdd8f63177.png)

Closes #1117 