### PR TITLE
Update helper tooltips

### DIFF
--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-required.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-required.html
@@ -1,5 +1,5 @@
 <fieldset class="form__group form-choice">
-    <legend class="control__label">foo&nbsp;<span class="required-indicator" data-toggle="tooltips" title="required">*</span></legend>
+    <legend class="control__label">foo&nbsp;<span class="required-indicator" data-tippy-content="required">*</span></legend>
     <div class="controls">
         <label for="form_field_0" class="control__label">
             <input

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/edit_button-input.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/edit_button-input.html
@@ -1,9 +1,8 @@
 <input
     aria-label="edit"
     data-action="edit"
-    data-placement="right"
-    data-title="Edit this item"
-    data-toggle="tooltips"
+    data-tippy-content="Edit this item"
+    data-tippy-placement="right"
     type="button"
     value="&lt;i aria-hidden=&quot;true&quot; class=&quot;icon-pencil&quot;&gt;&lt;/i&gt;"
     class="btn edit-button"

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/edit_button-link.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/edit_button-link.html
@@ -1,1 +1,1 @@
-<a aria-label="edit" data-action="edit" data-placement="right" data-title="Edit this item" data-toggle="tooltips" class="btn edit-button"><i aria-hidden="true" class="icon-pencil"></i></a>
+<a aria-label="edit" data-action="edit" data-tippy-content="Edit this item" data-tippy-placement="right" class="btn edit-button"><i aria-hidden="true" class="icon-pencil"></i></a>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/edit_button-placements.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/edit_button-placements.html
@@ -1,7 +1,7 @@
-<button aria-label="edit" data-action="edit" data-placement="top" data-title="Edit this item" data-toggle="tooltips" type="button" class="btn edit-button"><i aria-hidden="true" class="icon-pencil"></i></button>
+<button aria-label="edit" data-action="edit" data-tippy-content="Edit this item" data-tippy-placement="top" type="button" class="btn edit-button"><i aria-hidden="true" class="icon-pencil"></i></button>
 
-<button aria-label="edit" data-action="edit" data-placement="right" data-title="Edit this item" data-toggle="tooltips" type="button" class="btn edit-button"><i aria-hidden="true" class="icon-pencil"></i></button>
+<button aria-label="edit" data-action="edit" data-tippy-content="Edit this item" data-tippy-placement="right" type="button" class="btn edit-button"><i aria-hidden="true" class="icon-pencil"></i></button>
 
-<button aria-label="edit" data-action="edit" data-placement="bottom" data-title="Edit this item" data-toggle="tooltips" type="button" class="btn edit-button"><i aria-hidden="true" class="icon-pencil"></i></button>
+<button aria-label="edit" data-action="edit" data-tippy-content="Edit this item" data-tippy-placement="bottom" type="button" class="btn edit-button"><i aria-hidden="true" class="icon-pencil"></i></button>
 
-<button aria-label="edit" data-action="edit" data-placement="left" data-title="Edit this item" data-toggle="tooltips" type="button" class="btn edit-button"><i aria-hidden="true" class="icon-pencil"></i></button>
+<button aria-label="edit" data-action="edit" data-tippy-content="Edit this item" data-tippy-placement="left" type="button" class="btn edit-button"><i aria-hidden="true" class="icon-pencil"></i></button>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/edit_button-submit.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/edit_button-submit.html
@@ -2,9 +2,8 @@
     type="submit"
     aria-label="edit"
     data-action="edit"
-    data-placement="right"
-    data-title="Edit this item"
-    data-toggle="tooltips"
+    data-tippy-content="Edit this item"
+    data-tippy-placement="right"
     class="btn edit-button">
     <i aria-hidden="true" class="icon-pencil"></i>
 </button>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/edit_button-target.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/edit_button-target.html
@@ -1,3 +1,3 @@
-<button aria-label="edit" data-action="edit" data-action-target="foo" data-placement="right" data-title="Edit this item" data-toggle="tooltips" type="button" class="btn edit-button">
+<button aria-label="edit" data-action="edit" data-action-target="foo" data-tippy-content="Edit this item" data-tippy-placement="right" type="button" class="btn edit-button">
     <i aria-hidden="true" class="icon-pencil"></i>
 </button>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/edit_button.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/edit_button.html
@@ -1,3 +1,3 @@
-<button aria-label="edit" data-action="edit" data-placement="right" data-title="Edit this item" data-toggle="tooltips" type="button" class="btn edit-button">
+<button aria-label="edit" data-action="edit" data-tippy-content="Edit this item" data-tippy-placement="right"  type="button" class="btn edit-button">
     <i aria-hidden="true" class="icon-pencil"></i>
 </button>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/media-actions.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/media-actions.html
@@ -2,7 +2,7 @@
     <img src="foo.png" alt="foo alt" class="media__image" />
     <div class="media__body">
         <span class="pull-right">
