### PR TITLE
Resolve modal markup issues

### DIFF
--- a/stylesheets/_component.modals.scss
+++ b/stylesheets/_component.modals.scss
@@ -230,13 +230,12 @@
 
     .close,
     .download {
-        color: color(gray);
+        color: color(gray) !important;
         font-size: 1.4em;
-        padding: 18px;
         transition: color .1s ease;
 
         &:hover {
-            color: color(jadu-blue);
+            color: color(jadu-blue) !important;
         }
 
         &:focus {
@@ -245,13 +244,30 @@
     }
 
     .close {
+        border-radius: 0;
+        box-shadow: none;
         margin-right: 0;
         margin-top: 0;
+        padding: 17px;
+
+        &:active {
+            background: none;
+            top: 0;
+        }
+
+        &:hover {
+            transform: none;
+
+            &::after {
+                position: relative;
+            }
+        }
     }
 
     .download {
         border-right: 1px solid color(gray, off-white);
         float: right;
+        padding: 18px;
 
         @include ie-lte(9) {
             display: inline-block;

--- a/views/lexicon/tabs/modals.html.twig
+++ b/views/lexicon/tabs/modals.html.twig
@@ -1,14 +1,16 @@
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
 {% block tab_content %}
-<p><button class="btn" data-toggle="modal" data-target="#modalExample" class="btn">Launch Standard Modal via a button</button></p>
+<p><button class="btn" data-toggle="modal" data-target="#modalExample">Launch Standard Modal via a button</button></p>
+<p><button class="btn" data-toggle="modal" data-target="#modalTwo">Launch Danger Modal via a button</button></p>
+<p><button class="btn" data-toggle="modal" data-target="#modalThree">Launch Long Modal via a button</button></p>
 <p><a data-toggle="modal" href="#myFullScreenModal" class="btn">Launch Full Screen Modal</a></p>
 
 <div class="modal modal__example" id="modalExample" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modalExample-title" aria-describedby="modalExample-description">
     <div class="modal__dialog">
         <div class="modal__content">
             <div class="modal__header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close modal dialog"><span aria-hidden="true">&times;</span></button>
                 <h1 class="modal__title" id="modalExample-title">A simple example</h1>
             </div>
             <div class="modal__body">
@@ -23,30 +25,11 @@
     </div><!-- /.modal__dialog -->
 </div><!-- /.modal -->
 
-<div class="modal modal__example show" id="modalOne" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modalOne-title" aria-describedby="modalOne-description">
+<div class="modal modal--danger modal__example" id="modalTwo" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modalTwo-title" aria-describedby="modalTwo-description">
     <div class="modal__dialog">
         <div class="modal__content">
             <div class="modal__header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h1 class="modal__title" id="modalOne-title">A simple example</h1>
-            </div>
-            <div class="modal__body">
-                <p id="modalOne-description" class="hide">Here goes a short description (a couple of lines) about the modal's purpose, if needed.</p>
-                <p>The modal body might have instructions, a form, or other stuff.</p>
-            </div>
-            <div class="modal__footer">
-                <button type="button" class="btn btn--primary">Save Changes</button>
-                <button type="button" class="btn btn--naked" data-dismiss="modal">Cancel</button>
-            </div>
-        </div><!-- /.modal__content -->
-    </div><!-- /.modal__dialog -->
-</div><!-- /.modal -->
-
-<div class="modal modal--danger modal__example show" id="modalTwo" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modalTwo-title" aria-describedby="modalTwo-description">
-    <div class="modal__dialog">
-        <div class="modal__content">
-            <div class="modal__header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close modal dialog"><span aria-hidden="true">&times;</span></button>
                 <h1 class="modal__title" id="modalTwo-title"><i class="icon-warning-sign"></i> You're about to do something really, really bad</h1>
             </div>
             <div class="modal__body">
@@ -62,12 +45,12 @@
     </div><!-- /.modal__dialog -->
 </div><!-- /.modal -->
 
-<div class="modal fade" id="modalThree" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modalThree-title" aria-describedby="modalThree-description">
+<div class="modal" id="modalThree" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modalThree-title" aria-describedby="modalThree-description">
     <div class="modal__dialog">
         <div class="modal__content">
             <form>
                 <div class="modal__header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close dialog">&times;</button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close modal dialog"><span aria-hidden="true">&times;</span></button>
                     <h1 class="modal__title" id="modalThree-title">Standard modal</h1>
                 </div>
                 <div class="modal__body">
@@ -142,7 +125,7 @@
                 <div class="modal__image">
                     <p id="fullModal-description" class="hide">Here goes a short description (a couple of lines) about the modal's purpose, if needed.</p>
                     <figure class="scaled">
-                        <img class="scaled__image" src="../../../images/youtube.jpg" alt="Pexample image" />
+                        <img class="scaled__image" src="../../../images/youtube.jpg" alt="Example image" />
                     </figure>
                 </div>
             </div>

--- a/views/lexicon/tabs/modals.html.twig
+++ b/views/lexicon/tabs/modals.html.twig
@@ -83,7 +83,7 @@
     </div><!-- /.modal__dialog -->
 </div><!-- /.modal -->
 
-<div class="modal modal--full-screen fade" id="myFullScreenModal" tabindex="-1" role="dialog" aria-hidden="true" aria-labelledby="fullModal-title" aria-describedby="fullModal-description">
+<div class="modal modal--full-screen fade" id="myFullScreenModal" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="fullModal-title" aria-describedby="fullModal-description">
     <div class="modal__dialog">
         <div class="modal__content">
             <div class="modal__header">
@@ -95,10 +95,9 @@
 
                 <div class="modal__controls">
                     {{
-                        html.link({
-                            'href': '#',
+                        html.button({
                             'label': html.icon('times', {
-                                'label': 'Close'
+                                'label': 'Close modal dialog'
                             }),
                             'class': 'close',
                             'data-dismiss': 'modal',


### PR DESCRIPTION
This branch fixes the below markup issues found on the lexicon examples:

1. The modal X close button incorrectly had `aria-hidden="true"` and was missing an `aria-label`. `aria-label="Close modal dialog"` has been added to the button and the X wrapped in `<span aria-hidden="true">.
2. The full page modal used a link for the close button, this has been changed to a button and related styles added.
3. Full page modal example, incorrectly had `aria-hidden="true"` on the main `.modal` wrapper and was missing `aria-modal="true"`
4. The 2 modal example which were shown on page load have been hidden to prevent SR testing issues.
5. Redundant `fade` classes have been removed.

Documentation update to follow.
