### PR TITLE
Make table detail triggers work with DT collapse mode

### DIFF
--- a/js/TableDetailComponent.js
+++ b/js/TableDetailComponent.js
@@ -66,17 +66,27 @@ class TableDetailComponent {
         this.$tableDetailBackdrop = this.$html.find('.table-detail-backdrop');
 
         // Open click listener
-        this.$table.find('[data-table-detail-view-detail]').on('click', (event) => {
+        this.$html.on('click', '[data-table-detail-view-detail]', (event) => {
             event.preventDefault();
-            let detailContent = $(event.currentTarget).closest('tr').data('table-detail-content');
-            let customDetailPanelTitle = $(event.currentTarget).closest('tr').data('table-detail-panel-custom-title');
+            
+            let $parentRow = $(event.currentTarget).closest('tr');
+
+            // If the table is in DT collapse mode, and the detail trigger is in the child row
+            // then fetch the detail content from the appropriate parent row
+            if ($parentRow.hasClass('child')) {
+                $parentRow = $parentRow.prev();
+            }
+
+            let detailContent = $parentRow.data('table-detail-content');
+            let customDetailPanelTitle = $parentRow.data('table-detail-panel-custom-title');
+
             $triggeringElement = $(event.target);
 
             this.viewDetail(detailContent, customDetailPanelTitle);
         });
 
         // Close click listener
-        this.$detailPanel.find('[data-table-detail-close-panel]').on('click', (event) => {
+        this.$html.on('click', '[data-table-detail-close-panel]', (event) => {
             event.preventDefault();
             this.closeDetail();
             $triggeringElement.trigger('focus');

--- a/js/TableDetailComponent.js
+++ b/js/TableDetailComponent.js
@@ -66,9 +66,9 @@ class TableDetailComponent {
         this.$tableDetailBackdrop = this.$html.find('.table-detail-backdrop');
 
         // Open click listener
-        this.$html.on('click', '[data-table-detail-view-detail]', (event) => {
+        this.$table.on('click', '[data-table-detail-view-detail]', (event) => {
             event.preventDefault();
-            
+
             let $parentRow = $(event.currentTarget).closest('tr');
 
             // If the table is in DT collapse mode, and the detail trigger is in the child row
@@ -86,7 +86,7 @@ class TableDetailComponent {
         });
 
         // Close click listener
-        this.$html.on('click', '[data-table-detail-close-panel]', (event) => {
+        this.$detailPanel.find('[data-table-detail-close-panel]').on('click', (event) => {
             event.preventDefault();
             this.closeDetail();
             $triggeringElement.trigger('focus');

--- a/js/TableDetailComponent.js
+++ b/js/TableDetailComponent.js
@@ -20,10 +20,10 @@ class TableDetailComponent {
         }
 
         let $panelHtml = $(
-            '<div class="table-detail t-table-detail" data-table-detail-panel role="dialog" aria-modal="true" aria-hidden="true">' +
+            '<div class="table-detail t-table-detail" data-table-detail-panel role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="table-detail-title">' +
             '   <div class="table-detail__header">' +
             '       <button type="button" class="close table-detail__header-close" data-table-detail-close-panel aria-label="Close" tabindex="-1"><span aria-hidden="true">&times;</span></button>' +
-            '       <h1 class="table-detail__title" data-table-detail-panel-title>Detail</h1>' +
+            '       <h1 id="table-detail-title" class="table-detail__title" data-table-detail-panel-title>Detail</h1>' +
             '   </div>' +
             '   <div class="table-detail__body" data-table-detail-panel-body></div>' +
             '</div>'

--- a/tests/js/web/TableDetailComponentTest.js
+++ b/tests/js/web/TableDetailComponentTest.js
@@ -150,7 +150,7 @@ describe('TableDetailComponent', () => {
 		it('should prevent the default behaviour of the click', () => {
 			tableDetailComponent.init($body);
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 
 			expect(clickEvent.isDefaultPrevented()).to.be.true;
 		});
@@ -158,7 +158,7 @@ describe('TableDetailComponent', () => {
 		it('should set a custom panel title if one is set', () => {
 			tableDetailComponent.init($body);
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 
 			expect($body.find('[data-table-detail-panel-title]').text()).to.equal('custom panel title');
 		});
@@ -167,7 +167,7 @@ describe('TableDetailComponent', () => {
 			tableDetailComponent.init($body);
 			$body.find('[data-table-detail-panel-body]').append('some content to be removed');
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 
 			expect($body.find('[data-table-detail-panel-body]').html()).to.equal('<p>content</p><form><button>button</button></form>');
 		});
@@ -175,7 +175,7 @@ describe('TableDetailComponent', () => {
 		it('should add the "in" class to the backdrop to show it', () => {
 			tableDetailComponent.init($body);
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 
 			expect($body.find('.table-detail-backdrop').hasClass('in')).to.be.true;
 		});
@@ -183,7 +183,7 @@ describe('TableDetailComponent', () => {
 		it('should add the "table-detail--open" class to the panel to open it', () => {
 			tableDetailComponent.init($body);
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 
 			expect($body.find('[data-table-detail-panel]').hasClass('table-detail--open')).to.be.true;
 		});
@@ -192,7 +192,7 @@ describe('TableDetailComponent', () => {
 			tableDetailComponent.init($body);
 			$body.find('[data-table-detail-content]').attr('data-table-detail-content', '<p>Content</p>')
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 
 			expect($body.find('[data-table-detail-close-panel]').is(':focus')).to.be.true;
 		});
@@ -200,7 +200,7 @@ describe('TableDetailComponent', () => {
 		it('should focus the first focusable element if one is present ', () => {
 			tableDetailComponent.init($body);
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 
 			expect($body.find('[data-table-detail-panel-body] form button').is(':focus')).to.be.true;
 		});
@@ -262,7 +262,7 @@ describe('TableDetailComponent', () => {
 		it('should remove the "in" class from the backdrop to hide it', () => {
 			tableDetailComponent.init($body);
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 			$body.find('[data-table-detail-close-panel]').trigger(clickEvent);
 
 			expect($body.find('.table-detail-backdrop').hasClass('in')).to.be.false;
@@ -271,7 +271,7 @@ describe('TableDetailComponent', () => {
 		it('should remove the "table-detail--open" class from the panel', () => {
 			tableDetailComponent.init($body);
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 			$body.find('[data-table-detail-close-panel]').trigger(clickEvent);
 
 			expect($body.find('[data-table-detail-panel]').hasClass('table-detail--open')).to.be.false;
@@ -280,7 +280,7 @@ describe('TableDetailComponent', () => {
 		it('should add tabindex="-1" to all focusable elements', () => {
 			tableDetailComponent.init($body);
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 			$body.find('[data-table-detail-close-panel]').trigger(clickEvent);
 
 			expect($body.find('[data-table-detail-panel-body] button').attr('tabindex')).to.equal('-1');
@@ -292,7 +292,7 @@ describe('TableDetailComponent', () => {
 		it('should not be possible to focus elements in the panel', () => {
 			tableDetailComponent.init($body);
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 			$body.find('[data-table-detail-close-panel]').trigger(clickEvent);
 
 			expect($body.find('[data-table-detail-panel-body] button').attr('tabindex')).to.equal('-1');
@@ -302,7 +302,7 @@ describe('TableDetailComponent', () => {
 		it('should add the aria-hidden="true" attribute to the panel', () => {
 			tableDetailComponent.init($body);
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 			$body.find('[data-table-detail-close-panel]').trigger(clickEvent);
 
 			expect($body.find('.table-detail[aria-hidden="true"]')).to.have.length(1);
@@ -330,7 +330,7 @@ describe('TableDetailComponent', () => {
 		it('should remove the "in" class from the backdrop to hide it', () => {
 			tableDetailComponent.init($body);
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 			expect($body.find('.table-detail-backdrop').hasClass('in')).to.be.true;
 
 			$body.find('.table-detail-backdrop').trigger(clickEvent);
@@ -340,7 +340,7 @@ describe('TableDetailComponent', () => {
 		it('should remove the "table-detail--open" class from the panel to close it', () => {
 			tableDetailComponent.init($body);
 
-			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
+			$body.find('.parent [data-table-detail-view-detail]').trigger(clickEvent);
 			expect($body.find('[data-table-detail-panel]').hasClass('table-detail--open')).to.be.true;
 
 			$body.find('.table-detail-backdrop').trigger(clickEvent);

--- a/tests/js/web/TableDetailComponentTest.js
+++ b/tests/js/web/TableDetailComponentTest.js
@@ -21,7 +21,10 @@ describe('TableDetailComponent', () => {
 			'		<th>Actions</th>' +
 			'	</thead>' +
 			'	<tbody>' +
-			'		<tr data-table-detail-content="<p>content</p><form><button>button</button></form>" data-table-detail-panel-custom-title="custom panel title">' +
+			'		<tr class="parent" data-table-detail-content="<p>content</p><form><button>button</button></form>" data-table-detail-panel-custom-title="custom panel title">' +
+			'			<td><a href="#" data-table-detail-view-detail="true">Details</a></td>' +
+			'		</tr>' +
+			'		<tr class="child">' +
 			'			<td><a href="#" data-table-detail-view-detail="true">Details</a></td>' +
 			'		</tr>' +
 			'	</tbody>' +
@@ -200,6 +203,25 @@ describe('TableDetailComponent', () => {
 			$body.find('[data-table-detail-view-detail]').trigger(clickEvent);
 
 			expect($body.find('[data-table-detail-panel-body] form button').is(':focus')).to.be.true;
+		});
+	});
+
+	describe('When the view panel link is clicked from the child row', () => {
+		it('should fetch the panel title from the parent row', () => {
+			tableDetailComponent.init($body);
+
+			$body.find('.child [data-table-detail-view-detail]').trigger(clickEvent);
+
+			expect($body.find('[data-table-detail-panel-title]').text()).to.equal('custom panel title');
+		});
+
+		it('should empty the panel body and replace the content', () => {
+			tableDetailComponent.init($body);
+			$body.find('[data-table-detail-panel-body]').append('some content to be removed');
+
+			$body.find('.child [data-table-detail-view-detail]').trigger(clickEvent);
+
+			expect($body.find('[data-table-detail-panel-body]').html()).to.equal('<p>content</p><form><button>button</button></form>');
 		});
 	});
 

--- a/views/lexicon/patterns/table-detail/index.html.twig
+++ b/views/lexicon/patterns/table-detail/index.html.twig
@@ -6,12 +6,21 @@
     {% include '/lexicon/patterns/table-detail/table-detail.html.twig' %}
 {% endset %}
 
+{% set tab_two %}
+    {% include '/lexicon/patterns/table-detail/table-detail-collapsing.html.twig' %}
+{% endset %}
+
 {%
     set tabs_content = [
         {
             "id"    : "tabledetail",
-            "label" : "Table Detail",
-            "src"   : tab_one,
+            "label" : "Scrolling",
+            "src"   : tab_one
+        },
+        {
+            "id"    : "tabledetailcollapse",
+            "label" : "Collapsing",
+            "src"   : tab_two,
             "active": true
         }
     ]

--- a/views/lexicon/patterns/table-detail/table-detail-collapsing.html.twig
+++ b/views/lexicon/patterns/table-detail/table-detail-collapsing.html.twig
@@ -1,0 +1,63 @@
+{% extends "@pulsar/pulsar/components/tab.html.twig" %}
+
+{% block tab_sidebar %}
+    <h2 class="heading">{{ html.icon('info-sign', { 'class': 'sidebar-icon'}) }} Example help</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. In tellus dolor, condimentum efficitur arcu sed, feugiat pellentesque lacus. Pellentesque ac ipsum ac mauris cursus volutpat. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.</p>
+{% endblock tab_sidebar %}
+
+{% block tab_content %}
+<table class="table datatable table--full" data-table-detail-table>
+    <thead>
+        <tr>
+            <td><span class="hide">Table controls</span></td>
+            <th class="table-selection" data-orderable="false">
+                <span class="hide">Row selection controls</span>
+                <input type="checkbox" class="form__control checkbox js-select-all" aria-label="Select all rows" data-tippy-content="Select all rows" data-tippy-placement="right" />
+            </th>
+            <th>Date</th>
+            <th>Time</th>
+            <th>User type</th>
+            <th>Event</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for i in 0..5 %}
+        <tr data-table-detail-content="<div class=&quot;padding&quot;><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce sit amet lobortis mi. Maecenas elit nulla, ullamcorper quis neque in, fermentum egestas ipsum. Vestibulum tincidunt molestie interdum. Nunc et risus id arcu tincidunt ullamcorper. Donec aliquet, magna vitae suscipit tristique, dolor lacus laoreet ipsum, a commodo felis ex eget tellus. Cras velit est, sagittis a cursus in, mollis et dolor. Phasellus pellentesque, risus vitae maximus dictum, felis magna consequat nisi, vel rutrum augue quam in quam. Duis sed arcu sit amet erat maximus luctus eget sit amet ex. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis ac sem ut nisi pharetra tincidunt sit amet eu ligula. Aliquam eget tellus risus. Pellentesque eleifend risus nec cursus iaculis.</p>
+
+            <p>Sed eget erat vel felis fermentum mattis. Morbi vulputate vehicula velit, id cursus metus. Donec imperdiet neque sit amet elit finibus laoreet. In consequat vitae lorem et consequat. Curabitur non cursus neque. Phasellus interdum dignissim quam vel auctor. Morbi egestas ex id sem laoreet lobortis. Phasellus iaculis quam eget dui pellentesque, vel tempus erat laoreet. Aenean auctor, sem eu aliquet sagittis, est ligula interdum dolor, sed convallis erat diam nec purus. Aenean faucibus suscipit orci, eu aliquam nisi pulvinar eget. In hac habitasse platea dictumst. Morbi mi nibh, gravida nec ullamcorper sed, blandit sit amet nisl. Quisque facilisis luctus sapien quis ornare. Cras a gravida nisl. Maecenas hendrerit ut leo eget faucibus.</p>
+
+                <p>Integer efficitur, nunc hendrerit dapibus maximus, justo leo semper lorem, ac pretium risus ligula et orci. Phasellus leo libero, ullamcorper sit amet efficitur quis, consectetur id nulla. Sed id sem tortor. Nullam hendrerit blandit elementum. Proin elementum orci nulla, eget pretium erat feugiat eget. Nulla eu pretium urna. Mauris scelerisque malesuada metus vitae vehicula.</p>
+
+                    <p>Nam tincidunt turpis eget augue feugiat, non facilisis mi pretium. Nunc in consequat lacus. Ut massa massa, vehicula egestas vehicula nec, egestas varius dolor. Ut tristique, nulla sed consectetur fermentum, augue libero vulputate augue, auctor elementum felis eros eget ante. Integer sapien tortor, vehicula ac scelerisque id, dapibus in dui. Cras blandit, dolor sed suscipit dictum, sapien elit semper sem, ut laoreet nisi libero vitae purus. Phasellus dui ante, tristique vitae pretium ut, eleifend quis leo. Etiam aliquet, est eu placerat lobortis, justo augue iaculis odio, nec auctor ex ex et nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Aenean volutpat augue nec massa sagittis, at mollis tortor gravida.</p>
+
+                        <p>Phasellus at posuere leo, sit amet consectetur ligula. Donec ultrices odio ut diam efficitur, sit amet feugiat ligula convallis. Phasellus feugiat nunc mattis faucibus aliquam. Sed non elit eu purus vestibulum hendrerit varius a leo. Donec at fermentum nulla. Nam in libero varius, dignissim nulla non, ultrices sem. Integer in libero felis. Proin nec nulla ut augue dapibus aliquet id non odio. Integer sit amet mollis magna. Quisque iaculis neque ac lobortis tempor. Suspendisse potenti. Proin pellentesque arcu sed ante volutpat feugiat.</p></div>" data-table-detail-panel-custom-title="A custom title set on the clicked TR">
+            <td class="table-responsive">
+                <button class="table-child-toggle">
+                    {{ html.icon('plus-sign', { 'label': 'Toggle collapsed columns' }) }}
+                </button>
+            </td>
+            <td class="table-selection">
+                <input type="checkbox" class="form__control checkbox js-select" aria-label="Select row" />
+            </td>
+            <td>{{ html.link({ 'label': '13/01/2017', 'class': 'table-action', 'data-table-detail-view-detail': true }) }}</td>
+            <td>3:30pm</td>
+            <td>
+                {{
+                    html.label({
+                        'label': 'council staff',
+                        'class': 'label--success'
+                    })
+                }}
+            </td>
+            <td>Case status changed</td>
+            <td>
+                {{ html.link({ 'label': 'Details', 'class': 'table-action', 'data-table-detail-view-detail': true, 'href': '#' }) }}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{% endblock tab_content %}
+


### PR DESCRIPTION
This change tweaks the event handlers to cope with the detail trigger changing DOM position, and adds a check so that the detail content can be fetched from the expected row rather than the collapsed detail.

Also adds a lexicon example for collapsing tables to the table detail pattern, and a new `aria-labelledby` attribute to bring in the accessibility improvements from modals requested by #820.

Closes #819
Closes #820

## Breaking change checklist

The following points should be considered as an early-warning of introducing a breaking change to a Continuum platform product. This is not an exhaustive list of what constitutes a breaking change.

| Does this pull request... | ⚠️ Yes / ✅ No |
| ---- | ---- |
| require changes to `main.js` | ✅ No |
| require changes to `index.js` | ✅ No |
| require changes to `pulsar.scss` | ✅ No |
| require changes to `gruntfile.js` | ✅ No |
| require changes to `package.json` (not including dev dependencies) | ✅ No |
| require changes to `base.html.twig` (or other core views like header/footer) | ✅ No |
| require new arguments to be passed to a js component | ✅ No |
| require markup changes to maintain functionality | ✅ No |
| require changes to existing unit tests | ✅ No |

## Browser testing checklist

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Edge
- [x] IE 11
- [x] Mobile Safari
- [x] Samsung Internet