### PR TITLE
Filterbar select2 placeholder and tab.js fixes

### DIFF
--- a/js/FilterBarComponent.js
+++ b/js/FilterBarComponent.js
@@ -60,7 +60,7 @@ function createFilterListButton ($filterbar) {
     });
 
     // Build up list and mark up for Add filter button
-    $addFilterButton = $('<button class="btn filter-bar__add" data-ui="show-filter-list" data-toggle="popover" data-trigger="click" title="Filter by" data-html="true" data-placement="bottom" data-content="" aria-haspopup="true"><i class="icon-plus"><span class="hide">Add</span></i></button>');
+    $addFilterButton = $('<button class="btn filter-bar__add" type="button" data-ui="show-filter-list" data-toggle="popover" data-trigger="click" title="Filter by" data-html="true" data-placement="bottom" data-content="" aria-haspopup="true"><i class="icon-plus"><span class="hide">Add</span></i></button>');
     $addFilterButton.attr('data-content', $filterList[0].outerHTML);
 
     // Append button and label wrapper
@@ -165,7 +165,7 @@ function showAddFilterPopover ($filterbar) {
 
             // Refresh the select2
             $select2 = $popoverContent.find('.js-select2:not([data-init="false"])');
-            select2Placeholder = $select2.attr('placeholder');
+            select2Placeholder = $select2.attr('data-placeholder');
             $select2.select2({placeholder: select2Placeholder});
 
             // Trigger popover with form field on added label
@@ -441,7 +441,11 @@ function populateFilterList ($filterbar) {
             filterValue = $filterField.val();
 
         if ($filterField.hasClass('select')) {
-            filterValue = $(':selected', $filterField).text();
+            if ($filterField.prop('multiple')) {
+                filterValue = $filterField.find('option:selected').toArray().map(item => item.text).join(', ');
+            } else if ($filterField.find('option:selected').val()) {
+                filterValue = $filterField.find('option:selected').text();
+            }
         }
 
         if ($filterField[0].type === 'checkbox') {
@@ -454,7 +458,7 @@ function populateFilterList ($filterbar) {
             filterLabel = filterLabel + ': ';
         }
 
-        if (filterValue !== '' && filterValue !== null) {
+        if (filterValue !== '' && filterValue !== null && filterValue.length !== 0) {
             $labelContainer.prepend('<span class="label label--large label--inverse label--removable" data-filter-id="' + filterId + '"><span class="label__text">' + filterLabel + filterValue + '</span><button type="button" data-ui="filter-cancel" class="btn remove-button" data-filter-id="'+ filterId +'"><i class="icon-remove-sign"></i></button></span>');
 
             // Keep track of how many filters have already been applied

--- a/js/HelpTextComponent.js
+++ b/js/HelpTextComponent.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('./libs/tab');
 var $ = require('jquery');
 
 function HelpTextComponent(html, window, document) {

--- a/js/PulsarFormComponent.js
+++ b/js/PulsarFormComponent.js
@@ -30,28 +30,6 @@ PulsarFormComponent.prototype.init = function () {
 
     // Time picker
     component.initTimePickers();
-
-    // reinitialise select2 items in a tab when the tab is focused to fix widths
-    $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-        var $target = $($(e.target).attr('href')),
-            $select2 = $target.find('.js-select2:not([data-init="false"])');
-
-        $.each($select2, function() {
-            component.initSelect2($(this));
-        });
-    });
-
-    // reinitialise select2 items when opening a modal to fix widths
-    $('[data-toggle="modal"]').on('click', function (e) {
-        var $target = $($(e.target).attr('data-target')).length ? $($(e.target).attr('data-target')) : $($(e.target).attr('href')),
-            $select2 = $target.find('.js-select2:not([data-init="false"])');
-
-        $target.on('shown.bs.modal', function() {
-            $.each($select2, function() {
-                component.initSelect2($(this));
-            });
-        });
-    });
 }
 
 /**
@@ -166,7 +144,7 @@ PulsarFormComponent.prototype.initColourpickers = function () {
             }
         });
 
-        // Remove the text input inside the picker, which we don't use and 
+        // Remove the text input inside the picker, which we don't use and
         // causes a11y issues if left in the markup
         component.$html.find('.sp-input-container').remove();
 

--- a/js/TabEnhancements/TabEnhancements.js
+++ b/js/TabEnhancements/TabEnhancements.js
@@ -1,0 +1,66 @@
+var $ = require('jquery');
+
+/**
+ * Enhance tab.js behaviour
+*/
+class TabEnhancements {
+    /**
+     * Initialise
+     * @param {jQuery} $html - a jQuery wrapper of the html node
+     */
+    init ($html) {
+        this.$html = $html;
+
+        if(typeof $.fn.tab === 'undefined') {
+            console.warn('PULSAR: tab.js must be loaded in order to use TabEnhacements.js');
+        }
+
+        // Make sure tab panes are at least as high as the tab list (cms legacy tabs list)
+        this.$html.find('.tabs > .tabs__content > .tab__pane').css('min-height', this.$html.find('.tabs__list').height());
+
+        // Switch the first active tab to use <main> with the skip target
+        this.changeActiveTabElementToMain(this.$html.find('.tab__pane.is-active'));
+
+
+        // Make the current tabs .tab__content <main> and the previous tabs .tab__content <div>
+        // to avoid multiple <main>'s in the DOM at one time
+        this.$html.find('.nav-inline [data-toggle="tab"]').on('show.bs.tab', (event) => {
+            const $activeTab = this.$html.find($(event.target).attr('href'));
+            const $previousTab = this.$html.find($(event.relatedTarget).attr('href'));
+
+            this.changeActiveTabElementToMain($activeTab);
+            this.changePreviousTabElementToDiv($previousTab);
+        });
+
+    }
+
+    /**
+     * Change the active tab's main element from a <div> to a <main> and add the skip target ID
+     * @param {jQuery} $activeTab - a jQuery wrapper of the newly active tab
+     */
+    changeActiveTabElementToMain($activeTab) {
+        const $activeTabInner = $activeTab.find('.tab__inner');
+        const $activeTabChildrenOfMain = $activeTab.find('.tab__content').contents();
+        const $activeTabNewMain = $('<main class="tab__content" id="skip-target"></main>').append($activeTabChildrenOfMain);
+        const $activeTabOldMain = $activeTab.find('.tab__content');
+
+        $activeTabOldMain.remove();
+        $activeTabNewMain.prependTo($activeTabInner);
+    }
+
+    /**
+     * Change the previous tab's main element from a <main> to a <div>
+     * @param {jQuery} $previousTab - a jQuery wrapper of the previously active tab
+     */
+    changePreviousTabElementToDiv($previousTab) {
+        const $previousTabInner = $previousTab.find('.tab__inner');
+        const $previousTabChildrenOfMain = $previousTab.find('.tab__content').contents();
+        const $previousTabNewMain = $('<div class="tab__content"></div>').append($previousTabChildrenOfMain);
+        const $previousTabOldMain = $previousTab.find('.tab__content');
+
+        $previousTabOldMain.remove();
+        $previousTabNewMain.prependTo($previousTabInner);
+    }
+}
+
+module.exports = TabEnhancements;

--- a/js/TabEnhancements/TabEnhancements.js
+++ b/js/TabEnhancements/TabEnhancements.js
@@ -21,7 +21,6 @@ class TabEnhancements {
         // Switch the first active tab to use <main> with the skip target
         this.changeActiveTabElementToMain(this.$html.find('.tab__pane.is-active'));
 
-
         // Make the current tabs .tab__content <main> and the previous tabs .tab__content <div>
         // to avoid multiple <main>'s in the DOM at one time
         this.$html.find('.nav-inline [data-toggle="tab"]').on('show.bs.tab', (event) => {

--- a/js/index.js
+++ b/js/index.js
@@ -49,7 +49,8 @@ var $                     = require('jquery'),
     ModalFocusService = require('./Modals/ModalFocusService'),
     ModalListener = require('./Modals/ModalListener'),
     datePicker = require('pulsar-date-picker'),
-    FocusManagementService = require('./FocusManagementService');
+    FocusManagementService = require('./FocusManagementService'),
+    TabEnhancements = require('./TabEnhancements/TabEnhancements');
 
 require('jstree');
 
@@ -78,5 +79,6 @@ module.exports = {
     ModalFocusService,
     ModalListener,
     datePicker,
-    FocusManagementService
+    FocusManagementService,
+    TabEnhancements
 };

--- a/js/libs/tab.js
+++ b/js/libs/tab.js
@@ -156,46 +156,4 @@ var $ = require('jquery');
 		}
 	});
 
-	$(document).ready(function() {
-		// Make sure tab panes are at least as high as the tab list (otherwise they just look weird)
-		$('.tabs > .tabs__content > .tab__pane').css('min-height', $('.tabs__list').height());
-
-		// Switch the first active tab to use <main> with the skip target
-		$('.tab__pane.is-active').find('.tab__content').replaceWith(function () {
-			return $('<main />', {
-				html: $(this).html(),
-				class: 'tab__content',
-				id: 'skip-target'
-			});
-		});
-
-		// Make the current tabs .tab__content <main> and the previous tabs .tab__content <div>
-		// to avoid multiple <main>'s in the DOM at one time
-		$('.nav-inline [data-toggle="tab"]').on('show.bs.tab', function (e) {
-			// New tab
-			// Get the contents of tab and move to newly created main.tab__content
-			// Then remove new tabs div.tab__content
-			var $newTab = $($(e.target).attr('href')),
-				$newTabInner = $newTab.find('.tab__inner'),
-				$newTabChildrenOfMain = $newTab.find('.tab__content').contents(),
-				$newTabNewMain = $('<main class="tab__content"></main>').append($newTabChildrenOfMain),
-				$newTabOldMain = $newTab.find('.tab__content');
-
-			$newTabOldMain.remove();
-			$newTabNewMain.prependTo($newTabInner);
-
-			// Previous tab
-			// Get contents of the tab and move to newly created div.tab__content
-			// then remove previous tabs main.tab__content
-			var $previousTab = $($(e.relatedTarget).attr('href')),
-				$previousTabInner = $previousTab.find('.tab__inner'),
-				$previousTabChildrenOfMain = $previousTab.find('.tab__content').contents(),
-				$previousTabNewMain = $('<div class="tab__content"></div>').append($previousTabChildrenOfMain),
-				$previousTabOldMain = $previousTab.find('.tab__content');
-
-			$previousTabOldMain.remove();
-			$previousTabNewMain.prependTo($previousTabInner);
-		});
-	});
-
 module.exports = Tab;

--- a/js/libs/tab.js
+++ b/js/libs/tab.js
@@ -168,27 +168,33 @@ var $ = require('jquery');
 				id: 'skip-target'
 			});
 		});
