### PR TITLE
Fixed modal background issue

### DIFF
--- a/stylesheets/_layout.tabs.scss
+++ b/stylesheets/_layout.tabs.scss
@@ -41,7 +41,6 @@
     transform: none;
     transition: transform 500ms ease;
     width: 100%;
-    will-change: transform;
 
     @include respond-min($screen-desktop) {
         display: table-row;


### PR DESCRIPTION
This branch fixes an issue introduced in #1257 where `will-change: transform` was added to `.inner-wrapper`. This broke the display of modals (see below). Descendants of transformed elements can't be fixed per the [CSS Transforms spec](https://drafts.csswg.org/css-transforms/#ref-for-valdef-overflow-auto).

> A transformed element creates a containing block even for descendants that have been set to position: fixed. In other words, the containing block for a fixed-position descendant of a transformed element is the transformed element, not the viewport

Before fix:
![Screenshot 2020-06-26 at 15 53 50](https://user-images.githubusercontent.com/756393/85871925-ffb9dd80-b7c6-11ea-8266-49962a8ea6e4.png)

After fix:
![Screenshot 2020-06-26 at 15 55 21](https://user-images.githubusercontent.com/756393/85871952-08121880-b7c7-11ea-82bb-9bb92fad1ad2.png)

`will-change: transform` was incorrectly added in an attempt to increase animation performance of the mobile nav flyouts. Removing it has no adverse effects.