### PR TITLE
Ensure interactive elements in closed mobile sidebar cannot be focussed or seen by SRs

### DIFF
--- a/js/HelpTextComponent.js
+++ b/js/HelpTextComponent.js
@@ -176,7 +176,7 @@ HelpTextComponent.prototype.toggleChildElementInteractivity = function ($contain
     if (interactive === true) {
         $container.find(focusableElements).removeAttr('tabindex');
     } else {
-        $container.find(focusableElements).attr('tabindex', "-1");
+        $container.find(focusableElements).attr('tabindex', '-1');
     }
 }
 

--- a/js/HelpTextComponent.js
+++ b/js/HelpTextComponent.js
@@ -34,6 +34,9 @@ HelpTextComponent.prototype.init = function () {
         component.toggleHelpSidebar();
     });
 
+    // Make mobile help container child element non-interactive
+    component.toggleChildElementInteractivity($tabHelpContainer, false);
+
     // Bind to tab.js event to update help text in sidebar on tab change
     component.$html.find('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
         component.updateHelpSidebar();
@@ -47,8 +50,10 @@ HelpTextComponent.prototype.toggleHelpSidebar = function () {
 
     if ($mobileToggleHelpButton.hasClass('is-open')) {
         $mobileToggleHelpButton.removeClass('is-open');
+        component.toggleChildElementInteractivity($tabHelpContainer, false);
     } else {
         $mobileToggleHelpButton.addClass('is-open');
+        component.toggleChildElementInteractivity($tabHelpContainer, true);
     }
 
     if (component.$html.hasClass('open-help')) {
@@ -122,6 +127,9 @@ HelpTextComponent.prototype.updateHelpSidebar = function () {
 
             // Add mobile help close button
             $(mobileCloseHelpButton).prependTo($tabHelp);
+
+            // Hide mobile sidebar interactive elements from a11y tree while closed
+            component.toggleChildElementInteractivity($tabHelp, false);
         }
 
         // Watch for window resizes
@@ -132,6 +140,9 @@ HelpTextComponent.prototype.updateHelpSidebar = function () {
 
                 // Add mobile help close button
                 $(mobileCloseHelpButton).prependTo($tabHelp);
+
+                // Hide mobile sidebar interactive elements from a11y tree while closed
+                component.toggleChildElementInteractivity($tabHelp, false);
             }
         });
     } else {
@@ -144,7 +155,7 @@ HelpTextComponent.prototype.updateHelpSidebar = function () {
  */
 HelpTextComponent.prototype.handleFocusOut = function (e) {
     var component = this;
-    
+
     if (component.$html.hasClass('open-help')) {
         // Using timeout due to :focus return body when an element loses focus before new element gains focus
         setTimeout(() => {
@@ -153,6 +164,19 @@ HelpTextComponent.prototype.handleFocusOut = function (e) {
                 component.toggleHelpSidebar();
             }
         }, 1);
+    }
+}
+
+/**
+ * Toggle focusability of elements
+ */
+HelpTextComponent.prototype.toggleChildElementInteractivity = function ($container, interactive) {
+    var focusableElements = 'a[href], button';
+
+    if (interactive === true) {
+        $container.find(focusableElements).removeAttr('tabindex');
+    } else {
+        $container.find(focusableElements).attr('tabindex', "-1");
     }
 }
 

--- a/tests/js/web/HelpTextComponentTest.js
+++ b/tests/js/web/HelpTextComponentTest.js
@@ -24,7 +24,7 @@ describe('HelpTextComponent', function() {
         this.$tabContainer = $('<div class="tab__container"></div>').appendTo(this.$tabPane)
         this.$tabContent = $('<div class="tab__content"></div>').appendTo(this.$tabContainer);
         this.$tabContentLink = $('<a href="#">link outside of sidebar</a>').appendTo(this.$tabContent);
-        this.$tabSidebar = $('<div class="tab__sidebar">Some help text</div>').appendTo(this.$tabContainer);
+        this.$tabSidebar = $('<div class="tab__sidebar">Some help text <a href="#">link</a></div>').appendTo(this.$tabContainer);
 
         this.helpTextComponent = new HelpTextComponent(this.$html, this.window, this.$document[0]);
     });
@@ -46,7 +46,7 @@ describe('HelpTextComponent', function() {
         });
 
         it('should copy the active tabs sidebar contents to the tab-help container', function() {
-            expect(this.$tabHelp.html()).to.equal('<button class="close-page-help js-close-page-help"><i class="icon-remove-sign" aria-hidden="true"></i><span class="hide">Close on-page help</span></button>Some help text');
+            expect(this.$tabHelp.html()).to.equal('<button class="close-page-help js-close-page-help" tabindex="-1"><i class="icon-remove-sign" aria-hidden="true"></i><span class="hide">Close on-page help</span></button>Some help text <a href="#" tabindex="-1">link</a>');
         });
 
         it('should add the help-close button to the tab-help container', function() {
@@ -55,6 +55,10 @@ describe('HelpTextComponent', function() {
 
         it('should add the help toggle button to the toolbar', function() {
             expect(this.$toolbar.find('.js-show-page-help').length).to.equal(1);
+        });
+
+        it('should add tabindex="-1" to all links and buttons', function () {
+            expect(this.$tabHelp.find('a').attr('tabindex')).to.equal('-1')
         });
     });
 
@@ -102,8 +106,14 @@ describe('HelpTextComponent', function() {
             sinon.spy(this.helpTextComponent, 'toggleHelpSidebar');
             this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
             this.$tabHelpContainer.trigger('transitionend');
-            
+
             expect(this.helpTextComponent.toggleHelpSidebar).to.have.been.called;
+        });
+
+        it('should remove tabindex="-1" from all links and buttons', function () {
+            this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
+
+            expect(this.$tabHelp.find('a').attr('tabindex')).to.be.undefined;
         });
     });
 
@@ -154,6 +164,10 @@ describe('HelpTextComponent', function() {
             this.$toolbar.find('.js-show-page-help').trigger(this.clickEvent);
 
             expect(this.$tabHelpContainer.attr('aria-hidden')).to.equal('true');
+        });
+
+        it('should add tabindex="-1" to all links and buttons', function () {
+            expect(this.$tabHelp.find('a').attr('tabindex')).to.equal('-1')
         });
     });
 
@@ -284,7 +298,7 @@ describe('HelpTextComponent', function() {
         });
 
         it('should copy the active tabs sidebar contents to the tab-help container', function() {
-            expect(this.$tabHelp.html()).to.equal('<button class="close-page-help js-close-page-help"><i class="icon-remove-sign" aria-hidden="true"></i><span class="hide">Close on-page help</span></button>Some help text');
+            expect(this.$tabHelp.html()).to.equal('<button class="close-page-help js-close-page-help" tabindex="-1"><i class="icon-remove-sign" aria-hidden="true"></i><span class="hide">Close on-page help</span></button>Some help text <a href="#" tabindex="-1">link</a>');
         });
 
         it('should add the help-close button to the tab-help container', function() {


### PR DESCRIPTION
This fixes an issue where links/buttons within the mobile help sidebar could be tabbed to and be seen/navigated to by screen readers.

Fixes #1247 