### PR TITLE
html.label improvements

### DIFF
--- a/stylesheets/_component.labels.scss
+++ b/stylesheets/_component.labels.scss
@@ -61,3 +61,9 @@
         line-height: inherit;
     }
 }
+
+// Linked labels
+a:focus .label {
+    @include pulsar-link-label-focused;
+}
+

--- a/stylesheets/_mixin.focus.scss
+++ b/stylesheets/_mixin.focus.scss
@@ -112,3 +112,8 @@
     outline: none;
     text-decoration: none;
 }
+
+@mixin pulsar-link-label-focused {
+    background-color: color(background, focus);
+    color: color(black);
+}

--- a/stylesheets/_mixin.focus.scss
+++ b/stylesheets/_mixin.focus.scss
@@ -114,6 +114,7 @@
 }
 
 @mixin pulsar-link-label-focused {
-    background-color: color(background, focus);
-    color: color(black);
+    background-color: color(background, focus) !important;
+    border-radius: 0;
+    color: color(black) !important;
 }

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/label-removable-states.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/label-removable-states.html
@@ -1,8 +1,8 @@
-<span class="label">default<a data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove</span></i></a></span>
-<span class="label label--primary">primary<a data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove</span></i></a></span>
-<span class="label label--success">success<a data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove</span></i></a></span>
-<span class="label label--warning">warning<a data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove</span></i></a></span>
-<span class="label label--danger">danger<a data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove</span></i></a></span>
-<span class="label label--info">info<a data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove</span></i></a></span>
-<span class="label label--inverse">inverse<a data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove</span></i></a></span>
-<span class="label label--large">label large<a data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove</span></i></a></span>
+<span class="label">default<button type="button" data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove default</span></i></button></span>
+<span class="label label--primary">primary<button type="button" data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove primary</span></i></button></span>
+<span class="label label--success">success<button type="button" data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove success</span></i></button></span>
+<span class="label label--warning">warning<button type="button" data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove warning</span></i></button></span>
+<span class="label label--danger">danger<button type="button" data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove danger</span></i></button></span>
+<span class="label label--info">info<button type="button" data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove info</span></i></button></span>
+<span class="label label--inverse">inverse<button type="button" data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove inverse</span></i></button></span>
+<span class="label label--large">label large<button type="button" data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove label large</span></i></button></span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/label-removable.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/label-removable.html
@@ -1,1 +1,1 @@
-<span class="label">foo<a data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove</span></i></a></span>
+<span class="label">foo<button type="button" data-action="remove" data-action-target="this" class="btn remove-button"><i class="icon-remove-sign"><span class="hide">Remove foo</span></i></button></span>

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -770,7 +770,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
             html.remove_button({
                 'tooltip': false,
                 'target': 'this',
-                'type': 'link'
+                'label': 'Remove ' ~ options.label|default|raw
             })
         }}
         {% endif %}
@@ -1363,6 +1363,7 @@ placement | string | Can be `top`, `left`, `bottom`, `right`
 target    | string | CSS Selector of the item to be removed, will be turned into the `data-action-target` attribute
 type      | string | Can be `button` (default), `link`, `input`, `submit`
 data-*    | string | Data attributes, eg: `'data-foo': 'bar'`
+label     | string | SR friendly hidden label
 
 #}
 {% macro remove_button(options) %}
@@ -1387,7 +1388,7 @@ data-*    | string | Data attributes, eg: `'data-foo': 'bar'`
                 'type': options.type|default('button'),
                 'data-action': 'remove',
                 'data-action-target': options.target|default,
-                'label': html.icon('remove-sign', { 'label': 'Remove' })
+                'label': html.icon('remove-sign', { 'label': options.label|default('Remove')})
             })
         )
     }}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -770,7 +770,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
             html.remove_button({
                 'tooltip': false,
                 'target': 'this',
-                'label': 'Remove ' ~ options.label|default|raw
+                'label': 'Remove ' ~ options.label|default
             })
         }}
         {% endif %}
@@ -1388,7 +1388,7 @@ label     | string | SR friendly hidden label
                 'type': options.type|default('button'),
                 'data-action': 'remove',
                 'data-action-target': options.target|default,
-                'label': html.icon('remove-sign', { 'label': options.label|default('Remove')})
+                'label': html.icon('remove-sign', { 'label': options.label|default('Remove') })
             })
         )
     }}


### PR DESCRIPTION
### Changes

1. Labels within links now have appropriate focus styles:
![image](https://user-images.githubusercontent.com/756393/77165774-e1975f80-6aaa-11ea-89d7-5270b231e197.png)
2. Removable labels now use a `button` instead of a `a`.
3. Label remove button now reads "Remove {label text}" rather than just "Remove".

Fixes #1164 