### PR TITLE
If no title is passed to a panel, render as a div and remove the aria attribute

### DIFF
--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/panel-no-title.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/panel-no-title.html
@@ -1,0 +1,3 @@
+<div class="panel">
+    <div class="panel__body">bar</div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/panel-no-title.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/panel-no-title.html.twig
@@ -1,0 +1,8 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    html.panel({
+        'body': 'bar'
+    })
+}}
+{% endblock %}

--- a/views/lexicon/tabs/panels.html.twig
+++ b/views/lexicon/tabs/panels.html.twig
@@ -225,4 +225,10 @@
         </div>
     </section>
 
+    {{
+        html.panel({
+            'body': 'A panel with no title will be rendered as a div, not a section.'
+        })
+    }}
+
 {% endblock tab_content %}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1205,17 +1205,22 @@ data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
+    {% set tag = 'section' %}
     {% set actions_placements = ['inline', 'left', 'center', 'right'] %}
     {% set guid = 'guid-' ~ random() %}
 
-    <section{{
+    {% if options.title is not defined or options.title is empty %}
+        {% set tag = 'div' %}
+    {% endif %}
+
+    <{{ tag }}{{
         attributes(options
             |exclude('actions actions_placement heading_level icon title body')
             |defaults({
                 'class': 'panel'
             })
         )
-    }} aria-labelledby="{{ guid }}">
+    }}{% if tag == 'section' %} aria-labelledby="{{ guid }}"{% endif %}>
         {% if options.icon is defined and options.icon is not empty %}
             {{ html.icon(options.icon|default, { 'class': 'panel__icon' }) }}
         {% endif %}
@@ -1243,7 +1248,7 @@ data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
                 {% endfor %}
             </div>
         {% endif %}
-    </section>
+    </{{ tag }}>
 
 {% endspaceless %}
 {% endmacro %}


### PR DESCRIPTION
This removes accessibility warnings when panels without titles are desired.