### PR TITLE
Lock Timepicker to 1.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11877,9 +11877,9 @@
       }
     },
     "timepicker": {
-      "version": "1.13.9",
-      "resolved": "https://registry.npmjs.org/timepicker/-/timepicker-1.13.9.tgz",
-      "integrity": "sha512-km0OnVuKCjYjjUegCQ8VDn74ddUsGWuCT65fn6hdBHLCZ9SkowaNcw2xeIhCOgFBojFDBRp3uRhd04hyZfgFhQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/timepicker/-/timepicker-1.13.2.tgz",
+      "integrity": "sha512-6UKd1emYGMhH1b/stdbZauqvXRwKJW80ysz5uYN60kkRfEHfJrr0yqgtmoieOCL5XzkpOPrXqVZt2HRin6EJHQ==",
       "requires": {
         "jquery": ">=1.7"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11877,9 +11877,9 @@
       }
     },
     "timepicker": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/timepicker/-/timepicker-1.13.2.tgz",
-      "integrity": "sha512-6UKd1emYGMhH1b/stdbZauqvXRwKJW80ysz5uYN60kkRfEHfJrr0yqgtmoieOCL5XzkpOPrXqVZt2HRin6EJHQ==",
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/timepicker/-/timepicker-1.13.9.tgz",
+      "integrity": "sha512-km0OnVuKCjYjjUegCQ8VDn74ddUsGWuCT65fn6hdBHLCZ9SkowaNcw2xeIhCOgFBojFDBRp3uRhd04hyZfgFhQ==",
       "requires": {
         "jquery": ">=1.7"
       }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "pulsar-date-picker": "^1.0.0",
     "select2": "github:jadu/selectWoo#jadu-1.1.2",
     "spectrum-colorpicker": "^1.8.0",
-    "timepicker": "^1.13.9",
+    "timepicker": "1.13.2",
     "tippy.js": "^5.2.1",
     "vide": "^0.5.1"
   }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "pulsar-date-picker": "^1.0.0",
     "select2": "github:jadu/selectWoo#jadu-1.1.2",
     "spectrum-colorpicker": "^1.8.0",
-    "timepicker": "^1.13.2",
+    "timepicker": "^1.13.9",
     "tippy.js": "^5.2.1",
     "vide": "^0.5.1"
   }


### PR DESCRIPTION
Due to issues building JS related to other versions of timepicker, I'm going to temp lock to v1.13.2 until a better fix can be investigated.