### PR TITLE
fix issue where notifications dropdown wasn't visibly opening

### DIFF
--- a/js/DropdownButtonComponent.js
+++ b/js/DropdownButtonComponent.js
@@ -99,7 +99,7 @@ class DropdownButtonComponent {
     handleBodyClick (event) {
         const $clickedElement = $(event.target);
 
-        if ($clickedElement.attr('data-toggle') === 'dropdown' || $clickedElement.closest(Selectors.BTN_GROUP).hasClass(Selectors.OPEN)) {
+        if ($clickedElement.attr('data-toggle') === 'dropdown' || $clickedElement.closest(Selectors.DATA_TOGGLE).hasClass(Selectors.OPEN)) {
             return;
         }
         this.closeAllDropdowns();

--- a/js/DropdownButtonComponent.js
+++ b/js/DropdownButtonComponent.js
@@ -6,6 +6,7 @@ const Selectors = {
     'DROP_MENU': '.dropdown__menu',
     'VISIBLE_ITEMS': '.dropdown__menu li a:not(.is-disabled):not(.disabled), .dropdown__menu li button:not(.is-disabled):not(.disabled):not(:disabled)',
     'DISABLED': '.disabled, .is-disabled, :disabled',
+    'DROPDOWN': '.dropdown',
     'BTN_GROUP': '.btn__group',
     'BTN_GROUP_OPEN': '.btn__group.open',
     'BTN_GROUP_DROP': '.btn__group.dropdown, .btn__group.dropup',
@@ -99,7 +100,7 @@ class DropdownButtonComponent {
     handleBodyClick (event) {
         const $clickedElement = $(event.target);
 
-        if ($clickedElement.attr('data-toggle') === 'dropdown' || $clickedElement.closest(Selectors.DATA_TOGGLE).hasClass(Selectors.OPEN)) {
+        if ($clickedElement.attr('data-toggle') === 'dropdown' || $clickedElement.closest(Selectors.BTN_GROUP).hasClass(Selectors.OPEN) || $clickedElement.closest(Selectors.DROPDOWN).hasClass(Selectors.OPEN)) {
             return;
         }
         this.closeAllDropdowns();


### PR DESCRIPTION
The notifications event target ends up being the icon, and it doesn’t use a btn__group therefore the previous `closest(Selectors.BTN_GROUP)` never hit it and the notifications list was closed immediately after opening.

This change also checks the closest `.dropdown` class to look for the open class, which seems to make all the toolbar dropdowns work again.