### PR TITLE
Allow a modal link to use the data-target attribute

### DIFF
--- a/js/PulsarFormComponent.js
+++ b/js/PulsarFormComponent.js
@@ -43,7 +43,7 @@ PulsarFormComponent.prototype.init = function () {
 
     // reinitialise select2 items when opening a modal to fix widths
     $('[data-toggle="modal"]').on('click', function (e) {
-        var $target = $($(e.target).attr('href')),
+        var $target = $($(e.target).attr('data-target')).length ? $($(e.target).attr('data-target')) : $($(e.target).attr('href')),
             $select2 = $target.find('.js-select2:not([data-init="false"])');
 
         $target.on('shown.bs.modal', function() {


### PR DESCRIPTION
This was previously reserved for buttons only.

`data-target` will take priority over `href`

Closes #1266 