### PR TITLE
Remove 99% width constraint from textareas

### DIFF
--- a/stylesheets/_structure.forms.scss
+++ b/stylesheets/_structure.forms.scss
@@ -139,10 +139,6 @@
     }
 }
 
-.controls > .textarea {
-    max-width: 99%; // take into account any textarea border which might look like it’s overlapping at 100% width
-}
-
 // at narrow viewports, forms collapse into a single column view
 @include respond-max($screen-smaller) {
     .form__group {


### PR DESCRIPTION
The code comment related to this was:

```// take into account any textarea border which might look like it’s overlapping at 100% width```

Suspect this was a holdout from an older version of Pulsar which used thicker borders on input elements, maybe combined with older IE versions with larger scrollbars... either way, I can't see a legit reason for this to exist anymore.

Closes #1229