-		
+
+		// Make the current tabs .tab__content <main> and the previous tabs .tab__content <div>
+		// to avoid multiple <main>'s in the DOM at one time
 		$('.nav-inline [data-toggle="tab"]').on('show.bs.tab', function (e) {
-			var showTab = $(e.target).attr('href'),
-				hideTab = $(e.relatedTarget).attr('href');
+			// New tab
+			// Get the contents of tab and move to newly created main.tab__content
+			// Then remove new tabs div.tab__content
+			var $newTab = $($(e.target).attr('href')),
+				$newTabInner = $newTab.find('.tab__inner'),
+				$newTabChildrenOfMain = $newTab.find('.tab__content').contents(),
+				$newTabNewMain = $('<main class="tab__content"></main>').append($newTabChildrenOfMain),
+				$newTabOldMain = $newTab.find('.tab__content');
 
-			// Switch active tab to use <main> element
-			$(showTab).find('.tab__content').replaceWith(function () {
-				return $('<main />', {
-					html: $(this).html(),
-					class: 'tab__content',
-					id: 'skip-target'
-				});
-			});
+			$newTabOldMain.remove();
+			$newTabNewMain.prependTo($newTabInner);
 
-			// Switch tab being hidden to use <div>
-			$(hideTab).find('.tab__content').replaceWith(function () {
-				return $('<div />', {
-					html: $(this).html(),
-					class: 'tab__content'
-				});
-			});
+			// Previous tab
+			// Get contents of the tab and move to newly created div.tab__content
+			// then remove previous tabs main.tab__content
+			var $previousTab = $($(e.relatedTarget).attr('href')),
+				$previousTabInner = $previousTab.find('.tab__inner'),
+				$previousTabChildrenOfMain = $previousTab.find('.tab__content').contents(),
+				$previousTabNewMain = $('<div class="tab__content"></div>').append($previousTabChildrenOfMain),
+				$previousTabOldMain = $previousTab.find('.tab__content');
+
+			$previousTabOldMain.remove();
+			$previousTabNewMain.prependTo($previousTabInner);
 		});
 	});
 

