### PR TITLE
Improve contrast of notifications dismiss button

### DIFF
--- a/stylesheets/_component.notifications.scss
+++ b/stylesheets/_component.notifications.scss
@@ -17,6 +17,12 @@
         }
     }
 
+    // double chained to override specificity of default remove button
+    .remove-button.remove-button {
+        padding: $btn-padding-top $btn-padding-x $btn-padding-bottom;
+        position: absolute;
+        right: $btn-padding-x; // shift away from edge of notifications container
+    }
 }
 
 .notifications-container {

--- a/stylesheets/_component.remove-button.scss
+++ b/stylesheets/_component.remove-button.scss
@@ -9,18 +9,14 @@
 
     [class^="icon-"],
     [class*=" icon-"] {
-        color: color(gray, light);
+        color: color(black);
         font-size: 1.2em;
         vertical-align: middle;
     }
 
     &:hover {
+        @include pulsar-button-focused;
         transform: none;
-
-        [class^="icon-"],
-        [class*=" icon-"] {
-            color: color(black);
-        }
     }
 }
 


### PR DESCRIPTION
* Increase default contrast to meet AA
* Add missing focus styles
* Tweak position to cope with new button padding added to accommodate focus styles

**After (focused and non-focused)**
![Screenshot 2020-06-04 at 08 56 22](https://user-images.githubusercontent.com/18653/83731553-a4228700-a642-11ea-83c1-6d0060d6d240.png)

Closes #1250

