### PR TITLE
Remove invalid valign attribute from DT empty message after load

### DIFF
--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -250,6 +250,10 @@ PulsarUIComponent.prototype.initDataTables = function () {
         // Add sticky scroll bar
         component.stickyScrollBarComponent.init($table);
     });
+
+    // Remove invalid attribute after tables are loaded
+    // https://datatables.net/forums/discussion/comment/145251/#Comment_145251
+    component.$html.find('.dataTables_empty').removeAttr('valign');
 };
 
 PulsarUIComponent.prototype.styleTableOverflows = function ($container) {


### PR DESCRIPTION
This change removes the `valign` attribute from the empty table message on page load.

This issue has been raised on the [DataTables forum](https://datatables.net/forums/discussion/comment/145251/#Comment_145251) albeit a year ago, the only other solution for us would've been to for DataTables which isn't going to happen.