### PR TITLE
Select woo jadu 1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
     },
     "acorn": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
       "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
       "dev": true
     },
@@ -423,7 +423,7 @@
         },
         "chalk": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
           "integrity": "sha1-HJhDdzfxGZ68wdTEj9Qbn5yOjyM=",
           "dev": true,
           "requires": {
@@ -1646,7 +1646,7 @@
     },
     "browserify": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify/-/browserify-10.0.0.tgz",
       "integrity": "sha1-4Ber2ALGHu4NI7pNmUGL5DCBPvw=",
       "dev": true,
       "requires": {
@@ -1920,7 +1920,7 @@
     },
     "buffer": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
       "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
       "dev": true,
       "requires": {
@@ -2132,7 +2132,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -2163,7 +2163,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -2353,7 +2353,7 @@
       "dependencies": {
         "convert-source-map": {
           "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
           "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA=",
           "dev": true
         },
@@ -3425,7 +3425,7 @@
     },
     "es6-promise": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
       "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw=",
       "dev": true
     },
@@ -3887,7 +3887,7 @@
       "dependencies": {
         "combined-stream": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
@@ -3963,8 +3963,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3985,14 +3984,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4007,20 +4004,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4137,8 +4131,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4150,7 +4143,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4165,7 +4157,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4173,14 +4164,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4199,7 +4188,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4280,8 +4268,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4293,7 +4280,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4379,8 +4365,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4416,7 +4401,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4436,7 +4420,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4480,14 +4463,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4760,13 +4741,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
           "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
           "dev": true
         },
         "chalk": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "integrity": "sha1-s89O0P9Tl8mcdbj2edsvUoMfltw=",
           "dev": true,
           "requires": {
@@ -4822,7 +4803,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
           "dev": true
         },
@@ -4834,7 +4815,7 @@
         },
         "chalk": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
@@ -5067,7 +5048,7 @@
         },
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
@@ -5417,7 +5398,7 @@
         },
         "uglify-js": {
           "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
+          "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
           "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
           "dev": true,
           "requires": {
@@ -5441,7 +5422,7 @@
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
@@ -5526,7 +5507,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
@@ -5667,7 +5648,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -5734,7 +5715,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
@@ -6009,7 +5990,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -6313,7 +6294,7 @@
         },
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
@@ -6642,7 +6623,7 @@
       "dependencies": {
         "commander": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
           "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
           "dev": true
         },
@@ -7004,7 +6985,7 @@
         },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
