### PR TITLE
Make indented fields adjust their total width by subtracting the label width

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -655,7 +655,6 @@ fieldset {
     &.form__group--indent .controls {
         @include respond-min($screen-tablet) {
             @include shrink($form-label-cols);
-            border: 1px solid red;
         }
     }
 

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -363,17 +363,6 @@ fieldset {
         @include col-span-width(4, 9);
     }
 
-    // When used inside a modal or repeater, default to full width
-    .modal,
-    .table__form {
-        .control__label + .controls > .form__control:not(.checkbox):not(.radio) {
-            &,
-            & + .select2 {
-                @include col-span-width(9, 9);
-            }
-        }
-    }
-
     // column variations
     @for $i from 1 through 9 {
         .control__label + .controls > .form__control:not(.checkbox):not(.radio).form__control-col--#{$i},

--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -363,6 +363,17 @@ fieldset {
         @include col-span-width(4, 9);
     }
 
+    // When used inside a modal or repeater, default to full width
+    .modal,
+    .table__form {
+        .control__label + .controls > .form__control:not(.checkbox):not(.radio) {
+            &,
+            & + .select2 {
+                @include col-span-width(9, 9);
+            }
+        }
+    }
+
     // column variations
     @for $i from 1 through 9 {
         .control__label + .controls > .form__control:not(.checkbox):not(.radio).form__control-col--#{$i},
@@ -639,6 +650,13 @@ fieldset {
     > .controls {
         margin-left: 0; // remove gutter
         width: 100%;
+    }
+
+    &.form__group--indent .controls {
+        @include respond-min($screen-tablet) {
+            @include shrink($form-label-cols);
+            border: 1px solid red;
+        }
     }
 
     > .controls > .control__label {

--- a/stylesheets/_structure.grid.scss
+++ b/stylesheets/_structure.grid.scss
@@ -69,6 +69,11 @@ $gutter_pc:     .5;
     margin-left: ($one_col * $num) + ($gutter_pc * ($num));
 }
 
+@mixin shrink($num) {
+    $one_col: (100% - ($gutter_pc * ($columns - 1))) / $columns;
+    width: (100% - (($one_col * $num) + ($gutter_pc * ($num))));
+}
+
 // indent an element using padding-left by a given number of columns
 @mixin push-padding($num) {
     $one_col: (100% - ($gutter_pc * ($columns - 1))) / $columns;


### PR DESCRIPTION
Chose to add a grid mixin for this as we're already doing a calculation for the control label, so this width calculation will obey the configured values for gutters and columns.

**Before**
(Vertical line here is an xScope guide, not a border visible in the UI)
![Screenshot 2020-06-01 at 10 27 41](https://user-images.githubusercontent.com/18653/83396046-3b919b00-a3f3-11ea-9656-9b05b2ae5e1c.png)
**After**
![Screenshot 2020-06-01 at 10 27 28](https://user-images.githubusercontent.com/18653/83396054-40564f00-a3f3-11ea-9dc4-655baf13024a.png)

Closes #1242 
