### PR TITLE
Apply consistent select styling to datatable length dropdown

### DIFF
--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -356,17 +356,39 @@ th.sorting_disabled:hover {
     display: block;
     float: none;
     font-family: $font-size-small;
-    line-height: 42px;
-    margin-bottom: 10px;
+    margin: 10px 0;
     text-align: center;
     width: 100%;
 
     @include respond-min($screen-tablet) {
         display: inline-block;
         float: right;
-        margin-bottom: 0;
+        margin: 5px 0 10px;
         text-align: left;
         width: auto;
+    }
+
+    select {
+        appearance: none;
+        background-image: linear-gradient(45deg, transparent 49%, color(text) 49%), linear-gradient(135deg, color(text) 49%, transparent 49%), linear-gradient(to right, color(gray, off-white), color(gray, off-white));
+        background-position: calc(100% - 10px) calc(1em - 2px), calc(100% - 5px) calc(1em - 2px), 100% 0;
+        background-size: 5px 5px, 5px 5px, 22px 100%;
+        background-repeat: no-repeat;
+        border: 1px solid $input-border;
+        border-radius: $input-border-radius;
+        height: 32px;
+        line-height: 32px;
+        padding: 0 30px 0 $padding-base-horizontal;
+
+        // remove the arrow in IE10 & 11, modern browsers are taken care of
+        // by the `appearance` property
+        &::-ms-expand {
+            display: none;
+
+            @media screen and (-ms-high-contrast: active) {
+                display: block;
+            }
+        }
     }
 
     select:focus {

--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -356,14 +356,14 @@ th.sorting_disabled:hover {
     display: block;
     float: none;
     font-family: $font-size-small;
-    margin: 10px 0;
+    margin: $margin-large-vertical 0;
     text-align: center;
     width: 100%;
 
     @include respond-min($screen-tablet) {
         display: inline-block;
         float: right;
-        margin: 5px 0 10px;
+        margin: $margin-small-vertical 0 $margin-small-horizontal;
         text-align: left;
         width: auto;
     }


### PR DESCRIPTION
Add updated Pulsar select styles to the DataTables length dropdown.

**Regular**
![Screenshot 2020-02-07 at 16 49 11](https://user-images.githubusercontent.com/18653/74049665-84e55700-49cc-11ea-9361-ccb84b3eadb2.png)

**Responsive**
![Screenshot 2020-02-07 at 16 49 27](https://user-images.githubusercontent.com/18653/74049634-6ed79680-49cc-11ea-820d-933959a08c41.png)

## Browser testing checklist

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge
- [x] IE 11
- [x] Mobile Safari
- [x] Samsung Internet