### PR TITLE
form.button_group a11y fixes

### DIFF
--- a/stylesheets/_component.choice.scss
+++ b/stylesheets/_component.choice.scss
@@ -3,21 +3,6 @@
     overflow: visible;
 }
 
-fieldset.form-choice {
-    padding: 0;
-
-    > .control__label {
-        border-bottom: 0;
-        float: left; // as we can't use inline-block
-        font-size: inherit;
-        line-height: inherit;
-    }
-
-    > .controls {
-        clear: left;
-    }
-}
-
 // Align form-choice to grid
 @include respond-min($screen-tablet) {
     .form-choice > .controls > .control__label {

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -739,14 +739,23 @@ fieldset.form__group--compound {
     padding: 0;
 }
 
-.form__group--compound {
-    > .control__label {
+// undo fieldset styling when fieldset/legend used for form__group and control__label
+fieldset.form__group {
+    padding: 0;
+
+    > legend.control__label {
         border-bottom: 0;
         float: left; // as we can't use inline-block
         font-size: inherit;
         line-height: inherit;
     }
 
+    > .controls {
+        clear: left;
+    }
+}
+
+.form__group--compound {
     > .controls {
         // override regular stacked styling
         > .form__control,

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-error.html
@@ -1,4 +1,4 @@
-<div class="form__group has-error form__button-group">
+<fieldset class="form__group has-error form__button-group">
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -8,4 +8,4 @@
         <label class="control__label">MW</label>
         <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-guidance-container.html
@@ -1,5 +1,5 @@
-<div class="form__group form__button-group">
-    <label class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" data-toggle="popover" data-autoclose="true" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></label>
+<fieldset class="form__group form__button-group">
+    <legend class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" data-toggle="popover" data-autoclose="true" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></legend>
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -8,4 +8,4 @@
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-guidance.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-guidance.html
@@ -1,5 +1,5 @@
-<div class="form__group form__button-group">
-    <label class="control__label">foo <i data-container="body" data-content="bar" data-placement="top" data-toggle="popover" data-autoclose="true" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></label>
+<fieldset class="form__group form__button-group">
+    <legend class="control__label">foo <i data-container="body" data-content="bar" data-placement="top" data-toggle="popover" data-autoclose="true" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></legend>
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -8,4 +8,4 @@
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-help.html
@@ -1,4 +1,4 @@
-<div class="form__group form__button-group">
+<fieldset class="form__group form__button-group">
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -8,4 +8,4 @@
         <label class="control__label">MW</label>
         <span class="help-block" id="guid-1">my help text</span>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-label-hide.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-label-hide.html
@@ -1,5 +1,5 @@
-<div class="form__group form__button-group">
-    <label class="control__label hide">foo</label>
+<fieldset class="form__group form__button-group">
+    <legend class="control__label hide">foo</legend>
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -8,4 +8,4 @@
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-label.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-label.html
@@ -1,5 +1,5 @@
-<div class="form__group form__button-group">
-    <label class="control__label">Band</label>
+<fieldset class="form__group form__button-group">
+    <legend class="control__label">Band</legend>
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -8,4 +8,4 @@
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-type_button.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-type_button.html
@@ -1,7 +1,7 @@
-<div class="form__group form__button-group">
+<fieldset class="form__group form__button-group">
     <div class="controls btn__group">
         <button name="bands" class="btn">AM</button>
         <button name="bands" class="btn">FM</button>
         <button name="bands" class="btn">MW</button>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-type_checkbox.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-type_checkbox.html
@@ -1,4 +1,4 @@
-<div class="form__group form__button-group">
+<fieldset class="form__group form__button-group">
     <div class="controls btn__group">
         <input name="bands" type="checkbox" class="form__control checkbox" />
         <label class="control__label">AM</label>
@@ -7,4 +7,4 @@
         <input name="bands" type="checkbox" class="form__control checkbox" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-type_radio.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-type_radio.html
@@ -1,4 +1,4 @@
-<div class="form__group form__button-group">
+<fieldset class="form__group form__button-group">
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -7,4 +7,4 @@
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group.html
@@ -1,4 +1,4 @@
-<div class="form__group form__button-group">
+<fieldset class="form__group form__button-group">
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -7,4 +7,4 @@
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -73,6 +73,9 @@ items         | array  | An array of items to put in the dropdown list (usually 
         {% set options = options|defaults({'aria-describedby': describedByIds|join(' ')}) %}
     {% endif %}
 
+    {% set containerTag = 'fieldset' %}
+    {% set labelTag = 'legend' %}
+
     {# If error is preset add aria-invalid="true" and aria-describedby to all inputs #}
     {% set items = options.items %}
 
@@ -98,7 +101,7 @@ items         | array  | An array of items to put in the dropdown list (usually 
         form.group({
             'parent': options
                 |only('bare class error error_ids guidance guidance-container has_error help help_id id label required show-label type')
-                |merge({'class': options.class|default ~ ' form__button-group'}),
+                |merge({'class': options.class|default ~ ' form__button-group', 'containerTag' : containerTag, 'labelTag': labelTag }),
             'controls': {'class': 'btn__group'},
             'inputs': items
         })
@@ -1293,6 +1296,7 @@ controls.class    | string | A space separated list of class names
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 
     {% set groupClass = 'form__group' %}
+    {% set containerTag = 'div' %}
     {% set labelTag = 'label' %}
 
     {% if options.parent.error is defined and options.parent.error is not empty %}
@@ -1308,6 +1312,10 @@ controls.class    | string | A space separated list of class names
         {% set showLabel = false %}
     {% endif %}
 
+    {% if options.parent.containerTag is defined and options.parent.containerTag is not empty %}
+        {% set containerTag = options.parent.containerTag %}
+    {% endif %}
+
     {% if options.parent.labelTag is defined and options.parent.labelTag is not empty %}
         {% set labelTag = options.parent.labelTag %}
     {% endif %}
@@ -1318,12 +1326,13 @@ controls.class    | string | A space separated list of class names
     {% endif %}
 
     {% if options.parent.bare is not defined or options.parent.bare != true %}
-    <div{{
+    <{{
         attributes(options.parent
                 |only('class aria-describedby')
                 |defaults({
                     'class': groupClass
-                })
+                }),
+                {'tag': containerTag}
             )
     -}}>
     {% endif %}
@@ -1450,7 +1459,7 @@ controls.class    | string | A space separated list of class names
         </label>
         {% endif %}
     {% if options.parent.bare is not defined or options.parent.bare != true %}
-    </div>
+    </{{ containerTag }}>
     {% endif %}
 
 {% endmacro %}

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -101,7 +101,7 @@ items         | array  | An array of items to put in the dropdown list (usually 
         form.group({
             'parent': options
                 |only('bare class error error_ids guidance guidance-container has_error help help_id id label required show-label type')
-                |merge({'class': options.class|default ~ ' form__button-group', 'containerTag' : containerTag, 'labelTag': labelTag }),
+                |merge({'class': options.class|default ~ ' form__button-group', 'containerTag': containerTag, 'labelTag': labelTag }),
             'controls': {'class': 'btn__group'},
             'inputs': items
         })


### PR DESCRIPTION
This PR changes the mark up used in `form.button_group` from `div` and `label` to `fieldset` and `legend`. It also replaces the more specific fieldset styling for `form-choice` and `form__group--compound` with something more flexible and generic.

Browser tested in:
- Safari
- Chrome
- Firefox
- Edge
- IE11
- iOS safari

Fixes #1168 