### PR TITLE
Datatables column toggle improvements

### DIFF
--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -118,7 +118,8 @@ PulsarUIComponent.getDatatableOptions = function ($table) {
         pagingType: 'full_numbers',
         responsive: {
             details: {
-                type: 'column'
+                type: 'column',
+                target: '.table-child-toggle'
             }
         },
         select: select,

--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -263,18 +263,41 @@ th.sorting_disabled:hover {
 }
 
 .table-child-toggle {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    box-sizing: border-box;
     color: color(jadu-blue);
+    cursor: pointer;
     display: none;
-    font-size: 14px;
+    font-size: $font-size-base;
+    font-weight: normal;
+    line-height: normal;
+    margin: 0;
+    padding: 4px 7px 0;
+    position: relative;
+    text-align: center;
+    text-decoration: none;
+    user-select: none;
+    vertical-align: top;
+    white-space: nowrap;
+
+    &:focus {
+        @include pulsar-button-focused;
+    }
+
+    &:hover {
+        color: color(black);
+    }
 
     .collapsed & {
         display: inline-block;
     }
+}
 
-    .parent &::before {
-        color: color(jadu-red);
-        content: $minus-sign;
-    }
+.parent .table-child-toggle i::before {
+    color: color(jadu-red);
+    content: $minus-sign;
 }
 
 .datatable .child ul {

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1575,11 +1575,12 @@ Datatable - https://jadu.github.io/pulsar/components/datatable/
         <thead>
             <tr>
                 {% if overflow == 'collapse' %}
-                    <td></td>
+                    <td><span class="hide">Table controls</span></td>
                 {% endif %}
                 {% for column in options.data.columns %}
                     {% if loop.first %}
                         <th class="table-selection" data-orderable="false">
+                            <span class="hide">Row selection controls</span>
                             <input type="checkbox" class="form__control checkbox js-select-all" aria-label="Select all rows" data-toggle="tooltips" title="select all rows" data-placement="right" data-container="body" />
                         </th>
                     {% endif %}
@@ -1592,7 +1593,9 @@ Datatable - https://jadu.github.io/pulsar/components/datatable/
                 <tr>
                     {% if overflow == 'collapse' %}
                         <td class="table-responsive">
-                            {{ html.icon('plus-sign', { 'class': 'table-child-toggle' }) }}
+                            <button class="table-child-toggle">
+                                {{ html.icon('plus-sign', { 'label': 'Toggle collapsed columns' }) }}
+                            </button>
                         </td>
                     {% endif %}
                     <td class="table-selection">


### PR DESCRIPTION
### Details of change

Previously, when a collapsing datatable was in responsive mode and columns were hidden, the toggle control was an icon without SR friendly text. The parent `td` also had `tabindex="0"` to allow focus. This resulted in "blank" being read when the toggle control parent gained focus.

This change removed the `tabindex="0"` from the parent `td` and changes the icon to a button with hidden SR friendly text. This allows the toggle column control to be natively focussed and provides SR friendly hidden text which is announced as expected when SR users navigates the table or focusses the button.

### Testing info

Browser tested in:
- Chrome
- Firefox
- Safari
- Edge
- IE11

Screen reader tested in:
- MacOS VO
- JAWS 2018
- JAWS 18
- NVDA

Closes #1155 