### PR TITLE
Fix flash message positioning and spacing improvements

### DIFF
--- a/stylesheets/_component.flash.scss
+++ b/stylesheets/_component.flash.scss
@@ -111,8 +111,19 @@
 }
 
 .flash-container {
-    left: $nav-primary-width;
-    position: fixed;
-    right: 0;
+    clear: both;
+    margin: 0 -20px;
     z-index: $zindex-flash;
+
+    @include respond-min($screen-desktop) {
+        margin: 13px -20px 0;
+    }
+
+    > .flash:last-child {
+        margin-bottom: 15px;
+    }
+
+    &:empty {
+        display: none;
+    }
 }

--- a/stylesheets/_component.ribbon.scss
+++ b/stylesheets/_component.ribbon.scss
@@ -1,8 +1,8 @@
 .ribbon-wrapper {
-    margin: 22px -20px;
+    margin: 0 -20px 22px;
 
     @include respond-min($screen-desktop) {
-        margin: 0 -20px 22px;
+        margin: 10px -20px 22px;
     }
 
     .has-timeline & {
@@ -321,12 +321,6 @@
     color: #2455c3;
     font-size: .9em;
     text-decoration: none;
-}
-
-.flash-container.has-flash:not(:empty) ~ .content-main .ribbon-wrapper {
-    @include respond-min($screen-desktop) {
-        margin-top: -20px;
-    }
 }
 
 .ribbon {

--- a/stylesheets/_component.toolbar.scss
+++ b/stylesheets/_component.toolbar.scss
@@ -3,14 +3,12 @@
 .toolbar {
     display: block;
     float: left;
-    margin-bottom: 18px;
     padding: 12px 20px 0;
     width: 100%;
 
     @include respond-min($screen-desktop) {
         background-color: color(white);
-        margin-bottom: 0;
-        padding: 14px 20px 0;
+        padding: 18px 20px 0;
     }
 
     .dropdown {

--- a/stylesheets/_layout.tabs.scss
+++ b/stylesheets/_layout.tabs.scss
@@ -10,6 +10,10 @@
     font-size: 1.75em;
     line-height: 24px;
     margin-bottom: 13px;
+
+    @include respond-min($screen-desktop) {
+        margin-top: 17px;
+    }
 }
 
 .sub-title {

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-placement.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-placement.html
@@ -1,1 +1,1 @@
-<span data-tippy-placement="right" data-tippy-content="online" class="status is-online"><span class="hide">online</span>
+<span data-tippy-placement="right" data-tippy-content="online" class="status is-online"><span class="hide">online</span></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-title.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-title.html
@@ -1,1 +1,1 @@
-<span data-tippy-placement="top" data-tippy-content="foo" class="status is-online"><span class="hide">foo</span>
+<span data-tippy-placement="top" data-tippy-content="foo" class="status is-online"><span class="hide">foo</span></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-options.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-options.html
@@ -1,1 +1,1 @@
-<span data-foo="bar" id="baz" data-tippy-placement="top" data-tippy-content="online" class="status is-online foo"><span class="hide">online</span>
+<span data-foo="bar" id="baz" data-tippy-placement="top" data-tippy-content="online" class="status is-online foo"><span class="hide">online</span></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-state.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status-with-state.html
@@ -1,1 +1,1 @@
-<span data-tippy-placement="top" data-tippy-content="online" class="status is-online"><span class="hide">online</span>
+<span data-tippy-placement="top" data-tippy-content="online" class="status is-online"><span class="hide">online</span></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/status.html
@@ -1,1 +1,1 @@
-<span data-tippy-placement="top" data-tippy-content="active" class="status is-active"><span class="hide">active</span>
+<span data-tippy-placement="top" data-tippy-content="active" class="status is-active"><span class="hide">active</span></span>

--- a/views/pulsar/components/flash.html.twig
+++ b/views/pulsar/components/flash.html.twig
@@ -1,3 +1,4 @@
+{% spaceless %}
 <div class="flash-container js-flash-container">
 {% if flash_message is defined %}
 {% import '@pulsar/pulsar/v2/helpers/flash.html.twig' as flash %}
@@ -10,3 +11,4 @@
 }}
 {% endif %}
 </div>
+{% endspaceless %}

--- a/views/pulsar/layouts/base.html.twig
+++ b/views/pulsar/layouts/base.html.twig
@@ -53,8 +53,6 @@
     {% block pageStyle %}{% endblock %}
 </head>
 <body class="language-html">
-    {% include '@pulsar/pulsar/components/flash.html.twig' %}
-
     <a class="skip-link" href="#skip-target" tabindex="1">Skip to main content</a>
 
 {% block body %}
@@ -104,6 +102,8 @@
                 </form>
                 {% endblock %}
 
+                {% include '@pulsar/pulsar/components/flash.html.twig' %}
+
                 {{ nav.breadcrumbs(breadcrumbs|default) }}
 
                 {% set _ribbon = '' %}
@@ -120,9 +120,9 @@
                     {% if _ribbon is not empty %}
                         {% block ribbon_content %}
                             <div class="ribbon-wrapper">
-                                <aside class="ribbon" aria-label="content summary">
+                                <section class="ribbon" aria-label="content summary">
                                     {{ _ribbon|raw }}
-                                </aside>
+                                </section>
                             </div>
                         {% endblock %}
                     {% endif %}
@@ -131,7 +131,7 @@
                 </div>
             </div>
 
-            <div class="tab-help-container t-tab-help-container"><div class="tab-help"></div></div>
+            <aside aria-label="additional information" class="tab-help-container t-tab-help-container"><div class="tab-help"></div></aside>
         </div>
     </div>
 

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1480,7 +1480,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
             })
         )
     }}>
-        <span class="hide">{{ options['title'] }}
+        <span class="hide">{{ options['title'] }}</span>
     </span>
 
 {% endif %}


### PR DESCRIPTION
### Flash message position

Prior to the fixes in this change, flash messages were incorrectly positioned over the toolbar which hid other elements such as the search form and user dropdowns.

Position before fix:
![image](https://user-images.githubusercontent.com/756393/76432253-a01bfb80-63aa-11ea-83b5-1737b7992290.png)

Position after fix:
![image](https://user-images.githubusercontent.com/756393/76432444-e7a28780-63aa-11ea-8464-cbbcba864ebb.png)

### Other changes:

- Tweaked spacing between flash messages, main title and ribbon
- Change the mobile tab help container element from a `div` to `aside` to match the desktop version and prevent AXE warnings re content outside of landmarks
- Fixed broken mark up in `html.status` helper
- Change ribbon element from `aside` to a more appropriate `section`