-            <button data-placement="right" data-toggle="tooltips" data-title="Remove this item" type="button" data-action="remove" data-action-target="#example" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove</span></i></button>
+            <button data-tippy-content="Remove this item" data-tippy-placement="right" type="button" data-action="remove" data-action-target="#example" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove</span></i></button>
         </span>
         <p>Bar</p>
         <span class="small-type muted">Baz</span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-link.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-link.html
@@ -1,7 +1,6 @@
 <a
-    data-placement="right"
-    data-toggle="tooltips"
-    data-title="Remove this item"
+    data-tippy-content="Remove this item"
+    data-tippy-placement="right"
     data-action="remove"
     class="btn remove-button">
 <i class="icon-remove-sign"><span class="hide">Remove</span></i></a>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-placements.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-placements.html
@@ -1,34 +1,30 @@
 <button
-    data-placement="top"
-    data-toggle="tooltips"
-    data-title="Remove this item"
+    data-tippy-content="Remove this item"
+    data-tippy-placement="top"
     type="button"
     data-action="remove"
     class="btn remove-button">
 <i class="icon-remove-sign"><span class="hide">Remove</span></i></button>
 
 <button
-    data-placement="right"
-    data-toggle="tooltips"
-    data-title="Remove this item"
+    data-tippy-content="Remove this item"
+    data-tippy-placement="right"
     type="button"
     data-action="remove"
     class="btn remove-button">
 <i class="icon-remove-sign"><span class="hide">Remove</span></i></button>
 
 <button
-    data-placement="bottom"
-    data-toggle="tooltips"
-    data-title="Remove this item"
+    data-tippy-content="Remove this item"
+    data-tippy-placement="bottom"
     type="button"
     data-action="remove"
     class="btn remove-button">
 <i class="icon-remove-sign"><span class="hide">Remove</span></i></button>
 
 <button
-    data-placement="left"
-    data-toggle="tooltips"
-    data-title="Remove this item"
+    data-tippy-content="Remove this item"
+    data-tippy-placement="left"
     type="button"
     data-action="remove"
     class="btn remove-button">

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-submit.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-submit.html
@@ -1,8 +1,7 @@
 <button
     type="submit"
-    data-placement="right"
-    data-toggle="tooltips"
-    data-title="Remove this item"
+    data-tippy-content="Remove this item"
+    data-tippy-placement="right"
     data-action="remove"
     class="btn remove-button">
 <i class="icon-remove-sign"><span class="hide">Remove</span></i></button>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-target.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button-target.html
@@ -1,7 +1,6 @@
 <button
-    data-placement="right"
-    data-toggle="tooltips"
-    data-title="Remove this item"
+    data-tippy-content="Remove this item"
+    data-tippy-placement="right"
     type="button"
     data-action="remove"
     data-action-target="foo"

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/remove_button.html
@@ -1,7 +1,6 @@
 <button
-    data-placement="right"
-    data-toggle="tooltips"
-    data-title="Remove this item"
+    data-tippy-content="Remove this item"
+    data-tippy-placement="right"
     type="button"
     data-action="remove"
     class="btn remove-button">

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -630,9 +630,8 @@ data-*    | string | Data attributes, eg: `'data-foo': 'bar'`
                     'class': options.class|default ~ ' edit-button',
                     'data-action': 'edit',
                     'data-action-target': options.target|default,
-                    'data-placement': options.placement|default('right'),
-                    'data-title': options.tooltip|default('Edit this item'),
-                    'data-toggle': 'tooltips',
+                    'data-tippy-content': options.tooltip|default('Edit this item'),
+                    'data-tippy-placement': options.placement|default('right'),
                     'label': html.icon('pencil'),
                     'type': options.type|default('button'),
                 })
@@ -1374,9 +1373,8 @@ data-*    | string | Data attributes, eg: `'data-foo': 'bar'`
     {% if options.tooltip is not defined or options.tooltip != false %}
     {%
         set options = options|default({})|merge({
-            'data-placement': options.placement|default('right'),
-            'data-toggle': 'tooltips',
-            'data-title': options.tooltip|default('Remove this item')
+            'data-tippy-content': options.tooltip|default('Remove this item'),
+            'data-tippy-placement': options.placement|default('right')
         })
     %}
     {% endif %}
@@ -1445,7 +1443,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 {% spaceless %}
 
 {% if options.title is not defined %}
-    {% set options = options|default({})|merge({ 'title': state|default('active') }) %}
+    {% set options = options|default({})|merge({ 'data-tippy-content': state|default('active') }) %}
 {% endif %}
 
 {% if options.icon is defined %}
@@ -1461,8 +1459,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
             |exclude('state icon')
             |merge({
                 'class': 'status--icon is-' ~ state|default('active'),
-                'data-placement': options['data-placement']|default('top'),
-                'data-toggle': 'tooltips',
+                'data-tippy-placement': options['data-placement']|default('top')
             })
         )
     }}
