### PR TITLE
Flatcap requirements for XFP

### DIFF
--- a/stylesheets/_component.choice.scss
+++ b/stylesheets/_component.choice.scss
@@ -3,21 +3,6 @@
     overflow: visible;
 }
 
-fieldset.form-choice {
-    padding: 0;
-
-    > .control__label {
-        border-bottom: 0;
-        float: left; // as we can't use inline-block
-        font-size: inherit;
-        line-height: inherit;
-    }
-
-    > .controls {
-        clear: left;
-    }
-}
-
 // Align form-choice to grid
 @include respond-min($screen-tablet) {
     .form-choice > .controls > .control__label {

--- a/stylesheets/_component.dropdowns.scss
+++ b/stylesheets/_component.dropdowns.scss
@@ -67,7 +67,8 @@
 
   // Links within the dropdown menu
   > li > a,
-  > li > .btn {
+  > li > .btn,
+  > li > span {
     background: none;
     border: 0;
     box-shadow: none;

--- a/stylesheets/_component.dropdowns.scss
+++ b/stylesheets/_component.dropdowns.scss
@@ -303,7 +303,7 @@
   }
 
   &.link--danger {
-    background-color: color(danger);
+    background-color: color(danger) !important;
     color: color(white) !important;
 
     &:hover {

--- a/stylesheets/_component.dropdowns.scss
+++ b/stylesheets/_component.dropdowns.scss
@@ -68,12 +68,12 @@
   // Links within the dropdown menu
   > li > a,
   > li > .btn {
-    background: none !important; // .btn styles are immutable
+    background: none;
     border: 0;
     box-shadow: none;
     border-radius: 0;
     clear: both;
-    color: $dropdown-link-color !important;
+    color: $dropdown-link-color;
     display: block;
     font-weight: normal;
     line-height: $line-height-base;
@@ -92,6 +92,9 @@
     }
   }
 
+  > li > .btn {
+    @extend .btn--white;
+  }
 }
 
 // Hover/Focus state
@@ -100,7 +103,7 @@
 .dropdown__menu > li > .btn:not(.is-disabled) {
   &:hover,
   &.active {
-    background-color: $dropdown-link-hover-bg !important;
+    background-color: $dropdown-link-hover-bg;
     box-shadow: 0;
     color: $dropdown-link-hover-color !important;
     text-decoration: none;
@@ -109,9 +112,8 @@
 
   &:focus {
     @include pulsar-dropdown-item-focused;
+    color: color(black) !important;
   }
-
-
 }
 
 // Active state
@@ -225,7 +227,7 @@
 
   &.link--primary {
     background-color: color(primary);
-    color: color(white);
+    color: color(white) !important;
 
     &:hover {
       background-color: darken(color(primary), 5%);
@@ -233,6 +235,7 @@
 
     &:focus {
       @include pulsar-dropdown-item-focused;
+      color: color(black) !important;
     }
 
     > .badge {
@@ -243,7 +246,7 @@
 
   &.link--success {
     background-color: color(success);
-    color: color(white);
+    color: color(white) !important;
 
     &:hover {
       background-color: darken(color(success), 5%);
@@ -251,6 +254,7 @@
 
     &:focus {
       @include pulsar-dropdown-item-focused;
+      color: color(black) !important;
     }
 
     > .badge {
@@ -261,7 +265,7 @@
 
   &.link--warning {
     background-color: color(warning);
-    color: color(white);
+    color: color(white) !important;
 
     &:hover {
       background-color: darken(color(warning), 5%);
@@ -269,6 +273,7 @@
 
     &:focus {
       @include pulsar-dropdown-item-focused;
+      color: color(black) !important;
     }
 
     > .badge {
@@ -279,7 +284,7 @@
 
   &.link--info {
     background-color: color(info);
-    color: color(white);
+    color: color(white) !important;
 
     &:hover {
       background-color: darken(color(info), 5%);
@@ -287,6 +292,7 @@
 
     &:focus {
       @include pulsar-dropdown-item-focused;
+      color: color(black) !important;
     }
 
     > .badge {
@@ -297,7 +303,7 @@
 
   &.link--danger {
     background-color: color(danger);
-    color: color(white);
+    color: color(white) !important;
 
     &:hover {
       background-color: darken(color(danger), 5%);
@@ -305,6 +311,7 @@
 
     &:focus {
       @include pulsar-dropdown-item-focused;
+      color: color(black) !important;
     }
 
     > .badge {
@@ -315,7 +322,7 @@
 
   &.link--inverse {
     background-color: color(inverse);
-    color: color(white);
+    color: color(white) !important;
 
     &:hover {
       background-color: darken(color(inverse), 5%);
@@ -323,6 +330,7 @@
 
     &:focus {
       @include pulsar-dropdown-item-focused;
+      color: color(black) !important;
     }
 
     > .badge {

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -746,14 +746,23 @@ fieldset.form__group--compound {
     padding: 0;
 }
 
-.form__group--compound {
-    > .control__label {
+// undo fieldset styling when fieldset/legend used for form__group and control__label
+fieldset.form__group {
+    padding: 0;
+
+    > legend.control__label {
         border-bottom: 0;
         float: left; // as we can't use inline-block
         font-size: inherit;
         line-height: inherit;
     }
 
+    > .controls {
+        clear: left;
+    }
+}
+
+.form__group--compound {
     > .controls {
         // override regular stacked styling
         > .form__control,

--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -198,6 +198,7 @@
 
     &:focus {
         @include pulsar-outline-button-focused;
+        border-width: 1px;
     }
 }
 

--- a/stylesheets/_component.notifications.scss
+++ b/stylesheets/_component.notifications.scss
@@ -88,7 +88,7 @@
 }
 
 .notifications-dismiss {
-    color: color(text, light);
+    color: color(text);
     display: inline-block;
     float: right;
     line-height: 1.75em;

--- a/stylesheets/_component.notifications.scss
+++ b/stylesheets/_component.notifications.scss
@@ -40,6 +40,11 @@
 .notifications-toggle {
     @extend %toolbar-icon;
 
+    // Fix an issue in CMS where legacy dropdowns create a duplicate caret in :before
+    &::before {
+        display: none;
+    }
+
     // the red dot indicator
     &.has-new::before {
         background-color: color(danger);

--- a/stylesheets/_component.panels.scss
+++ b/stylesheets/_component.panels.scss
@@ -102,6 +102,10 @@
             a:visited {
                 color: $state-color-alt !important;
             }
+
+            a:focus {
+                color: color(black) !important;
+            }
         }
     }
 }

--- a/stylesheets/_component.panels.scss
+++ b/stylesheets/_component.panels.scss
@@ -100,7 +100,7 @@
             a:hover,
             a:active,
             a:visited {
-                color: $state-color-alt;
+                color: $state-color-alt !important;
             }
         }
     }

--- a/stylesheets/_component.timeline.scss
+++ b/stylesheets/_component.timeline.scss
@@ -106,7 +106,7 @@
     }
 
     &--user {
-        background-color: color(jadu-green, base);
+        background-color: color(jadu-green, darkest);
         color: color(white);
     }
 

--- a/stylesheets/_component.toolbar.scss
+++ b/stylesheets/_component.toolbar.scss
@@ -46,7 +46,7 @@
 
         i {
             font-size: 18px;
-            vertical-align: middle;
+            vertical-align: text-bottom;
 
             @include respond-min($screen-desktop) {
                 font-size: 14px;

--- a/stylesheets/_component.toolbar.scss
+++ b/stylesheets/_component.toolbar.scss
@@ -59,18 +59,18 @@
             }
         }
 
-        > .toolbar-action__text {
-            display: none;
-            margin-left: 0;
-
-            @include respond-min($screen-desktop) {
-                display: inline;
-                margin-left: 5px;
-            }
-        }
-
         > .caret {
             border-top-color: color(text);
+        }
+    }
+
+    .toolbar-action__text {
+        display: none;
+        margin-left: 0;
+
+        @include respond-min($screen-desktop) {
+            display: inline;
+            margin-left: 5px;
         }
     }
 

--- a/stylesheets/_component.toolbar.scss
+++ b/stylesheets/_component.toolbar.scss
@@ -44,9 +44,14 @@
             transform: none;
         }
 
+        &:focus {
+            @include pulsar-outline-button-focused;
+            border-width: 1px;
+        }
+
         i {
             font-size: 18px;
-            vertical-align: text-bottom;
+            vertical-align: middle;
 
             @include respond-min($screen-desktop) {
                 font-size: 14px;

--- a/stylesheets/_config.variables.scss
+++ b/stylesheets/_config.variables.scss
@@ -221,9 +221,9 @@ $zindex-footer:                       1020 !default;
 $zindex-tooltip:                      1055 !default;
 $zindex-sticky:                       1060 !default;
 $zindex-dropdown:                     1060 !default;
+$zindex-flash:                        1065 !default;
 $zindex-nav-secondary:                1070 !default;
 $zindex-nav:                          1080 !default;
-$zindex-flash:                        1085 !default;
 $zindex-popover:                      1090 !default;
 $zindex-modal:                        3000 !default;
 

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-error.html
@@ -1,4 +1,4 @@
-<div class="form__group has-error form__button-group">
+<fieldset class="form__group has-error form__button-group">
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -8,4 +8,4 @@
         <label class="control__label">MW</label>
         <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-guidance-container.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-guidance-container.html
@@ -1,5 +1,5 @@
-<div class="form__group form__button-group">
-    <label class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" data-toggle="popover" data-autoclose="true" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></label>
+<fieldset class="form__group form__button-group">
+    <legend class="control__label">foo <i data-container="baz" data-content="bar" data-placement="top" data-toggle="popover" data-autoclose="true" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></legend>
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -8,4 +8,4 @@
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-guidance.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-guidance.html
@@ -1,5 +1,5 @@
-<div class="form__group form__button-group">
-    <label class="control__label">foo <i data-container="body" data-content="bar" data-placement="top" data-toggle="popover" data-autoclose="true" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></label>
+<fieldset class="form__group form__button-group">
+    <legend class="control__label">foo <i data-container="body" data-content="bar" data-placement="top" data-toggle="popover" data-autoclose="true" aria-hidden="true" class="icon-question-sign input-group-guidance"></i></legend>
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -8,4 +8,4 @@
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-help.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-help.html
@@ -1,4 +1,4 @@
-<div class="form__group form__button-group">
+<fieldset class="form__group form__button-group">
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -8,4 +8,4 @@
         <label class="control__label">MW</label>
         <span class="help-block" id="guid-1">my help text</span>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-label-hide.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-label-hide.html
@@ -1,5 +1,5 @@
-<div class="form__group form__button-group">
-    <label class="control__label hide">foo</label>
+<fieldset class="form__group form__button-group">
+    <legend class="control__label hide">foo</legend>
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -8,4 +8,4 @@
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-label.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-label.html
@@ -1,5 +1,5 @@
-<div class="form__group form__button-group">
-    <label class="control__label">Band</label>
+<fieldset class="form__group form__button-group">
+    <legend class="control__label">Band</legend>
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -8,4 +8,4 @@
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-type_button.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-type_button.html
@@ -1,7 +1,7 @@
-<div class="form__group form__button-group">
+<fieldset class="form__group form__button-group">
     <div class="controls btn__group">
         <button name="bands" class="btn">AM</button>
         <button name="bands" class="btn">FM</button>
         <button name="bands" class="btn">MW</button>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-type_checkbox.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-type_checkbox.html
@@ -1,4 +1,4 @@
-<div class="form__group form__button-group">
+<fieldset class="form__group form__button-group">
     <div class="controls btn__group">
         <input name="bands" type="checkbox" class="form__control checkbox" />
         <label class="control__label">AM</label>
@@ -7,4 +7,4 @@
         <input name="bands" type="checkbox" class="form__control checkbox" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-type_radio.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-type_radio.html
@@ -1,4 +1,4 @@
-<div class="form__group form__button-group">
+<fieldset class="form__group form__button-group">
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -7,4 +7,4 @@
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group.html
@@ -1,4 +1,4 @@
-<div class="form__group form__button-group">
+<fieldset class="form__group form__button-group">
     <div class="controls btn__group">
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">AM</label>
@@ -7,4 +7,4 @@
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">MW</label>
     </div>
-</div>
+</fieldset>

--- a/views/lexicon/tabs/panels.html.twig
+++ b/views/lexicon/tabs/panels.html.twig
@@ -82,7 +82,7 @@
 
     {{
         html.panel({
-            'title': 'Default panel',
+            'title': 'Default panel padded',
             'class': 'panel--padded centered',
             'body': 'What you wanna ball with the kid
     Watch your step you might fall
@@ -189,8 +189,8 @@
                         <div class="timeline-content__inner"><span class="timeline-content__title">Alex Bearing (Editor):</span>
                         <div class="timeline-content__date">
                             {{ html.icon('clock-o', {'class': 'icon--info u-hidden-print', 'label': 'Time of message'}) }}
-                            <time class="u-visible-print-inline">10 Mar 2018, 10:01 AM</time>
-                            <time class="timeago u-hidden-print" datetime="Thu, 10 Mar 2018 10:01:04 +0100" data-timezone="Europe/London"> Thursday 29th March 2018 (11:59)</time>
+                            <p class="u-visible-print-inline">10 Mar 2018, 10:01 AM</p>
+                            <time class="timeago u-hidden-print" data-timeago="Tue, 17 Mar 2020 10:48:24 +0000" datetime="2020-03-17 10:03:24" data-timezone="Europe/London">Tuesday, 17 March 2020 10:48</time>
                         </div>
                         <div class="timeline-content__body" data-id="2650349">
                             <p id="message-120530" class="timeline-content__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut congue felis aliquet, sodales leo vitae, lacinia diam. Pellentesque nec tincidunt justo, at viverra eros. Donec laoreet, neque ac consectetur auctor, nisi tellus pretium ante, at tincidunt velit nunc et ante. In placerat mi vel nunc viverra, a ultrices est facilisis. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aliquam libero ex, sollicitudin sit amet molestie porta, ultricies a mauris. Integer condimentum imperdiet risus, ac tincidunt nisi faucibus ac. Quisque non congue augue, id ultrices ipsum. Nunc finibus urna diam, in luctus lectus viverra vitae. Mauris ligula diam, aliquam nec nisi id, posuere fringilla leo. Aenean varius felis metus, eu interdum odio suscipit id. Sed tellus mi, laoreet non lacinia ac, maximus eu sem.

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -73,6 +73,9 @@ items         | array  | An array of items to put in the dropdown list (usually 
         {% set options = options|defaults({'aria-describedby': describedByIds|join(' ')}) %}
     {% endif %}
 
+    {% set containerTag = 'fieldset' %}
+    {% set labelTag = 'legend' %}
+
     {# If error is preset add aria-invalid="true" and aria-describedby to all inputs #}
     {% set items = options.items %}
 
@@ -98,7 +101,7 @@ items         | array  | An array of items to put in the dropdown list (usually 
         form.group({
             'parent': options
                 |only('bare class error error_ids guidance guidance-container has_error help help_id id label required show-label type')
-                |merge({'class': options.class|default ~ ' form__button-group'}),
+                |merge({'class': options.class|default ~ ' form__button-group', 'containerTag' : containerTag, 'labelTag': labelTag }),
             'controls': {'class': 'btn__group'},
             'inputs': items
         })
@@ -1293,6 +1296,7 @@ controls.class    | string | A space separated list of class names
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 
     {% set groupClass = 'form__group' %}
+    {% set containerTag = 'div' %}
     {% set labelTag = 'label' %}
 
     {% if options.parent.error is defined and options.parent.error is not empty %}
@@ -1308,6 +1312,10 @@ controls.class    | string | A space separated list of class names
         {% set showLabel = false %}
     {% endif %}
 
+    {% if options.parent.containerTag is defined and options.parent.containerTag is not empty %}
+        {% set containerTag = options.parent.containerTag %}
+    {% endif %}
+
     {% if options.parent.labelTag is defined and options.parent.labelTag is not empty %}
         {% set labelTag = options.parent.labelTag %}
     {% endif %}
@@ -1318,12 +1326,13 @@ controls.class    | string | A space separated list of class names
     {% endif %}
 
     {% if options.parent.bare is not defined or options.parent.bare != true %}
-    <div{{
+    <{{
         attributes(options.parent
                 |only('class aria-describedby')
                 |defaults({
                     'class': groupClass
-                })
+                }),
+                {'tag': containerTag}
             )
     -}}>
     {% endif %}
@@ -1450,7 +1459,7 @@ controls.class    | string | A space separated list of class names
         </label>
         {% endif %}
     {% if options.parent.bare is not defined or options.parent.bare != true %}
-    </div>
+    </{{ containerTag }}>
     {% endif %}
 
 {% endmacro %}

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -101,7 +101,7 @@ items         | array  | An array of items to put in the dropdown list (usually 
         form.group({
             'parent': options
                 |only('bare class error error_ids guidance guidance-container has_error help help_id id label required show-label type')
-                |merge({'class': options.class|default ~ ' form__button-group', 'containerTag' : containerTag, 'labelTag': labelTag }),
+                |merge({'class': options.class|default ~ ' form__button-group', 'containerTag': containerTag, 'labelTag': labelTag }),
             'controls': {'class': 'btn__group'},
             'inputs': items
         })


### PR DESCRIPTION
# Choice helper fieldset change

This branch cherry-picks the fieldset changes to choice helpers introduced in #1093

# Flash message z-index

The flash message DOM position changed, this restores the appropriate zindex and stops the flash appearing above the secondary navigation. Closes #1233 

**After**
![Screenshot 2020-05-21 at 11 50 51](https://user-images.githubusercontent.com/18653/82552103-62c9ac00-9b59-11ea-83da-ffa1486b2151.png)

This branch also includes the choice group to fieldset changes so they can both be tested in CMS at the same time,

# Danger links in dropdown buttons

**Before**
![btn-before](https://user-images.githubusercontent.com/18653/82653604-602d8c00-9c17-11ea-99e7-4331e03f510a.gif)

**After**
![btn-after](https://user-images.githubusercontent.com/18653/82653619-6459a980-9c17-11ea-8c8c-1b511d85956d.gif)

# Toolbar focus styles

Fixes #1230, All buttons adopt the standard focus style, focusing the menu button no longer causes the search bar to move.

![toolbarfocus](https://user-images.githubusercontent.com/18653/83001246-6484eb00-a003-11ea-9773-a8a850c6b5fd.gif)


