### PR TITLE
Datatables accessibility improvements

### DIFF
--- a/js/DataTables/dataTablesDrawCallback.js
+++ b/js/DataTables/dataTablesDrawCallback.js
@@ -5,6 +5,9 @@ module.exports.drawCallback = function () {
     // Only show pagination when needed
     pagination.toggle(this.api().page.info().pages > 1);
 
+    // Make pagination links appear as buttons to AT
+    pagination.find('.paginate_button').attr('role', 'button');
+
     // Add aria-current to current page number
     pagination.find('.paginate_button.current').attr('aria-current', 'true');
 

--- a/js/DataTables/dataTablesInitComplete.js
+++ b/js/DataTables/dataTablesInitComplete.js
@@ -1,5 +1,7 @@
 module.exports.initComplete = function () {
     let pagination = $(this).closest('.dataTables_wrapper').find('.dataTables_paginate');
 
-    pagination.wrap('<nav aria-label="Table pagination"></nav>');
+    if (this.api().page.info().pages > 1) {
+        pagination.wrap('<nav aria-label="Table pagination"></nav>');
+    }
 }

--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -242,7 +242,7 @@ PulsarUIComponent.prototype.initDataTables = function () {
 
         $(window).on('load resize', function () {
             component.styleTableOverflows($table);
-            
+
             // reset column widths so headers match the body
             $($.fn.dataTable.tables(true)).DataTable().columns.adjust();
         });
@@ -262,7 +262,7 @@ PulsarUIComponent.prototype.styleTableOverflows = function ($container) {
         tableVisibleWidth = $container.width();
 
     // Toggle right hand shadow, if overflowing to the right
-    if (tableFullWidth === tableVisibleWidth) {
+    if (Math.floor(tableFullWidth) === Math.floor(tableVisibleWidth)) {
         $container
             .removeClass('table--overflow-right');
     }

--- a/tests/js/web/DataTables/dataTablesDrawCallbackTest.js
+++ b/tests/js/web/DataTables/dataTablesDrawCallbackTest.js
@@ -1,7 +1,7 @@
 const { drawCallback } = require('../../../../js/DataTables/dataTablesDrawCallback'),
     $ = require('jquery');
 
-describe('datatablesDrawCallback', () => {
+describe('dataTablesDrawCallback', () => {
     const infoStub = sinon.stub().returns({
         pages: 666
     });
@@ -51,6 +51,14 @@ describe('datatablesDrawCallback', () => {
 
         expect($datatablePagination.find('.paginate_button.disabled').hasClass('u-display-none')).to.be.true;
     });
+
+    it('should add role="button" to pagination links', () => {
+        drawCallbackWithContext = drawCallback.bind($datatable);
+        drawCallbackWithContext();
+
+        expect($datatablePagination.find('.paginate_button.current').attr('role')).to.equal('button');
+        expect($datatablePagination.find('.paginate_button:contains("2")').attr('role')).to.equal('button');
+    })
 
     it('should add aria-labels to the numbered links', () => {
         drawCallbackWithContext = drawCallback.bind($datatable);

--- a/tests/js/web/DataTables/dataTablesInitCompleteTest.js
+++ b/tests/js/web/DataTables/dataTablesInitCompleteTest.js
@@ -1,7 +1,7 @@
 const { initComplete } = require('../../../../js/DataTables/dataTablesInitComplete'),
     $ = require('jquery');
 
-describe('datatablesInitComplete', () => {
+describe('dataTablesInitComplete', () => {
     let $body,
         $dataTableWrapper,
         $datatable,
@@ -13,20 +13,55 @@ describe('datatablesInitComplete', () => {
         $dataTableWrapper = $(`<div class="dataTables_wrapper"></div>`).appendTo($body);
         $datatable = $(`<div class="fake-table"></div>`).appendTo($dataTableWrapper);
         $datatablePagination = $(`<div class="dataTables_paginate"></div>`).appendTo($dataTableWrapper);
-
-        initCompleteWithContext = initComplete.bind($datatable);
-        initCompleteWithContext();
     });
 
     afterEach(() => {
         $body.empty()
     });
 
-    it('should wrap the datatable pagination in a nav element', () => {
-        expect($datatablePagination.parent().is('nav')).to.be.true;
+    describe('When the datatable has more than one page', () => {
+        beforeEach (() => {
+            const infoStub = sinon.stub().returns({
+                pages: 666
+            });
+
+            $datatable.api = sinon.stub().returns({
+                page: {
+                    info: infoStub
+                }
+            });
+
+            initCompleteWithContext = initComplete.bind($datatable);
+            initCompleteWithContext();
+        });
+
+        it('should wrap the datatable pagination in a nav element if there are pages', () => {
+            expect($datatablePagination.parent().is('nav')).to.be.true;
+        });
+
+        it('should add an accessible name to the wrapping nav element if there are pages', () => {
+            expect($datatablePagination.parent().attr('aria-label')).to.equal('Table pagination');
+        });
     });
 
-    it('should add an accessible name to the wrapping nav element', () => {
-        expect($datatablePagination.parent().attr('aria-label')).to.equal('Table pagination');
+    describe('When the datatable has less one or fewer pages', () => {
+        beforeEach (() => {
+            const infoStub = sinon.stub().returns({
+                pages: 0
+            });
+
+            $datatable.api = sinon.stub().returns({
+                page: {
+                    info: infoStub
+                }
+            });
+
+            initCompleteWithContext = initComplete.bind($datatable);
+            initCompleteWithContext();
+        });
+
+        it('should not wrap the datatable pagination in a nav element if there are no pages', () => {
+            expect($datatablePagination.parent().is('nav')).to.be.false;
+        });
     });
 });

--- a/tests/js/web/DataTables/dataTablesInitCompleteTest.js
+++ b/tests/js/web/DataTables/dataTablesInitCompleteTest.js
@@ -44,7 +44,7 @@ describe('dataTablesInitComplete', () => {
         });
     });
 
-    describe('When the datatable has less one or fewer pages', () => {
+    describe('When the datatable has one or fewer pages', () => {
         beforeEach (() => {
             const infoStub = sinon.stub().returns({
                 pages: 0

--- a/views/lexicon/tables/basic-scrolling.html.twig
+++ b/views/lexicon/tables/basic-scrolling.html.twig
@@ -3,6 +3,7 @@
 {% block tab_content %}
 
     <table class="table table--full table--horizontal">
+        <caption class="hide">A list of Servers</caption>
         <thead>
             <tr>
                 <th>Name</th>

--- a/views/lexicon/tables/basic.html.twig
+++ b/views/lexicon/tables/basic.html.twig
@@ -2,6 +2,7 @@
 
 {% block tab_content %}
     <table class="table table--full">
+        <caption class="hide">A list of Servers</caption>
         <thead>
             <tr>
                 <th>Name</th>

--- a/views/lexicon/tables/datatable-collapse.html.twig
+++ b/views/lexicon/tables/datatable-collapse.html.twig
@@ -1,6 +1,6 @@
 {% extends '@pulsar/pulsar/components/tab.html.twig' %}
 
-{% 
+{%
     set data = {
         'columns': [
             { 'title': 'Title' },
@@ -27,14 +27,14 @@
                 'Owner': 'James Cameron',
                 'Modified': '1991-07-01 12:34',
                 'Live': true,
-                'Visible': false 
+                'Visible': false
             },
             {
                 'Title': 'Conan the Barbarian',
                 'Owner': 'John Millius',
                 'Modified': '1982-04-02 12:34',
                 'Live': false,
-                'Visible': true 
+                'Visible': true
             },
             {
                 'Title': 'Predator',
@@ -209,12 +209,13 @@
 %}
 
 {% block tab_content %}
-    {{ 
+    {{
         html.datatable({
             'data-order': '[[ 3, "desc" ]]',
             'overflow': 'collapse',
-            'data': data
-        }) 
+            'data': data,
+            'caption': 'A list of films featuring Arnold Schwarzenegger'
+        })
     }}
 {% endblock tab_content %}
 
@@ -225,11 +226,11 @@
         <li>Table overflow collapses rows</li>
         <li>Automatic pagination</li>
     </ul>
-    <pre><code class="hljs">&#123;&#123; 
+    <pre><code tabindex="0" class="hljs">&#123;&#123;
     html.datatable(&#123;
         'data-order': '[[ 3, "desc" ]]',
         'data': data,
         'overflow': 'collapse'
-    &#125;) 
+    &#125;)
 &#125;&#125;</code></pre>
 {% endblock tab_sidebar %}

--- a/views/lexicon/tables/datatable-empty.html.twig
+++ b/views/lexicon/tables/datatable-empty.html.twig
@@ -1,6 +1,6 @@
 {% extends '@pulsar/pulsar/components/tab.html.twig' %}
 
-{% 
+{%
     set data = {
         'columns': [
             { 'title': 'Title' },
@@ -26,24 +26,25 @@
 %}
 
 {% block tab_content %}
-    {{ 
+    {{
         html.datatable({
             'data-empty-table': 'There are currently no Arnie films to display',
             'data-order': '[[ 3, "desc" ]]',
-            'data': data
-        }) 
+            'data': data,
+            'caption': 'A list of films featuring Arnold Schwarzenegger'
+        })
     }}
 {% endblock tab_content %}
 
 {% block tab_sidebar %}
     <h2>Empty DataTable</h2>
     <p>The 'no results' message is automatically shown, and can be customised with the `data-empty-table` attribute.</p>
-    <pre><code class="hljs">&#123;&#123; 
+    <pre><code tabindex="0" class="hljs">&#123;&#123;
     html.datatable(&#123;
         'class': 'table--full table--horizontal',
         'data-empty-table': 'There are currently no Arnie films to display',
         'data-order': '[[ 3, "desc" ]]',
         'data': data
-    &#125;) 
+    &#125;)
 &#125;&#125;</code></pre>
 {% endblock tab_sidebar %}

--- a/views/lexicon/tables/datatable.html.twig
+++ b/views/lexicon/tables/datatable.html.twig
@@ -1,6 +1,6 @@
 {% extends '@pulsar/pulsar/components/tab.html.twig' %}
 
-{% 
+{%
     set data = {
         'columns': [
             { 'title': 'Title' },
@@ -27,14 +27,14 @@
                 'Owner': 'James Cameron',
                 'Modified': '1991-07-01 12:34',
                 'Live': true,
-                'Visible': false 
+                'Visible': false
             },
             {
                 'Title': 'Conan the Barbarian',
                 'Owner': 'John Millius',
                 'Modified': '1982-04-02 12:34',
                 'Live': false,
-                'Visible': true 
+                'Visible': true
             },
             {
                 'Title': 'Predator',
@@ -214,7 +214,8 @@
             'data-order': '[[ 3, "desc" ]]',
             'data': data,
             'data-select': 'false',
-            'data-length-change': 'true'
+            'data-length-change': 'true',
+            'caption': 'A list of films featuring Arnold Schwarzenegger'
         })
     }}
 {% endblock tab_content %}
@@ -226,7 +227,7 @@
         <li>Table overflow scrolls horizontally</li>
         <li>Automatic pagination</li>
     </ul>
-    <pre><code class="hljs">&#123;&#123;
+    <pre><code tabindex="0" class="hljs">&#123;&#123;
     html.datatable(&#123;
         'class': 'table--full',
         'data-order': '[[ 3, "desc" ]]',

--- a/views/lexicon/tables/sortable.html.twig
+++ b/views/lexicon/tables/sortable.html.twig
@@ -2,6 +2,7 @@
 
 {% block tab_content %}
     <table class="table is-sortable table--full">
+        <caption class="hide">A sortable list of files</caption>
         <thead>
             <tr>
                 <th>File title</th>
@@ -245,6 +246,7 @@
 
     <br/>
     <table class="table is-sortable table--full">
+        <caption class="hide">Another sortable list of files</caption>
         <thead>
             <tr>
                 <th>File title</th>

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1579,8 +1579,11 @@ Datatable - https://jadu.github.io/pulsar/components/datatable/
 
     {% if options.data is defined and options.data is not empty %}
     <table{{ attributes(options
-                |exclude('overflow')
+                |exclude('overflow caption')
                 |defaults({ 'class': 'table datatable table--full' })) }} style="width: 100%">
+        {% if options.caption is defined and options.caption is not empty %}
+        <caption class="hide">{{ options.caption }}</caption>
+        {% endif %}
         <thead>
             <tr>
                 {% if overflow == 'collapse' %}
@@ -1605,7 +1608,7 @@ Datatable - https://jadu.github.io/pulsar/components/datatable/
                     {% if overflow == 'collapse' %}
                         <td class="table-responsive">
                             <button class="table-child-toggle">
-                                {{ html.icon('plus-sign', { 'label': 'Toggle collapsed columns' }) }}
+                                {{ html.icon('plus-sign', { 'label': 'Toggle this rows collapsed columns' }) }}
                             </button>
                         </td>
                     {% endif %}


### PR DESCRIPTION
This PR resolves the following issues found while a11y auditing lexicon datatables examples:

1. Scrollable/overflowing tables incorrectly displayed the overflow gradient styles on load when no overflow was present
2. Table pagination nav landmark was present in the DOM when there were no pagination links, resulting in SR users being able to jump/nagivate to the empty navigation
3. Pagination links were read as "group" in SRs. They now announce as Buttons
4. Collapsed row toggle button label wasn't clear (read as if it would expand all collapsed columns for the table)
5. `html.datatable` helper did not allow for table captions
6. Added table captions to lexicon examples
7. Scrollable code examples in lexicon sidebar where not keyboard accessible


TODO: documentation change to highlight new `html.datatable` `caption` option.