### PR TITLE
Fix SR issues with required indicator and status helper

### DIFF
--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-required.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-required.html
@@ -1,5 +1,5 @@
 <fieldset class="form__group form-choice">
-    <legend class="control__label">foo&nbsp;<span class="required-indicator" data-toggle="tooltips" title="required">*</span></legend>
+    <legend class="control__label">foo&nbsp;<span aria-hidden="true" class="required-indicator" data-tippy-content="required">*</span></legend>
     <div class="controls">
         <label for="form_field_0" class="control__label">
             <input

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-placement.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-placement.html
@@ -1,1 +1,1 @@
-<span data-placement="right" title="online" data-toggle="tooltips" class="status is-online"></span>
+<span data-tippy-placement="right" data-tippy-content="online" class="status is-online"><span class="hide">online</span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-title.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-title.html
@@ -1,1 +1,1 @@
-<span title="foo" data-placement="top" data-toggle="tooltips" class="status is-online"></span>
+<span data-tippy-placement="top" data-tippy-content="foo" class="status is-online"><span class="hide">foo</span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-options.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-options.html
@@ -1,1 +1,1 @@
-<span data-foo="bar" id="baz" title="online" data-placement="top" data-toggle="tooltips" class="status is-online foo"></span>
+<span data-foo="bar" id="baz" data-tippy-placement="top" data-tippy-content="online" class="status is-online foo"><span class="hide">online</span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-state.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-state.html
@@ -1,1 +1,1 @@
-<span title="online" data-placement="top" data-toggle="tooltips" class="status is-online"></span>
+<span data-tippy-placement="top" data-tippy-content="online" class="status is-online"><span class="hide">online</span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status.html
@@ -1,1 +1,1 @@
-<span title="active" data-placement="top" data-toggle="tooltips" class="status is-active"></span>
+<span data-tippy-placement="top" data-tippy-content="active" class="status is-active"><span class="hide">active</span>

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1458,11 +1458,12 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {{
         html.icon(iconGlyph|default('times-rectangle'), options
-            |exclude('state icon')
+            |exclude('state icon title data-placement')
             |merge({
                 'class': 'status--icon is-' ~ state|default('active'),
-                'data-placement': options['data-placement']|default('top'),
-                'data-toggle': 'tooltips',
+                'data-tippy-placement': options['data-placement']|default('top'),
+                'data-tippy-content': options['title'],
+                'label': options['title']
             })
         )
     }}
@@ -1471,16 +1472,18 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
     <span{{
         attributes(options
-            |exclude('state icon')
+            |exclude('state icon title data-placement')
             |merge({
-                'data-placement': options['data-placement']|default('top')
+                'data-tippy-placement': options['data-placement']|default('top')
             })
             |defaults({
                 'class': 'status is-' ~ state|default('active'),
-                'data-toggle': 'tooltips'
+                'data-tippy-content': options['title']
             })
         )
-    }}></span>
+    }}>
+        <span class="hide">{{ options['title'] }}
+    </span>
 
 {% endif %}
 

--- a/views/pulsar/v2/helpers/util.html.twig
+++ b/views/pulsar/v2/helpers/util.html.twig
@@ -155,7 +155,7 @@
 {% macro required(required) %}
 {% spaceless %}
     {% if required %}
-        &nbsp;<span class="required-indicator" data-toggle="tooltips" title="required">*</span>
+        &nbsp;<span aria-hidden="true" class="required-indicator" data-tippy-content="required">*</span>
     {% endif  %}
 {% endspaceless %}
 {% endmacro %}


### PR DESCRIPTION
### Required indicator

This fix resolves an issue where screen readers would announce the require indicator in input labels resulting in "star" being announced. For example: "First name star, required, edit text".

### Status helper

This fix resolves an issue where `html.status()` did not contain any screen reader readable text. `html.status()` now adds a SR friendly hidden span containing either the state text or any passed `title` option. This change also changes the helper over to the new accessible tooltips. Note that although tooltips on non-focusable element is normally avoided, in this case as the status mark up contains the same text in a SR friendly hidden span so the experience is the same for both sighted users and users of AT.

### Testing info
Changes have been tested in:

- Mac OS Voiceover
- JAWS 2018
- JAWS 18
- NVDA