### PR TITLE
Remove redundant, invalid text input when colour picker is created

### DIFF
--- a/js/PulsarFormComponent.js
+++ b/js/PulsarFormComponent.js
@@ -166,6 +166,10 @@ PulsarFormComponent.prototype.initColourpickers = function () {
             }
         });
 
+        // Remove the text input inside the picker, which we don't use and 
+        // causes a11y issues if left in the markup
+        component.$html.find('.sp-input-container').remove();
+
         // changing the input should update the picker
         $input.on('change', function () {
             $pickerInput.spectrum('set', '#' + $input.val());


### PR DESCRIPTION
I can’t see a way to control the generated colourpicker theme so while not ideal, this is a quick way to remove the inaccessible element after it has been created.

Addresses #1070