### PR TITLE
Improve link hover style

### DIFF
--- a/stylesheets/_component.breadcrumb.scss
+++ b/stylesheets/_component.breadcrumb.scss
@@ -9,6 +9,10 @@
     a {
         color: color(gray, dark); // must be AA 4.5:1
 
+        &:hover {
+            color: color(link, hover);
+        }
+
         &:focus {
             color: color(black);
         }

--- a/stylesheets/_palette.base.scss
+++ b/stylesheets/_palette.base.scss
@@ -173,7 +173,7 @@ $palette-alias: (
     link: (
         base:     #2a7da7, // WCAG 4.58:1 AA compliant
         dark:     darken(#2a7da7, 5),
-        hover:    darken(#2a7da7, 5),
+        hover:    #000,
         focus:    darken(#2a7da7, 15), // WCAG 5.39:1 AA compliant when used on color(background, focus)
         inverse:  #fff,
         inverse-hover: darken(#fff, 10%),


### PR DESCRIPTION
### Before change when hovered

Breadcrumbs:

![Screenshot 2020-03-19 at 13 30 12](https://user-images.githubusercontent.com/756393/77079931-9caef280-69f0-11ea-960e-583d9435eb17.png)

Links:

![Screenshot 2020-03-19 at 13 30 02](https://user-images.githubusercontent.com/756393/77079942-9fa9e300-69f0-11ea-8562-ec15f4a701ca.png)


### After change when hovered

Breadcrumbs:

![Screenshot 2020-03-19 at 13 31 42](https://user-images.githubusercontent.com/756393/77079988-b05a5900-69f0-11ea-8c1d-4517236caf6c.png)

Links:

![Screenshot 2020-03-19 at 13 31 55](https://user-images.githubusercontent.com/756393/77079993-b18b8600-69f0-11ea-9949-1ab0694f4cfa.png)


Fixes #1163 

