### PR TITLE
Stop focused nav items being obscured by hovered items

### DIFF
--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -376,6 +376,8 @@
 
         &:focus {
             @include pulsar-link-focused;
+            position: relative;
+            z-index: $zindex-nav-secondary + 1;
         }
 
         &:active {


### PR DESCRIPTION
**Before**
![Screenshot 2020-05-29 at 11 40 25](https://user-images.githubusercontent.com/18653/83251528-a0ee4d80-a1a1-11ea-9494-e47d4c8d1826.png)

**After**
![Screenshot 2020-05-29 at 11 40 04](https://user-images.githubusercontent.com/18653/83251537-a481d480-a1a1-11ea-9386-9d6dc2baae5e.png)

This does reduce the visual area of the hovered item by a few px but the clickable hit target remains the same.

Closes #1236