### PR TITLE
Allow mobile help button to still be present if no main title is available

### DIFF
--- a/js/HelpTextComponent.js
+++ b/js/HelpTextComponent.js
@@ -84,7 +84,7 @@ HelpTextComponent.prototype.updateHelpSidebar = function () {
         $activeTabContainer = component.$html.find('.tab__pane.is-active .tab__container'),
         activeTabSideBarContentHtml = component.$html.find('.tab__pane.is-active .tab__sidebar').html(),
         $mobileToggleHelpButton = $('<button class="show-page-help js-show-page-help"><i class="icon-question-sign" aria-hidden="true"></i><span class="hide">Show on-page help</span></button>'),
-        $pageMainTitle = component.$html.find('.main-title'),
+        $mobileToggleContainer = component.$html.find('.toolbar'),
         $tabHelp = component.$html.find('.tab-help'),
         isMobile,
         mobileCloseHelpButton = '<button class="close-page-help js-close-page-help"><i class="icon-remove-sign" aria-hidden="true"></i><span class="hide">Close on-page help</span></button>';
@@ -106,8 +106,8 @@ HelpTextComponent.prototype.updateHelpSidebar = function () {
         });
 
         // If mobile help button doesn't already exist add it if help text exists
-        if (!$pageMainTitle.find('.js-show-page-help').length) {
-            $mobileToggleHelpButton.appendTo($pageMainTitle);
+        if (!$mobileToggleContainer.find('.js-show-page-help').length) {
+            $mobileToggleHelpButton.appendTo($mobileToggleContainer);
         }
 
         // Add class used for setting desktop column widths

--- a/stylesheets/_component.tab-help.scss
+++ b/stylesheets/_component.tab-help.scss
@@ -66,11 +66,14 @@ $nav-color-dark:  darken(color(jadu-blue, dark), 5%) !default;
     border: 0;
     color: color(gray, dark);
     display: inline-block;
-    float: right;
+    font-size: 28px;
     line-height: normal;
+    margin-top: -45px;
     padding: 0;
+    position: absolute;
     text-decoration: none;
     transition: all 100ms ease-in;
+    right: 20px;
 
     @include respond-min($screen-desktop) {
         display: none;

--- a/tests/js/web/HelpTextComponentTest.js
+++ b/tests/js/web/HelpTextComponentTest.js
@@ -14,12 +14,12 @@ describe('HelpTextComponent', function() {
         this.$document = $('<div></div>').appendTo(this.$window);
         this.$html = $('<html></html>').appendTo(this.$document);
         this.$body = $('<body></body>').appendTo(this.$html);
+        this.$toolbar = $('<div class="toolbar"></div>').appendTo(this.$body);
         this.$tabHelpContainer = $('<div class="tab-help-container"></div>').appendTo(this.$body);
         this.$tabHelp = $('<div class="tab-help"></div>').appendTo(this.$tabHelpContainer);
         this.$contentMain = $('<div class="content-main"></div>').appendTo(this.$body);
         this.$tabsContent = $('<div class="tabs__content"></div>').appendTo(this.$contentMain);
         this.$tabLink = $('<a href="#" data-toggle="tab">tab</a>').appendTo(this.$tabsContent);
-        this.$mainTitle = $('<h1 class="main-title">Main title</h1>').appendTo(this.$tabsContent);
         this.$tabPane = $('<div class="tab__pane is-active"></div>').appendTo(this.$tabsContent);
         this.$tabContainer = $('<div class="tab__container"></div>').appendTo(this.$tabPane)
         this.$tabContent = $('<div class="tab__content"></div>').appendTo(this.$tabContainer);
@@ -53,8 +53,8 @@ describe('HelpTextComponent', function() {
             expect(this.$tabHelp.find('.js-close-page-help').length).to.equal(1);
         });
 
-        it('should add the help toggle button to the first heading', function() {
-            expect(this.$mainTitle.find('.js-show-page-help').length).to.equal(1);
+        it('should add the help toggle button to the toolbar', function() {
+            expect(this.$toolbar.find('.js-show-page-help').length).to.equal(1);
         });
     });
 
@@ -69,38 +69,38 @@ describe('HelpTextComponent', function() {
         });
 
         it('should prevent the default behaviour', function () {
-            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
 
             expect(this.clickEvent.isDefaultPrevented()).to.be.true;
         });
 
         it('should stop propagation of the click event', function () {
-            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
 
             expect(this.clickEvent.isPropagationStopped()).to.be.true;
         });
 
         it('should open the side menu', function () {
-            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
 
             expect(this.$html.hasClass('open-help')).to.be.true;
         });
 
         it('should add the is-open class to the button ', function () {
-            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
 
-            expect(this.$mainTitle.find('.js-show-page-help').hasClass('is-open')).to.be.true;
+            expect(this.$toolbar.find('.js-show-page-help').hasClass('is-open')).to.be.true;
         });
 
         it('should remove the aria-hidden attribute from the tab-help-container', function () {
-            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
 
             expect(this.$tabHelpContainer.attr('aria-hidden')).to.be.undefined;
         });
 
         it('move focus to the close button', function () {
             sinon.spy(this.helpTextComponent, 'toggleHelpSidebar');
-            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
             this.$tabHelpContainer.trigger('transitionend');
             
             expect(this.helpTextComponent.toggleHelpSidebar).to.have.been.called;
@@ -115,43 +115,43 @@ describe('HelpTextComponent', function() {
             this.helpTextComponent.updateHelpSidebar();
             this.clickEvent = $.Event('click');
             this.$html.addClass('open-help');
-            this.$mainTitle.find('.js-show-page-help').addClass('is-open');
+            this.$toolbar.find('.js-show-page-help').addClass('is-open');
         });
 
         it('should close the side menu', function () {
-            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
 
             expect(this.$html.hasClass('open-help')).to.be.false;
         });
 
         it('should remove the is-open class from the help button', function () {
-            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
 
-            expect(this.$mainTitle.find('.js-show-page-help').hasClass('is-open')).to.be.false;
+            expect(this.$toolbar.find('.js-show-page-help').hasClass('is-open')).to.be.false;
         });
 
         it('should add the hide class to the tab-help-container', function () {
-            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
             this.$tabHelpContainer.trigger('transitionend');
             expect(this.$tabHelpContainer.hasClass('hide')).to.be.true;
         });
 
         it('should add aria-hidden attribute to the tab-help-container', function () {
-            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
             this.$tabHelpContainer.trigger('transitionend');
             expect(this.$tabHelpContainer.attr('aria-hidden')).to.equal('true');
         });
 
         it('should add the hide class to the tab-help-container if lt-ie10', function () {
             this.$html.addClass('lt-ie10');
-            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
 
             expect(this.$tabHelpContainer.hasClass('hide')).to.be.true;
         });
 
         it('should add aria-hidden attribute to the tab-help-container', function () {
             this.$html.addClass('lt-ie10');
-            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
 
             expect(this.$tabHelpContainer.attr('aria-hidden')).to.equal('true');
         });
@@ -173,7 +173,7 @@ describe('HelpTextComponent', function() {
         });
 
         it('should stop propagation of the click event', function () {
-            this.$mainTitle.find('.js-show-page-help').trigger(this.clickEvent);
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
 
             expect(this.clickEvent.isPropagationStopped()).to.be.true;
         });
@@ -187,11 +187,11 @@ describe('HelpTextComponent', function() {
         });
 
         it('should remove the is-open class from the help button', function () {
-            this.$mainTitle.find('.js-show-page-help').addClass('is-open');
+            this.$toolbar.find('.js-show-page-help').addClass('is-open');
 
             this.$tabHelp.find('.js-close-page-help').trigger(this.clickEvent);
 
-            expect(this.$mainTitle.find('.js-show-page-help').hasClass('is-open')).to.be.false;
+            expect(this.$toolbar.find('.js-show-page-help').hasClass('is-open')).to.be.false;
         });
 
         it('should add the hide class from the tab-help-container', function () {
@@ -239,7 +239,7 @@ describe('HelpTextComponent', function() {
             this.helpTextComponent.updateHelpSidebar();
             this.clickEvent = $.Event('click');
             this.$html.addClass('open-help');
-            this.$mainTitle.find('.js-show-page-help').addClass('is-open');
+            this.$toolbar.find('.js-show-page-help').addClass('is-open');
         });
 
         it('should close the help side bar', function () {
@@ -251,7 +251,7 @@ describe('HelpTextComponent', function() {
         it('should remove the is-open class from the mobile help button', function () {
             this.$tabContentLink.trigger(this.clickEvent);
 
-            expect(this.$mainTitle.find('.js-show-page-help').hasClass('is-open')).to.be.false;
+            expect(this.$toolbar.find('.js-show-page-help').hasClass('is-open')).to.be.false;
         });
 
         it('should add the hide class from the tab-help-container', function () {


### PR DESCRIPTION
This moves the mobile help toggle from being a child of the .main-title element, to being a child of the parent .toolbar which has a significantly higher chance of being always available in the layout.

Closes #821

## Breaking change checklist

The following points should be considered as an early-warning of introducing a breaking change to a Continuum platform product. This is not an exhaustive list of what constitutes a breaking change.

| Does this pull request... | ⚠️ Yes / ✅ No |
| ---- | ---- |
| require changes to `main.js` | ✅ No |
| require changes to `index.js` | ✅ No |
| require changes to `pulsar.scss` | ✅ No |
| require changes to `gruntfile.js` | ✅ No |
| require changes to `package.json` (not including dev dependencies) | ✅ No |
| require changes to `base.html.twig` (or other core views like header/footer) | ✅ No |
| require new arguments to be passed to a js component | ✅ No |
| require markup changes to maintain functionality | ✅ No |
| require changes to existing unit tests | ⚠️ Yes, unit tests had to be changed to reflect the resulting markup changes |

## Browser testing checklist

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge
- [x] IE 11
- [x] Mobile Safari
- [x] Samsung Internet