@@ -7577,7 +7558,7 @@
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
@@ -7767,7 +7748,7 @@
     },
     "mocha": {
       "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "resolved": "http://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
       "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
       "dev": true,
       "requires": {
@@ -7785,13 +7766,13 @@
       "dependencies": {
         "commander": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
           "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
           "dev": true
         },
         "debug": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
@@ -8056,7 +8037,7 @@
         },
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
@@ -8431,7 +8412,7 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
@@ -8551,7 +8532,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -9267,7 +9248,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
@@ -10791,8 +10772,8 @@
       }
     },
     "select2": {
-      "version": "github:jadu/selectWoo#9e93093268d02065f19959764ff859ba4918e134",
-      "from": "github:jadu/selectWoo#jadu-1.1.2",
+      "version": "github:jadu/selectWoo#5ca5b68213071ffa28d02685426b7347c8b3aa8c",
+      "from": "github:jadu/selectWoo#jadu-1.1.3",
       "requires": {
         "almond": "~0.3.1",
         "jquery-mousewheel": "~3.1.13"
@@ -11030,7 +11011,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -12215,7 +12196,7 @@
         },
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
@@ -12250,7 +12231,7 @@
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
@@ -12779,7 +12760,7 @@
         },
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
@@ -13207,7 +13188,7 @@
     },
     "yargs": {
       "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
       "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "normalize.css": "^8.0.1",
     "pikaday": "^1.8.0",
     "pulsar-date-picker": "^1.0.0",
-    "select2": "github:jadu/selectWoo#jadu-1.1.2",
+    "select2": "github:jadu/selectWoo#jadu-1.1.3",
     "spectrum-colorpicker": "^1.8.0",
     "timepicker": "1.13.2",
     "tippy.js": "^5.2.1",

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-placeholder-multiple.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-placeholder-multiple.html
@@ -1,0 +1,8 @@
+<div class="form__group">
+    <div class="controls">
+        <select multiple data-placeholder="foo" class="form__control select js-select2">
+            <option value="foo">bar</option>
+            <option value="bar">baz</option>
+        </select>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-placeholder-multiple.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-placeholder-multiple.html.twig
@@ -1,0 +1,13 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.select2({
+        'placeholder': 'foo',
+        'multiple': true,
+        'options': {
+            'foo': 'bar',
+            'bar': 'baz'
+        }
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-placeholder-single.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-placeholder-single.html
@@ -1,0 +1,9 @@
+<div class="form__group">
+    <div class="controls">
+        <select data-placeholder="foo" class="form__control select js-select2">
+            <option value="">foo</option>
+            <option value="foo">bar</option>
+            <option value="bar">baz</option>
+        </select>
+    </div>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-placeholder-single.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-placeholder-single.html.twig
@@ -1,0 +1,12 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    form.select2({
+        'placeholder': 'foo',
+        'options': {
+            'foo': 'bar',
+            'bar': 'baz'
+        }
+    })
+}}
+{% endblock %}

--- a/views/lexicon/forms/select2.html.twig
+++ b/views/lexicon/forms/select2.html.twig
@@ -11,7 +11,7 @@
     {{
         form.select2({
             'id': 'guid-' ~ random(),
-            'label': 'Select field',
+            'label': 'Select (single select)',
             'options': [
                 {
                     'label': 'Value one',
@@ -45,13 +45,64 @@
     {{
         form.select2({
             'id': 'guid-' ~ random(),
-            'label': 'Select multiple',
+            'label': 'Select (single + placeholder)',
+            'required': true,
+            'placeholder': 'Please choose',
+            'options': [
+                {
+                    'label': 'Value one',
+                    'value': 'value1'
+                },
+                {
+                    'label': 'Value two',
+                    'value': 'value2'
+                }
+            ]
+        })
+    }}
+
+    {{
+        form.select2({
+            'id': 'guid-' ~ random(),
+            'label': 'Select (multiple)',
             'multiple': true,
             'options': [
                 {
-                    'label': 'Choose',
-                    'value': ''
+                    'label': 'Value one',
+                    'value': 'value1'
                 },
+                {
+                    'label': 'Value two',
+                    'value': 'value2'
+                },
+                {
+                    'label': 'Value three',
+                    'value': 'value1'
+                },
+                {
+                    'label': 'Value four',
+                    'value': 'value2'
+                },
+                {
+                    'label': 'Value five',
+                    'value': 'value1'
+                },
+                {
+                    'label': 'Value six',
+                    'value': 'value2'
+                }
+            ]
+
+        })
+    }}
+
+    {{
+        form.select2({
+            'id': 'guid-' ~ random(),
+            'label': 'Select (multiple + placeholder)',
+            'multiple': true,
+            'placeholder': 'Please choose',
+            'options': [
                 {
                     'label': 'Value one',
                     'value': 'value1'
@@ -87,10 +138,6 @@
             'label': 'Required',
             'required': true,
             'options': [
-                {
-                    'label': 'Choose',
-                    'value': ''
-                },
                 {
                     'label': 'Value one',
                     'value': 'value1'

--- a/views/pulsar/v2/helpers/elem.html.twig
+++ b/views/pulsar/v2/helpers/elem.html.twig
@@ -344,7 +344,17 @@ value       | string | Specifies the value of the input
         {% set options = options|merge({'data-label': options.label}) %}
     {% endif %}
 
-    {{ elem.select(options|merge({'class': 'select js-select2'})) }}
+    {% if options.placeholder is defined and options.placeholder is not empty %}
+        {% set options = options|merge({'data-placeholder': options.placeholder}) %}
+
+        {# Add empty option with label matching placeholder (required for select2 placeholders on single selects #}
+        {% if options.multiple is not defined or options.multiple == false %}
+            {% set placeholderOption = [{'label': options.placeholder, 'value': ''}] %}
+            {% set options = options|merge({ options: placeholderOption|merge(options.options) })%}
+        {% endif %}
+    {% endif %}
+
+    {{ elem.select(options|merge({'class': 'select js-select2'})|exclude('placeholder') ) }}
 
 {% endspaceless %}
 {% endmacro %}


### PR DESCRIPTION
This pull request contains the following changes:

- Jadu/selectWoo updated to latest version (jadu-1.1.3). This fixes a number of a11y tool errors and improves screen reader coverage
- Select2 twig helper no longer incorrectly adds the `placeholder` attribute to native selects causing markup validation failures
- Select2 twig helper now adds the empty `<option value="">{placeholder}</option>` required for single select select2's when the `placeholder` option is used

TODO: Will be updating documentation to add `placeholder` option examples after merge.