--- a/js/main.js
+++ b/js/main.js
@@ -35,6 +35,7 @@
     );
     pulsar.modalFocusService = new pulsar.ModalFocusService();
     pulsar.modalListener = new pulsar.ModalListener(pulsar.modalFocusService);
+    pulsar.tabEnhancements = new pulsar.TabEnhancements(document);
 
     $(function () {
         pulsar.button.init();
@@ -74,6 +75,9 @@
 
         // Favicon editor
         pulsar.faviconEditor.init();
+
+        // Tab Enhacements
+        pulsar.tabEnhancements.init($html);
     });
 
 }(jQuery));

--- a/tests/js/web/FilterBarComponentTest.js
+++ b/tests/js/web/FilterBarComponentTest.js
@@ -16,7 +16,7 @@ describe('FilterBarComponent', function () {
 			'			<div class="form__group">' +
 			'				<label for="colour" class="control__label">Colour</label>' +
 			'				<div class="controls">' +
-			'					<select id="colour" multiple="" placeholder="Choose one or more" class="form__control select js-select2">' +
+			'					<select id="colour" multiple="" data-placeholder="Choose one or more" class="form__control select js-select2">' +
 			'						<option value="colour_red">Red</option>' +
 			'						<option value="colour_blue">Blue</option>' +
 			'					</select>' +
@@ -25,8 +25,8 @@ describe('FilterBarComponent', function () {
 			'			<div class="form__group">' +
 			'				<label for="size" class="control__label">Size</label>' +
 			'				<div class="controls">' +
-			'					<select id="size" placeholder="Choose one" class="form__control select js-select2">' +
-			'						<option value=""></option>' +
+			'					<select id="size" data-placeholder="Choose one" class="form__control select js-select2">' +
+			'						<option value="">Choose one</option>' +
 			'						<option value="small">Small</option>' +
 			'						<option value="medium">Medium</option>' +
 			'						<option value="large">Large</option>' +
@@ -492,29 +492,41 @@ describe('FilterBarComponent', function () {
 			this.$container.find('#foo').val('some value');
 			this.$container.find('#inStock').prop('checked', 'checked');
 			this.$container.find('#size').val('medium');
-			this.$container.find('#colour').val('colour_red');
-
-			this.filterBar.init();
-
 		});
 
 		it('should add a label to the filterbar for text inputs', function () {
+			this.filterBar.init();
+
 			expect(this.$container.find('span[data-filter-id="foo"]')).to.have.length(1);
 		});
 
 		it('should add a label to the filterbar for checkbox inputs', function () {
+			this.filterBar.init();
+
 			expect(this.$container.find('span[data-filter-id="inStock"]')).to.have.length(1);
 		});
 
 		it('should add a label to the filterbar for select inputs', function () {
+			this.filterBar.init();
+
 			expect(this.$container.find('span[data-filter-id="size"]')).to.have.length(1);
+			expect(this.$container.find('span[data-filter-id="size"]').text()).to.be.equal('Size: Medium');
 		});
 
-		it('should add a label to the filterbar for colour inputs', function () {
+		it('should add a comma separated label to the filterbar for select inputs with the multiple attribute', function () {
+			this.$container.find('#colour').val(['colour_red', 'colour_blue']);
+
+			this.filterBar.init();
+
 			expect(this.$container.find('span[data-filter-id="colour"]')).to.have.length(1);
+			expect(this.$container.find('span[data-filter-id="colour"]').text()).to.be.equal('Colour: Red, Blue');
 		});
 
 		it('should hide the add filter button if all filters have been used', function () {
+			this.$container.find('#colour').val(['colour_red', 'colour_blue']);
+
+			this.filterBar.init();
+
 			expect(this.$container.find('[data-ui="show-filter-list"]').hasClass('u-display-none')).to.be.true;
 		});
 	});

--- a/tests/js/web/PulsarFormComponentTest.js
+++ b/tests/js/web/PulsarFormComponentTest.js
@@ -160,36 +160,6 @@ describe('PulsarFormComponent', function() {
 
     });
 
-    describe('Changing to a tab that contains select2 elements', function() {
-
-        beforeEach(function() {
-            this.pulsarForm.init();
-            this.pulsarForm.initSelect2 = sinon.stub();
-            this.$tabToggle.trigger('shown.bs.tab');
-        });
-
-        it('Should trigger the select2 init method', function() {
-            expect(this.pulsarForm.initSelect2).to.have.been.called;
-        });
-    });
-
-    describe('Opening a modal that contains select2 elements', function() {
-
-        beforeEach(function() {
-            this.pulsarForm.init();
-            this.pulsarForm.initSelect2 = sinon.stub();
-            this.$modalToggle.click();
-            this.$modal.trigger('shown.bs.modal');
-        });
-
-        it('Should trigger the select2 init method', function(done) {
-            setTimeout(() => {
-                expect(this.pulsarForm.initSelect2).to.have.been.called;
-                done();
-            }, 500);
-        });
-    });
-
     describe('Clicking a choice block radio input', function() {
 
         beforeEach(function() {

--- a/tests/js/web/TabEnhancements/TabEnhancementsTest.js
+++ b/tests/js/web/TabEnhancements/TabEnhancementsTest.js
@@ -1,0 +1,145 @@
+import $ from 'jquery';
+import TabEnhancements from '../../../../js/TabEnhancements/TabEnhancements'
+
+describe('TabEnhancements', () => {
+    let $html;
+    let $body;
+    let $legacyTabs;
+    let $tabs;
+    let tabEnhancements;
+    let consoleWarnStub;
+
+    beforeEach(() => {
+        $html = $('html');
+        $body = $('body');
+
+        $legacyTabs = $(`
+            <div class="tabs" id="legacyTabs">
+                <div class="tabs__content">
+                    <div class="tab__pane"></div>
+                </div>
+            </div>
+            <div class="tabs__list" id="legacyTabsList"></div>
+        `).appendTo($body);
+
+        $tabs = $(`
+            <div class="tabs__content" id="currentTabs">
+                <nav class="nav-inline">
+                    <ul class="nav-inline__list">
+                        <li class="nav-inline__item nav-inline__item--is-active is-active">
+                            <a href="#tab1" data-toggle="tab" class="nav-inline__link" id="tabLink1">Tab one</a>
+                        </li>
+                        <li class="nav-inline__item">
+                            <a href="#tab2" data-toggle="tab" class="nav-inline__link" id="tabLink2">Tab two</a>
+                        </li>
+                    </ul>
+                </nav>
+
+                <div class="tab__pane is-active" id="tab1">
+                    <div class="tab__container">
+                        <div class="tab__inner">
+                            <div class="tab__content">
+                                <p>tab 1 content</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="tab__pane" id="tab2">
+                    <div class="tab__container">
+                        <div class="tab__inner">
+                            <div class="tab__content">
+                                <p>tab 2 content</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `).appendTo($body);
+
+        tabEnhancements = new TabEnhancements();
+    });
+
+    afterEach(() => {
+        $body.empty();
+    });
+
+    describe('init()', () => {
+        it('should console.warn if tab.js is not loaded', () => {
+            consoleWarnStub = sinon.stub(console, 'warn');
+            $.fn.tab = undefined;
+
+            tabEnhancements.init($html);
+
+            expect(consoleWarnStub).to.be.calledOnce;
+        });
+
+        it('should set the min-height of legacy tabs tab__pane to the height of tabs__list', () => {
+            const $legacyTabsPane = $body.find('#legacyTabs .tab__pane');
+            const $legacyTabsList = $body.find('#legacyTabsList');
+            $legacyTabsList.height(100);
+
+            tabEnhancements.init($html);
+
+            expect($legacyTabsPane.css('min-height')).to.be.equal('100px');
+        });
+    });
+
+    describe('When the page loads', () => {
+        beforeEach(() => {
+            tabEnhancements.init($html);
+        });
+
+        it('should change the active tabs main element to <main>', () => {
+            expect($body.find('#currentTabs #tab1 .tab__content').is('main')).to.be.true;
+        });
+
+        it('should add id="skip-target" to the active tabs <main>', () => {
+            expect($body.find('#currentTabs #tab1 .tab__content').attr('id')).to.equal('skip-target');
+        });
+    });
+
+    describe('When a new tab is shown', () => {
+        beforeEach(() => {
+            sinon.spy(tabEnhancements, 'changePreviousTabElementToDiv');
+
+            tabEnhancements.init($html);
+
+            $body.find('#tabLink2').trigger('show.bs.tab');
+        });
+
+        it('should change the active tabs main element to <main>', () => {
+            expect($body.find('#currentTabs #tab2 .tab__content').is('main')).to.be.true;
+        });
+
+        it('should add id="skip-target" to the active tabs <main>', () => {
+            expect($body.find('#currentTabs #tab2 .tab__content').attr('id')).to.equal('skip-target');
+        });
+
+        it('should copy the contents active tabs main element over to the the new <main>', () => {
+            expect($body.find('#currentTabs #tab2 .tab__content').html().trim()).to.equal('<p>tab 2 content</p>');
+        });
+
+        // Test event is missing event.relatedTarget so testing the method is called and behaviour separately
+        it('should reset the previous tab by calling changePreviousTabElementToDiv()', () => {
+            expect(tabEnhancements.changePreviousTabElementToDiv).to.have.been.calledOnce;
+        });
+
+        describe('changePreviousTabElementToDiv()', () => {
+            beforeEach(() => {
+                tabEnhancements.changePreviousTabElementToDiv($body.find('#tab1'));
+            });
+
+            it('should replace the previous tabs <main class="tab__content"> element with <div class="tab__content">', () => {
+                expect($body.find('#currentTabs #tab1 .tab__content').is('div')).to.be.true;
+            });
+
+            it('should remove the id="skip-target"', () => {
+                expect($body.find('#currentTabs #tab1 .tab__content').attr('id')).to.be.undefined;
+            });
+
+            it('should copy the content from the old <main> to the new <div>', () => {
+                expect($body.find('#currentTabs #tab1 .tab__content').html().trim()).to.equal('<p>tab 1 content</p>');
+            });
+        });
+    });
+});

--- a/views/lexicon/patterns/filters/create-filter.html.twig
+++ b/views/lexicon/patterns/filters/create-filter.html.twig
@@ -28,15 +28,29 @@
 
 {% block tab_content %}
 
-    <div class="filter-bar display--none">
+    <div class="filter-bar u-display-none">
         {{ form.create() }}
             {{ form.fieldset_start({'legend': 'Filter by'}) }}
 
                 {{
                     form.select2({
-                        'label': 'Colour',
-                        'id': 'colour-4',
+                        'label': 'Colour (single + ph)',
+                        'id': 'colour-' ~ random(),
+                        'data-placeholder': 'Select One',
+                        'options': {
+                            '': 'Select one',
+                            'colour_red': 'Red',
+                            'colour_blue': 'Blue'
+                        }
+                    })
+                }}
+
+                {{
+                    form.select2({
+                        'label': 'Colour 3 (multi + ph)',
+                        'id': 'colour-' ~ random(),
                         'multiple': true,
+                        'data-placeholder': 'Select one or more',
                         'options': {
                             'colour_red': 'Red',
                             'colour_blue': 'Blue'
@@ -46,13 +60,12 @@
 
                 {{
                     form.select2({
-                        'label': 'Size',
-                        'id': 'size-4',
+                        'label': 'Colour 4 (multi no ph)',
+                        'id': 'colour-' ~ random(),
+                        'multiple': true,
                         'options': {
-                            '': '',
-                            'small': 'Small',
-                            'medium': 'Medium',
-                            'large': 'Large'
+                            'colour_red': 'Red',
+                            'colour_blue': 'Blue'
                         }
                     })
                 }}
@@ -60,28 +73,31 @@
                 {{
                     form.text({
                         'label': 'Text field example',
-                        'id': 'foo-4'
+                        'id': 'foo-' ~ random(),
+                        'class': 'form__group--full'
                     })
                 }}
 
                 {{
                     form.date({
                         'label': 'Added from',
-                        'id': 'addedFrom-4',
+                        'id': 'addedFrom-' ~ random(),
+                        'class': 'form__group--full'
                     })
                 }}
 
                 {{
                     form.date({
                         'label': 'Added to',
-                        'id': 'addedTo-4'
+                        'id': 'addedTo-' ~ random(),
+                        'class': 'form__group--full'
                     })
                 }}
 
                 {{
                     form.checkbox({
                         'label': 'In stock',
-                        'id': 'inStock-4'
+                        'id': 'inStock-' ~ random(),
                     })
                 }}
 

--- a/views/lexicon/patterns/filters/load-filter.html.twig
+++ b/views/lexicon/patterns/filters/load-filter.html.twig
@@ -34,10 +34,37 @@
 
                 {{
                     form.select2({
-                        'label': 'Colour',
-                        'id': 'colour-3',
-                        'multiple': true,
+                        'label': 'Colour (single + ph)',
+                        'id': 'colour-' ~ random(),
+                        'data-placeholder': 'Select One',
+                        'options': {
+                            '': 'Select One',
+                            'colour_red': 'Red',
+                            'colour_blue': 'Blue'
+                        }
+                    })
+                }}
+
+                {{
+                    form.select2({
+                        'label': 'Colour (single + ph + preselected)',
+                        'id': 'colour-' ~ random(),
+                        'data-placeholder': 'Select One',
                         'selected': 'colour_blue',
+                        'options': {
+                            '': 'Select One',
+                            'colour_red': 'Red',
+                            'colour_blue': 'Blue'
+                        }
+                    })
+                }}
+
+                {{
+                    form.select2({
+                        'label': 'Colour 3 (multi + ph)',
+                        'id': 'colour-' ~ random(),
+                        'multiple': true,
+                        'data-placeholder': 'Select one or more',
                         'options': {
                             'colour_red': 'Red',
                             'colour_blue': 'Blue'
@@ -47,14 +74,26 @@
 
                 {{
                     form.select2({
-                        'label': 'Size',
-                        'id': 'size-3',
-                        'selected': 'medium',
+                        'label': 'Colour 4 (multi no ph)',
+                        'id': 'colour-' ~ random(),
+                        'multiple': true,
                         'options': {
-                            '': '',
-                            'small': 'Small',
-                            'medium': 'Medium',
-                            'large': 'Large'
+                            'colour_red': 'Red',
+                            'colour_blue': 'Blue'
+                        }
+                    })
+                }}
+
+                {{
+                    form.select2({
+                        'label': 'Colour 5 (multi no ph preselected)',
+                        'id': 'colour-' ~ random(),
+                        'multiple': true,
+                        'selected': ['colour_red', 'colour_blue'],
+                        'options': {
+                            'colour_red': 'Red',
+                            'colour_blue': 'Blue',
+                            'colour_pink': 'Pink'
                         }
                     })
                 }}
@@ -62,21 +101,21 @@
                 {{
                     form.text({
                         'label': 'Text field example',
-                        'id': 'foo-3'
+                        'id': 'foo-' ~ random(),
                     })
                 }}
 
                 {{
                     form.date({
                         'label': 'Added from',
-                        'id': 'addedFrom-3',
+                        'id': 'addedFrom-' ~ random(),
                     })
                 }}
 
                 {{
                     form.date({
                         'label': 'Added to',
-                        'id': 'addedTo-3',
+                        'id': 'addedTo-' ~ random(),
                         'value': '04/07/2017'
                     })
                 }}
@@ -84,7 +123,7 @@
                 {{
                     form.checkbox({
                         'label': 'In stock',
-                        'id': 'inStock-3',
+                        'id': 'inStock-' ~ random(),
                         'checked': true
                     })
                 }}


### PR DESCRIPTION
This branch contains the following changes:

### Filter bar select2 fixes
1. Fixed an issue where select2's in the filter bar that had a placeholder would be displayed on page load (see below)
<img width="502" alt="screenshot_2020-07-27_at_18 01 05" src="https://user-images.githubusercontent.com/756393/89201254-19f69080-d5a9-11ea-87f6-e90218da652a.png">
2. Also fixed an issue where filterbar select2's with multiple selections would be displayed incorrectly - "label:Option1Option2" , rather than "label: Option1, Option2".

### Tab.js
#1258 introduced an issue where event handlers and JS would break on tab change. This resulted in the following elements being broken (after a js tab change): 

- select2
- colour picker
- date picker
- time picker
- repeater
- choice block radios and checkboxes
- dropzone
- jstree

This branch fixes the above issues and moves `tab.js` enhancements to their own class with relevant tests. As this functionality is not included in `tab.js`, the new `TabEnhancements` class file will need including and initialising in products using JS tabs.