### PR TITLE
Improve alignment of page selections with settings UI

### DIFF
--- a/stylesheets/_layout.settings.scss
+++ b/stylesheets/_layout.settings.scss
@@ -447,9 +447,23 @@
     table-layout: auto;
 }
 
+.content-actions__pages .control__label {
+    display: inline;
+    padding: 0;
+    vertical-align: unset;
+    width: auto;
+}
+
+// Match height of inputs to the expected height of buttons
 .content-actions__pages .form__control {
-    height: $input-height-small;
-    line-height: $input-height-small;
+    height: 35px;
+    line-height: 35px;
+}
+
+// Adjust position of caret to match new height and set enough padding so page numbers look nicer
+.content-actions__pages .form__control.select {
+    background-position: calc(100% - 10px) calc(10px + 5px), calc(100% - 5px) calc(10px + 5px), 100% 0;
+    padding-right: 32px;
 }
 
 .content-actions__buttons {

--- a/views/playground/branding/branding.html.twig
+++ b/views/playground/branding/branding.html.twig
@@ -173,17 +173,17 @@
 
         <div class="content-actions">
             <div class="content-actions__pages">
-                Page
-                    {{
-                        form.select({
-                            'id': 'pageSelection',
-                            'options': {
-                                'page1': '1',
-                                'page2': '2',
-                                'page3': '3'
-                            }
-                        })
-                    }}
+                {{
+                    form.select({
+                        'id': 'pageSelection',
+                        'label': 'Page',
+                        'options': {
+                            'page1': '1',
+                            'page2': '2',
+                            'page3': '3'
+                        }
+                    })
+                }}
                 of 3
             </div>
             <nav class="content-actions__buttons">

--- a/views/playground/branding/index.html.twig
+++ b/views/playground/branding/index.html.twig
@@ -13,6 +13,10 @@
     {% include 'playground/branding/tab_branding.html.twig' %}
 {% endset %}
 
+{% set tab_branding_two %}
+    {% include 'playground/branding/branding.html.twig' %}
+{% endset %}
+
 {%
     set tabs_content = [
         {
@@ -29,12 +33,12 @@
         {
           "id"    : "webhooks",
           "label" : "Webhooks",
-          "src"   : tab_branding
+          "src"   : tab_branding_two
         },
         {
           "id"    : "integrations",
           "label" : "Integrations",
-          "src"   : tab_branding
+          "src"   : tab_branding_two
         }
     ]
 %}


### PR DESCRIPTION
This change: 
* increases the height of the select element to match the expected height of buttons
* moves the caret position to match the new height (I could've calculated this based on the button padding vars but it didn't feel right using them here)
* adds additional padding on the right of the select element to improve how page numbers look (we don't have extra padding on the selects so we can sensibly cope with long options at narrow grid widths, but here it's always page numbers so is desired)
* adds support for the select label as provided in the original issue ticket.

**Before**
![](https://user-images.githubusercontent.com/9383439/83408240-35f37f80-a40a-11ea-8bfd-d1e4d67a082f.png)

**After**
![Screenshot 2020-06-02 at 08 46 53](https://user-images.githubusercontent.com/18653/83496050-6beb3f00-a4b0-11ea-9c88-61b1d70c9fd6.png)
Closes #1246 
