### PR TITLE
Fix SI error by properly hiding hidden fields

### DIFF
--- a/js/Repeater/RepeaterDataService.js
+++ b/js/Repeater/RepeaterDataService.js
@@ -41,6 +41,8 @@ class RepeaterDataService {
             clone.setAttribute('name', name);
             // Remove the new group attr
             clone.removeAttribute(this.queryService.getAttr('name'));
+            // Hide clone from SRs
+            clone.classList.add('u-display-none');
             // Add cloned input to entry
             savedData.appendChild(clone);
         });

--- a/tests/js/web/Repeater/RepeaterDataServiceTest.js
+++ b/tests/js/web/Repeater/RepeaterDataServiceTest.js
@@ -57,6 +57,7 @@ describe('RepeaterDataService', () => {
             expect(data.children).to.have.length.of(1);
             expect(data.firstElementChild.getAttribute('data-saved-entry-id')).to.equal('666');
             expect(clonedInput.getAttribute('name')).to.equal('test_input');
+            expect(clonedInput.className).to.equal('u-display-none');
             expect(clonedInput.getAttribute('data-name')).to.be.null;
             expect(uniqueIdServiceStub.uniquifyIds).to.have.been.calledOnce;
         });


### PR DESCRIPTION
This change fixes the issues reported in #1174 by adding `display: none` to the saved data hidden fields (via `.u-display-none`).

Fixes #1174 