### PR TITLE
Removed dropzone popover

### DIFF
--- a/views/lexicon/forms/dropzone.html.twig
+++ b/views/lexicon/forms/dropzone.html.twig
@@ -2,14 +2,13 @@
 
 {% block tab_content %}
     <h2 class="heading">DropZone</h2>
-
     {{
         html.dropzone({
             'class': 'lex-dropzone',
             'id': 'lexicon-dropzone',
-            'data-helper-content': '<h5>Multimedia</h5> <ul> <li>Images</li> <li>Video</li> <li>Audio</li> </ul> <h5>Text</h5> <ul> <li>Plain text</li> <li>Rich text</li> <li>Web page</li> </ul> <h5>Documents</h5> <ul> <li>Microsoft Word</li> <li>Microsoft Excel</li> <li>Open Document</li> <li>Open Office</li> <li>PDF</li> </ul>',
+            'data-helper-content': 'Images, Video, Audio, Plain text, Rich text, Web page, Microsoft Word, Microsoft Excel, Open Document, Open Office, PDF',
             'data-helper-container': 'body',
-            'data-helper-title': 'Accepted files',
+            'data-helper-title': 'Allowed files',
             'data-dropzone-max-files': '4',
             'data-dropzone-input-node-id': 'dropzone_input_hidden',
             'data-dropzone-idle-html': '<button class="dropzone__browse btn" aria-label="Browse files to upload">Browse Files</button>',

--- a/views/lexicon/tabs/popovers.html.twig
+++ b/views/lexicon/tabs/popovers.html.twig
@@ -5,11 +5,19 @@
 
 {% block tab_content %}
 
-      <p><button class="btn" data-toggle="popover" title="" data-content="And here's some amazing content. It's very engaging. right?" data-original-title="A Title">Toggle Demo Popover</button></p>
+    {{
+        flash.message({
+            'message': 'Deprecated due to lack of use and accessibility issues. Content should be displayed in a tooltip, modal or another alternative found.',
+            'type': 'warning',
+            'dismissable': false
+        })
+    }}
 
-      <p><button class="btn" data-toggle="popover" data-autoclose="true" title="Foo" data-content="Bar">Autoclose Popover</button></p>
+    <p class="u-margin-top--large"><button class="btn" data-toggle="popover" title="" data-content="And here's some amazing content. It's very engaging. right?" data-original-title="A Title">Toggle Demo Popover</button></p>
 
-      <p><button class="btn" rel="clickover" title="Foo" data-content="Bar">Legacy Clickover</button></p>
+    <p><button class="btn" data-toggle="popover" data-autoclose="true" title="Foo" data-content="Bar">Autoclose Popover</button></p>
+
+    <p><button class="btn" rel="clickover" title="Foo" data-content="Bar">Legacy Clickover</button></p>
 
 
 {% endblock tab_content %}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1507,10 +1507,8 @@ All DropZone options should be prefixed with `data-dropzone-`, for example `data
 
 Option                              | Type      | Description
 ----------------------------------- | --------- | ----------------------------------------------------
-data-helper-label                   | string    | The label for the default helper text popup
-data-helper-title                   | string    | The heading for the default helper text popup
-data-helper-content                 | string    | The content for the default helper text popup
-data-helper-container               | string    | The selector for the container of the helper text popup
+data-helper-title                   | string    | The heading for the default helper text
+data-helper-content                 | string    | The content for the default helper text
 data-dropzone-max-files             | string    | The maximum ammount of files a DropZone will accept
 data-dropzone-max-size              | string    | The combined file size limit of a group of files
 data-dropzone-idle-timer-duration   | string    | The duration
@@ -1545,17 +1543,9 @@ data-dropzone-file-node-type        | boolean   | Show file type in file html | 
             </div>
             <p class="dropzone__label">Drag &amp; Drop</p>
             <p class="dropzone__info">{{ idle|raw }}</p>
-
-            <p class="dropzone__help"
-               data-toggle="popover"
-               data-autoclose="true"
-               data-title="{{ options['data-helper-title']|default('Helper title')|raw }}"
-               data-content="{{ options['data-helper-content']|default('Helper content')|raw }}"
-               data-html="true"
-               data-placement="bottom"
-               data-container="{{ options['data-helper-container']|default('#' ~ options.id) }}"
-            >
-                {{ html.icon('question-sign') }} {{ options['data-helper-label']|default('Only certain file types are allowed') }}
+            <p class="dropzone__help">
+                {{ options['data-helper-title']|default('Helper title')|raw }}:
+                {{ options['data-helper-content']|default('Helper content')|raw }}
             </p>
         </div>
     {% endspaceless %}


### PR DESCRIPTION
As popover are due to be deprecated, this branch removes the popover found in the dropzone file uploader and replaces with plain text.

### Before:
![Screenshot 2020-06-30 at 14 00 48](https://user-images.githubusercontent.com/756393/86129167-2daa6500-bada-11ea-9155-6fa22ffcd8f1.png)

### After:
![Screenshot 2020-06-30 at 13 59 35](https://user-images.githubusercontent.com/756393/86129187-34d17300-bada-11ea-90dd-9ae07adec393.png)
