### PR TITLE
Fix issue where sidebar help close button loses child nodes in responsive mode

### DIFF
--- a/js/HelpTextComponent.js
+++ b/js/HelpTextComponent.js
@@ -71,7 +71,7 @@ HelpTextComponent.prototype.updateHelpSidebar = function () {
         $pageMainTitle = component.$html.find('.main-title'),
         $tabHelp = component.$html.find('.tab-help'),
         isMobile,
-        $mobileCloseHelpButton = $('<button class="close-page-help js-close-page-help"><i class="icon-remove-sign" aria-hidden="true"></i><span class="hide">Close on-page help</span></button>');
+        mobileCloseHelpButton = '<button class="close-page-help js-close-page-help"><i class="icon-remove-sign" aria-hidden="true"></i><span class="hide">Close on-page help</span></button>';
 
     // Check if active tab has help text
     if (activeTabSideBarContentHtml && activeTabSideBarContentHtml.length > 0) {
@@ -105,7 +105,7 @@ HelpTextComponent.prototype.updateHelpSidebar = function () {
             $tabHelp.html(activeTabSideBarContentHtml);
 
             // Add mobile help close button
-            $mobileCloseHelpButton.prependTo($tabHelp);
+            $(mobileCloseHelpButton).prependTo($tabHelp);
         }
 
         // Watch for window resizes
@@ -115,7 +115,7 @@ HelpTextComponent.prototype.updateHelpSidebar = function () {
                 $tabHelp.html(activeTabSideBarContentHtml);
 
                 // Add mobile help close button
-                $mobileCloseHelpButton.prependTo($tabHelp);
+                $(mobileCloseHelpButton).prependTo($tabHelp);
             }
         });
     } else {

--- a/stylesheets/_component.tab-help.scss
+++ b/stylesheets/_component.tab-help.scss
@@ -67,7 +67,6 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
     color: color(gray, dark);
     display: inline-block;
     float: right;
-    font-size: .9em;
     line-height: normal;
     padding: 0;
     text-decoration: none;
@@ -94,11 +93,15 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
 .close-page-help {
     background-color: transparent;
     border: 0;
+    color: color(white);
     font-size: $font-size-xlarge;
     margin-bottom: 10px;
-    padding-right: 0;
     position: absolute;
-    right: 10px;
+    right: 0;
     text-decoration: none;
     top: 10px;
+
+    &:focus {
+        @include pulsar-button-focused;
+    }
 }


### PR DESCRIPTION
This change fixes an odd IE11 issue where the sidebar help close button loses the child nodes when the viewport switches in and out of responsive mode.

Also added missing modern focus styles while I was here.

![Screenshot 2020-02-04 at 09 55 51](https://user-images.githubusercontent.com/18653/73734324-6285dc00-4735-11ea-99a8-29a36e4e91b3.png)

Closes #1120 