### PR TITLE
Fixed panel cta contrast issue and related lexicon a11y tool errors

### DIFF
--- a/stylesheets/_component.panels.scss
+++ b/stylesheets/_component.panels.scss
@@ -100,7 +100,7 @@
             a:hover,
             a:active,
             a:visited {
-                color: $state-color-alt;
+                color: $state-color-alt !important;
             }
         }
     }

--- a/stylesheets/_component.timeline.scss
+++ b/stylesheets/_component.timeline.scss
@@ -106,7 +106,7 @@
     }
 
     &--user {
-        background-color: color(jadu-green, base);
+        background-color: color(jadu-green, darkest);
         color: color(white);
     }
 

--- a/views/lexicon/tabs/panels.html.twig
+++ b/views/lexicon/tabs/panels.html.twig
@@ -82,7 +82,7 @@
 
     {{
         html.panel({
-            'title': 'Default panel',
+            'title': 'Default panel padded',
             'class': 'panel--padded centered',
             'body': 'What you wanna ball with the kid
     Watch your step you might fall
@@ -189,8 +189,8 @@
                         <div class="timeline-content__inner"><span class="timeline-content__title">Alex Bearing (Editor):</span>
                         <div class="timeline-content__date">
                             {{ html.icon('clock-o', {'class': 'icon--info u-hidden-print', 'label': 'Time of message'}) }}
-                            <time class="u-visible-print-inline">10 Mar 2018, 10:01 AM</time>
-                            <time class="timeago u-hidden-print" datetime="Thu, 10 Mar 2018 10:01:04 +0100" data-timezone="Europe/London"> Thursday 29th March 2018 (11:59)</time>
+                            <p class="u-visible-print-inline">10 Mar 2018, 10:01 AM</p>
+                            <time class="timeago u-hidden-print" data-timeago="Tue, 17 Mar 2020 10:48:24 +0000" datetime="2020-03-17 10:03:24" data-timezone="Europe/London">Tuesday, 17 March 2020 10:48</time>
                         </div>
                         <div class="timeline-content__body" data-id="2650349">
                             <p id="message-120530" class="timeline-content__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut congue felis aliquet, sodales leo vitae, lacinia diam. Pellentesque nec tincidunt justo, at viverra eros. Donec laoreet, neque ac consectetur auctor, nisi tellus pretium ante, at tincidunt velit nunc et ante. In placerat mi vel nunc viverra, a ultrices est facilisis. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aliquam libero ex, sollicitudin sit amet molestie porta, ultricies a mauris. Integer condimentum imperdiet risus, ac tincidunt nisi faucibus ac. Quisque non congue augue, id ultrices ipsum. Nunc finibus urna diam, in luctus lectus viverra vitae. Mauris ligula diam, aliquam nec nisi id, posuere fringilla leo. Aenean varius felis metus, eu interdum odio suscipit id. Sed tellus mi, laoreet non lacinia ac, maximus eu sem.


### PR DESCRIPTION
This changes fixes the issues reported in #1166 namely colour contrast failures for success and danger panel CTA button text colour.

I've also resolved some lexicon specific a11y errors relating to duplicate landmark names, incorrectly formatted date time attribute values and timeline avatar colour contrast.

Fixes #1166 