### PR TITLE
Add aria-disabled attribute to disabled UI wrapper and change text color for disabled links

### DIFF
--- a/js/DisableUiComponent.js
+++ b/js/DisableUiComponent.js
@@ -40,7 +40,7 @@ DisableUiComponent.prototype.disable = function (target) {
             .addClass('js-disabled u-cursor-not-allowed');
 
         // Wrap with disabled wrapper to visually disable
-        $this.wrap('<div class="u-ui-disabled"></div>');
+        $this.wrap('<div class="u-ui-disabled" aria-disabled="true"></div>');
     });
 };
 
@@ -53,7 +53,7 @@ DisableUiComponent.prototype.enable = function (target) {
         var $this = $(this);
 
         // Remove attribute used to disable a UI on load
-        $this.removeAttr('data-disable-ui');
+        $this.removeAttr('data-disable-ui, aria-disabled');
 
         // Enable form elements
         $this.find(FORM_ELEMENTS)
@@ -67,7 +67,8 @@ DisableUiComponent.prototype.enable = function (target) {
         // Enable links
         $this.find(LINK_ELEMENTS)
             .off('click', preventDefaultAndStopPropagation)
-            .removeClass('js-disabled u-cursor-not-allowed');
+            .removeClass('js-disabled u-cursor-not-allowed')
+            .removeProp('aria-disabled');
 
         // Remove wrapper which provides visually disabled styling
         if ($this.parent().hasClass('u-ui-disabled')) {

--- a/js/DisableUiComponent.js
+++ b/js/DisableUiComponent.js
@@ -54,7 +54,7 @@ DisableUiComponent.prototype.enable = function (target) {
         var $this = $(this);
 
         // Remove attribute used to disable a UI on load
-        $this.removeAttr('data-disable-ui, aria-disabled');
+        $this.removeAttr('data-disable-ui aria-disabled');
 
         // Enable form elements
         $this.find(FORM_ELEMENTS)

--- a/js/DisableUiComponent.js
+++ b/js/DisableUiComponent.js
@@ -37,7 +37,8 @@ DisableUiComponent.prototype.disable = function (target) {
         // Disable links (uses .js-disable as any existing disabled)
         $this.find(LINK_ELEMENTS)
             .on('click', preventDefaultAndStopPropagation)
-            .addClass('js-disabled u-cursor-not-allowed');
+            .addClass('js-disabled u-cursor-not-allowed')
+            .prop('aria-disabled', 'true');
 
         // Wrap with disabled wrapper to visually disable
         $this.wrap('<div class="u-ui-disabled" aria-disabled="true"></div>');

--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -36,7 +36,6 @@ PulsarUIComponent.prototype.initDisabledLinks = function() {
 
         $this
             .attr('aria-disabled', 'true')
-            .attr('tabindex', '-1')
             .attr('role', 'button')
             .attr('data-href', $this.attr('href'))
             .removeAttr('href')

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -662,7 +662,7 @@ fieldset {
 // look visually disabled too (the main label for the entire choice still uses
 // normal text colour)
 .is-disabled + .form-choice__label {
-    color: color(text, disabled);
+    opacity: .4;
 }
 
 .form__indent {

--- a/stylesheets/_utility.utilities.scss
+++ b/stylesheets/_utility.utilities.scss
@@ -358,6 +358,10 @@ p.success {
     @extend %u-cursor-not-allowed;
 
     opacity: .25 !important;
+
+    a.is-disabled {
+        color: color(link);
+    }
 }
 
 %u-no-hover:hover,

--- a/tests/js/web/DisableUiComponentTest.js
+++ b/tests/js/web/DisableUiComponentTest.js
@@ -52,6 +52,10 @@ describe('DisableUi component', function() {
 			expect(this.$standardForm.parent().hasClass('u-ui-disabled')).to.be.false;
 		});
 
+		it('should not have the aria-disabled attribute on the parent container', function() {
+			expect(this.$standardForm.parent().attr('aria-disabled')).to.be.undefined;
+		});
+
 		it('should remove the u-cursor-not-allowed class from form labels', function() {
 			expect(this.$label.hasClass('u-cursor-not-allowed')).to.be.false;
 		});
@@ -71,6 +75,14 @@ describe('DisableUi component', function() {
 		it('should remove the disabled class from form inputs', function() {
 			expect(this.$textInput.hasClass('disabled')).to.be.false;
 		});
+
+		it('should remove the aria-disabled attribute from links', function () {
+			var clickEvent = $.Event('click');
+
+			this.$link.trigger(clickEvent);
+
+			expect(this.$link.attr('aria-disabled')).to.be.undefined;
+		});
 	});
 
 	describe('the ‘disable’ method', function() {
@@ -78,6 +90,14 @@ describe('DisableUi component', function() {
 		beforeEach(function() {
 			this.disableUi.init();
 			this.disableUi.disable(this.$target);
+		});
+
+		it('should wrap the container in a div with the .u-ui-disabled class', function() {
+			expect(this.$standardForm.parent().hasClass('u-ui-disabled')).to.be.true;
+		});
+
+		it('should add the aria-disabled attribute to the UI container being disabled', function() {
+			expect(this.$standardForm.parent().attr('aria-disabled')).to.equal('true');
 		});
 
 		it('should prevent default on links', function() {
@@ -104,6 +124,14 @@ describe('DisableUi component', function() {
 			expect(this.$link.hasClass('u-cursor-not-allowed')).to.be.true;
 		});
 
+		it('should add the aria-disabled attribute to the link', function () {
+			var clickEvent = $.Event('click');
+
+			this.$link.trigger(clickEvent);
+
+			expect(this.$link.prop('aria-disabled')).to.equal('true');
+		});
+
 		it('should add the u-cursor-not-allowed class to form labels', function () {
 			expect(this.$label.hasClass('u-cursor-not-allowed')).to.be.true;
 		});
@@ -122,10 +150,6 @@ describe('DisableUi component', function() {
 
 		it('should add the disabled class to form inputs', function() {
 			expect(this.$textInput.hasClass('disabled')).to.be.true;
-		});
-
-		it('should wrap the container in a div with the .u-ui-disabled class', function() {
-			expect(this.$standardForm.parent().hasClass('u-ui-disabled')).to.be.true;
 		});
 	});
 

--- a/tests/js/web/PulsarUIComponentTest.js
+++ b/tests/js/web/PulsarUIComponentTest.js
@@ -77,12 +77,6 @@ describe('Pulsar UI Component', function() {
             expect(this.$html.find('.is-disabled').attr('data-href')).to.equal('#foo');
         });
 
-        it('should remove the link from the tabindex', function() {
-            this.$isDisabled.trigger(this.clickEvent);
-
-            expect(this.$html.find('.is-disabled').attr('tabindex')).to.equal('-1');
-        });
-
         it('should add the button role', function() {
             this.$isDisabled.trigger(this.clickEvent);
 

--- a/views/lexicon/patterns/disabled-ui/disabled-ui.html.twig
+++ b/views/lexicon/patterns/disabled-ui/disabled-ui.html.twig
@@ -31,7 +31,8 @@
     {{
         html.link({
             'label': 'External link',
-            'href': 'http://google.com'
+            'href': 'http://google.com',
+            'disabled': true
         })
     }}
 


### PR DESCRIPTION
Using opacity instead of a lighter `color` achieves the same visual effect, keeps a11y tools happy, and meets WCAG exceptions for disabled element contrast.

Also uses opacity for disabled choice labels

**Before**
![Screenshot 2020-03-24 at 09 00 53](https://user-images.githubusercontent.com/18653/77407514-28889c00-6dae-11ea-8b6c-94b657f807c4.png)
Using `color: color(text, disabled);` (`#bebebe`)

**After**
![Screenshot 2020-03-24 at 09 00 39](https://user-images.githubusercontent.com/18653/77407529-2cb4b980-6dae-11ea-9cac-37db9c735fbd.png)

This uses `opacity: .4;`, a touch darker than before, but still enough, I feel.

Closes #1177