@@ -1473,11 +1470,10 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
         attributes(options
             |exclude('state icon')
             |merge({
-                'data-placement': options['data-placement']|default('top')
+                'data-tippy-placement': options['data-placement']|default('top')
             })
             |defaults({
-                'class': 'status is-' ~ state|default('active'),
-                'data-toggle': 'tooltips'
+                'class': 'status is-' ~ state|default('active')
             })
         )
     }}></span>
@@ -1580,7 +1576,7 @@ Datatable - https://jadu.github.io/pulsar/components/datatable/
                 {% for column in options.data.columns %}
                     {% if loop.first %}
                         <th class="table-selection" data-orderable="false">
-                            <input type="checkbox" class="form__control checkbox js-select-all" aria-label="Select all rows" data-toggle="tooltips" title="select all rows" data-placement="right" data-container="body" />
+                            <input type="checkbox" class="form__control checkbox js-select-all" aria-label="Select all rows" data-tippy-content="select all rows" data-tippy-placement="right" />
                         </th>
                     {% endif %}
                     <th{{ attributes(column.attrs|default) }}>{{ column.title }}</th>

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1443,7 +1443,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 {% spaceless %}
 
 {% if options.title is not defined %}
-    {% set options = options|default({})|merge({ 'data-tippy-content': state|default('active') }) %}
+    {% set options = options|default({})|merge({ 'title': state|default('active') }) %}
 {% endif %}
 
 {% if options.icon is defined %}
@@ -1459,7 +1459,8 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
             |exclude('state icon')
             |merge({
                 'class': 'status--icon is-' ~ state|default('active'),
-                'data-tippy-placement': options['data-placement']|default('top')
+                'data-placement': options['data-placement']|default('top'),
+                'data-toggle': 'tooltips',
             })
         )
     }}
@@ -1470,10 +1471,11 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
         attributes(options
             |exclude('state icon')
             |merge({
-                'data-tippy-placement': options['data-placement']|default('top')
+                'data-placement': options['data-placement']|default('top')
             })
             |defaults({
-                'class': 'status is-' ~ state|default('active')
+                'class': 'status is-' ~ state|default('active'),
+                'data-toggle': 'tooltips'
             })
         )
     }}></span>

--- a/views/pulsar/v2/helpers/pulsar.html.twig
+++ b/views/pulsar/v2/helpers/pulsar.html.twig
@@ -93,10 +93,9 @@
               html.link({
                 'label': html.icon('check-sign'),
                 'class': 'notifications__dismiss',
-                'title': 'Mark all as read',
                 'data': {
-                    'toggle': 'tooltips',
-                    'placement': 'left'
+                    'tippy-content': 'Mark all as read',
+                    'tippy-placement': 'left',
                 }
               })
             }}

--- a/views/pulsar/v2/helpers/rules.html.twig
+++ b/views/pulsar/v2/helpers/rules.html.twig
@@ -101,7 +101,7 @@
                 <div class="rule-block rule-block--{{ options.type|default }}" data-index="__index__">
                     <div class="rule-block__header rule-block__header--{{ options.type|default }}">
                         <h5 class="rule-block__heading">{{ options.type|default }}</h5>
-                        <i data-toggle="tooltips" data-placement="right" data-title="What should cause this rule to run" title="What should cause this rule to run" aria-hidden="true"  class="icon-question-sign rule-block__heading__icon"></i>
+                        <i data-tippy-placement="right" data-tippy-content="What should cause this rule to run" class="icon-question-sign rule-block__heading__icon"></i>
                     </div>
 
                     <div class="rule-block__controls rule__trigger__form">
@@ -115,7 +115,7 @@
                         {% endif %}
 
                         {% if (options.removeable is defined and options.removeable != false) or options.removeable is not defined %}
-                            <a data-action="remove" data-placement="left" data-toggle="tooltips" data-title="Remove this item"  class="remove__control js-remove-trigger"><i  class="icon-remove-sign"><span class="hide">Remove this item</span></i></a>
+                            <a data-action="remove" data-tippy-placement="left" data-tippy-content="Remove this item" class="remove__control js-remove-trigger"><i  class="icon-remove-sign"><span class="hide">Remove this item</span></i></a>
                         {% endif %}
 
                     </div>

--- a/views/pulsar/v2/helpers/util.html.twig
+++ b/views/pulsar/v2/helpers/util.html.twig
@@ -155,7 +155,7 @@
 {% macro required(required) %}
 {% spaceless %}
     {% if required %}
-        &nbsp;<span class="required-indicator" data-toggle="tooltips" title="required">*</span>
+        &nbsp;<span class="required-indicator" data-tippy-content="required">*</span>
     {% endif  %}
 {% endspaceless %}
 {% endmacro %}


### PR DESCRIPTION
This change updates the following helpers to use the new accessible tooltips:

* `html.edit_button`
* `html.remove_button`
* `util.required`
* rules (remove button and info icon)

Note: this is a straight swap, additional accessibility issues have been spotted and will be resolved in a separate MR.