### PR TITLE
Fix landmark and SR issues with mobile help side bar

### DIFF
--- a/js/HelpTextComponent.js
+++ b/js/HelpTextComponent.js
@@ -15,7 +15,9 @@ HelpTextComponent.prototype.init = function () {
         $activeTabContainer = component.$html.find('.tab__pane.is-active .tab__container');
 
     // Visually hide sidebar so you can't tab to it with keyboard/screenreaders
-    $tabHelpContainer.addClass('hide');
+    $tabHelpContainer
+        .addClass('hide')
+        .attr('aria-hidden', 'true');
 
     // Help toggle click bind
     component.$html.on('touchstart click', '.js-show-page-help', function(e) {
@@ -51,14 +53,20 @@ HelpTextComponent.prototype.toggleHelpSidebar = function () {
     if (component.$html.hasClass('open-help')) {
         component.$html.removeClass('open-help');
         if (component.$html.hasClass('lt-ie10')) {
-            $tabHelpContainer.addClass('hide');
+            $tabHelpContainer
+                .addClass('hide')
+                .attr('aria-hidden', 'true');
         } else {
             $tabHelpContainer.one('webkitTransitionEnd otransitionend oTransitionEnd msTransitionEnd transitionend', function(e) {
-                $tabHelpContainer.addClass('hide');
+                $tabHelpContainer
+                    .addClass('hide')
+                    .attr('aria-hidden', 'true');
             });
         }
     } else {
-        $tabHelpContainer.removeClass('hide');
+        $tabHelpContainer
+            .removeClass('hide')
+            .removeAttr('aria-hidden');
         component.$html.addClass('open-help');
     }
 };

--- a/tests/js/web/HelpTextComponentTest.js
+++ b/tests/js/web/HelpTextComponentTest.js
@@ -41,6 +41,10 @@ describe('HelpTextComponent', function() {
             expect(this.$tabHelpContainer.hasClass('hide')).to.be.true;
         });
 
+        it('should add aria-hidden tab-help-container', function () {
+            expect(this.$tabHelpContainer.attr('aria-hidden')).to.equal('true');
+        });
+
         it('should copy the active tabs sidebar contents to the tab-help container', function() {
             expect(this.$tabHelp.html()).to.equal('<button class="close-page-help js-close-page-help"><i class="icon-remove-sign" aria-hidden="true"></i><span class="hide">Close on-page help</span></button>Some help text');
         });
@@ -86,6 +90,12 @@ describe('HelpTextComponent', function() {
 
             expect(this.$mainTitle.find('.js-show-page-help').hasClass('is-open')).to.be.true;
         });
+
+        it('should remove the aria-hidden attribute from the tab-help-container', function () {
+            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+
+            expect(this.$tabHelpContainer.attr('aria-hidden')).to.be.undefined;
+        });
     });
 
     describe('When the side help is open and the help button is pressed', function() {
@@ -117,11 +127,24 @@ describe('HelpTextComponent', function() {
             expect(this.$tabHelpContainer.hasClass('hide')).to.be.true;
         });
 
+        it('should add aria-hidden attribute to the tab-help-container', function () {
+            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$tabHelpContainer.trigger('transitionend');
+            expect(this.$tabHelpContainer.attr('aria-hidden')).to.equal('true');
+        });
+
         it('should add the hide class to the tab-help-container if lt-ie10', function () {
             this.$html.addClass('lt-ie10');
             this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
 
             expect(this.$tabHelpContainer.hasClass('hide')).to.be.true;
+        });
+
+        it('should add aria-hidden attribute to the tab-help-container', function () {
+            this.$html.addClass('lt-ie10');
+            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+
+            expect(this.$tabHelpContainer.attr('aria-hidden')).to.equal('true');
         });
     });
 
@@ -164,6 +187,10 @@ describe('HelpTextComponent', function() {
 
         it('should add the hide class from the tab-help-container', function () {
             expect(this.$tabHelpContainer.hasClass('hide')).to.be.true;
+        });
+
+        it('should add the aria-hidden attribute to the tab-help-container', function () {
+            expect(this.$tabHelpContainer.attr('aria-hidden')).to.equal('true');
         });
     });
 

--- a/views/pulsar/layouts/base.html.twig
+++ b/views/pulsar/layouts/base.html.twig
@@ -131,7 +131,7 @@
                 </div>
             </div>
 
-            <aside aria-label="additional information" class="tab-help-container t-tab-help-container"><div class="tab-help"></div></aside>
+            <aside aria-label="help" class="tab-help-container t-tab-help-container"><div class="tab-help"></div></aside>
         </div>
     </div>
 


### PR DESCRIPTION
This change fixes the AXE landmark errors reported in #1185. It also fixes an issue where a SR user could navigate to the mobile help container on desktop, which caused confusing screen reader results and also navigate to the closed help sidebar on mobile resulting in a blank screen.

Fixes #1185 