### PR TITLE
Improve options for disabling button group buttons

### DIFF
--- a/stylesheets/_component.button-groups.scss
+++ b/stylesheets/_component.button-groups.scss
@@ -37,6 +37,15 @@
             border-right-color: darken(color($state), 10);
         }
     }
+
+    .is-disabled + .control__label {
+        opacity: .5;
+
+        &:hover {
+            cursor: not-allowed;
+            transform: none;
+        }
+    }
 }
 
 .btn__group > .btn + .btn,

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-disable-all.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-disable-all.html
@@ -1,0 +1,10 @@
+<fieldset class="form__group form__button-group">
+    <div class="controls btn__group">
+        <input name="bands" disabled type="radio" class="form__control radio is-disabled" />
+        <label class="control__label">AM</label>
+        <input name="bands" disabled type="radio" class="form__control radio is-disabled" />
+        <label class="control__label">FM</label>
+        <input name="bands" disabled type="radio" class="form__control radio is-disabled" />
+        <label class="control__label">MW</label>
+    </div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-disable-all.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-disable-all.html.twig
@@ -1,0 +1,22 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.button_group({
+        'disabled': true,
+        'items': [
+            {
+                'label': 'AM',
+                'name': 'bands'
+            },
+            {
+                'label': 'FM',
+                'name': 'bands'
+            },
+            {
+                'label': 'MW',
+                'name': 'bands'
+            }
+        ]
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-disable-single.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-disable-single.html
@@ -1,0 +1,10 @@
+<fieldset class="form__group form__button-group">
+    <div class="controls btn__group">
+        <input name="bands" type="radio" class="form__control radio" />
+        <label class="control__label">AM</label>
+        <input name="bands" disabled type="radio" class="form__control radio is-disabled" />
+        <label class="control__label">FM</label>
+        <input name="bands" type="radio" class="form__control radio" />
+        <label class="control__label">MW</label>
+    </div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-disable-single.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-disable-single.html.twig
@@ -1,0 +1,22 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.button_group({
+        'items': [
+            {
+                'label': 'AM',
+                'name': 'bands'
+            },
+            {
+                'label': 'FM',
+                'name': 'bands',
+                'disabled': true
+            },
+            {
+                'label': 'MW',
+                'name': 'bands'
+            }
+        ]
+    })
+}}
+{% endblock %}

--- a/views/lexicon/forms.html.twig
+++ b/views/lexicon/forms.html.twig
@@ -99,8 +99,7 @@
         {
           "id"    : "repeater",
           "label" : "Repeater",
-          "src"   : tab_repeater,
-            "active": true
+          "src"   : tab_repeater
         },
         {
           "id"    : "select",

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -99,7 +99,7 @@ items         | array  | An array of items to put in the dropdown list (usually 
     {{
         form.group({
             'parent': options
-                |only('bare class error error_ids has_error help help_id id label required show-label type')
+                |only('bare class disabled error error_ids has_error help help_id id label required show-label type')
                 |merge({'class': options.class|default ~ ' form__button-group', 'containerTag': containerTag, 'labelTag': labelTag }),
             'controls': {'class': 'btn__group'},
             'inputs': items
@@ -1379,6 +1379,11 @@ controls.class    | string | A space separated list of class names
         {# input #}
         {% for input in options.inputs %}
             {% if input is iterable %}
+
+                {% if options.parent.disabled is defined and options.parent.disabled == true %}
+                    {% set input = input|merge({ 'disabled': true }) %}
+                {% endif %}
+
                 {% if options.parent.type is defined and options.parent.type is not empty %}
                     {% if options.parent.type == 'radio' %}
                         {{- form.radio_simple(input) -}}


### PR DESCRIPTION
This change allows button groups using the nested syntax (that pass an options array instead of passing full helpers as `items`) to either disable individual buttons, or all buttons.

## Disable all buttons
Pass `disabled` on the parent element to disable all children:

```twig
{{
    form.button_group({
        'label': 'Button group',
        'disabled': true,
        'items': [
            {
                'id': 'foo1',
                'label': 'Foo',
                'name': 'foo-1',
                'checked': true
            },
            {
                'id': 'bar1',
                'label': 'Bar',
                'name': 'foo-1'
            },
            {
                'id': 'baz1',
                'label': 'Baz',
                'name': 'foo-1'
            }
        ]
    })
}}
```

## Disable individual buttons
Pass `disabled` on a child in the `items` array to disable that button:

```twig
{{
    form.button_group({
        'label': 'Button group',
        'items': [
            {
                'id': 'foo1',
                'label': 'Foo',
                'name': 'foo-1',
                'checked': true
            },
            {
                'id': 'bar1',
                'label': 'Bar',
                'name': 'foo-1',
                'disabled': true,
            },
            {
                'id': 'baz1',
                'label': 'Baz',
                'name': 'foo-1'
            }
        ]
    })
}}
```

Closes #837 