### PR TITLE
Fix modal focus issues

### DIFF
--- a/js/Modals/ModalFocusService.js
+++ b/js/Modals/ModalFocusService.js
@@ -7,18 +7,32 @@ class ModalFocusService {
      * @param {jQuery} $container - jquery wrapper of the container, typically body
      */
     trapFocus ($modal, $container) {
-        let $modalFocusableElements = $modal.find('.modal__content')
+        const $modalFocusableElements = $modal.find('.modal__content')
                 .find('a[href], area[href], input, select, textarea, button, iframe, object, embed, [tabindex], *[contenteditable]')
-                .not('[tabindex=-1], [disabled], :hidden, [aria-hidden]'),
-            $modalHasForm = $modal.find('.modal__content form').length > 0;
+                .not('[tabindex=-1], [disabled], :hidden, [aria-hidden]');
+        const $modalBodyFocusableElements = $modal.find('.modal__body')
+                .find('a[href], area[href], input, select, textarea, button, iframe, object, embed, [tabindex], *[contenteditable]')
+                .not('[tabindex=-1], [disabled], :hidden, [aria-hidden]');
+        const $modalCloseButton = $modal.find('.close[data-dismiss="modal"]').first();
+        const $modalFooterCancelButton = $modal.find('.modal__footer [data-dismiss="modal"]').first();
 
-        // If modal contains a form, we should focus the first field, otherwise focus the close button
-        if ($modalHasForm) {
-            $modal.find('.modal__content form :input:not(input[type=button]):not(button):not([disabled]):not([aria-hidden]):visible:first').trigger('focus');
+        /**
+         * Manage focus
+         * If modal has focusable elements in body, focus the first
+         * if not, focus the X close button
+         * if for some reason it doesn't have that, focus the cancel button in footer
+         */
+        if ($modalBodyFocusableElements.length) {
+            $modalBodyFocusableElements.first().trigger('focus');
+        } else if ($modalCloseButton.length) {
+            $modalCloseButton.trigger('focus');
         } else {
-            $modal.find('.modal__header .close').trigger('focus');
+            $modalFooterCancelButton.trigger('focus');
         }
 
+        /**
+         * Trap focus within modal
+         */
         $container.on('keydown', this.keydownListener.bind(this, $modalFocusableElements));
     }
 

--- a/tests/js/web/Modals/ModalFocusServiceTest.js
+++ b/tests/js/web/Modals/ModalFocusServiceTest.js
@@ -9,7 +9,7 @@ describe('ModalFocusService', () => {
     let $actionsMenuChildLink;
     let $modal;
     let $closeButton;
-    let $input;
+    let $inputButton;
     let $cancelButton;
     let keyDownEvent;
     let service;
@@ -33,7 +33,7 @@ describe('ModalFocusService', () => {
                     <form>
                         <div class="test-wrapper">
                             <div class="modal__header">
-                                <button class="close" type="button">×</button>
+                                <button class="close" type="button" data-dismiss="modal">×</button>
                                 <h4>Assign to</h4>
                             </div>
 
@@ -46,7 +46,7 @@ describe('ModalFocusService', () => {
                             </div>
                             <div class="modal__footer">
                                 <button class="input7" type="submit">Save</button>
-                                <button class="input8" type="button">Cancel</button>
+                                <button class="input8" type="button" data-dismiss="modal">Cancel</button>
                             </div>
                         </div>
                     </form>
@@ -60,7 +60,7 @@ describe('ModalFocusService', () => {
         $body.append($wrapper);
 
         $closeButton = $modal.find('.close');
-        $input = $modal.find('.input6');
+        $inputButton = $modal.find('.input4');
         $cancelButton = $modal.find('.input8');
         keyDownEvent = $.Event('keydown');
 
@@ -73,21 +73,32 @@ describe('ModalFocusService', () => {
 
     describe('trapFocus()', () => {
 
-        describe('When a form is present', () => {
-            it('should focus the first non disabled, non button, non aria-hidden input within the form', () => {
+        describe('When focusable elements are present', () => {
+            it('should focus the first non disabled, non button, non aria-hidden input', () => {
                 service.trapFocus($modal, $body);
 
-                expect($input.is(':focus')).to.be.true;
+                expect($inputButton.is(':focus')).to.be.true;
             });
         });
 
-        describe('When a form not is present', () => {
-            it('should focus the close button', () => {
-                $body.find('.test-wrapper').unwrap();
+        describe('When there are no focusable elements', () => {
+            it('should focus the close X button', () => {
+                $body.find('.modal__body').empty();
 
                 service.trapFocus($modal, $body);
 
                 expect($closeButton.is(':focus')).to.be.true;
+            });
+        });
+
+        describe('When there are no focusable elements and no close X button ', () => {
+            it('should focus the close button', () => {
+                $body.find('.modal__body').empty();
+                $body.find('.modal__header .close').remove();
+
+                service.trapFocus($modal, $body);
+
+                expect($cancelButton.is(':focus')).to.be.true;
             });
         });
 

--- a/views/lexicon/tabs/modals.html.twig
+++ b/views/lexicon/tabs/modals.html.twig
@@ -1,26 +1,50 @@
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
 {% block tab_content %}
-<p><button class="btn" data-toggle="modal" data-target="#modalExample">Launch Standard Modal via a button</button></p>
-<p><button class="btn" data-toggle="modal" data-target="#modalTwo">Launch Danger Modal via a button</button></p>
-<p><button class="btn" data-toggle="modal" data-target="#modalThree">Launch Long Modal via a button</button></p>
-<p><a data-toggle="modal" href="#myFullScreenModal" class="btn">Launch Full Screen Modal</a></p>
+<h2>Modal focus management examples</h2>
+<p>
+    Launch a modal that contains a form but no inputs - close X should be focussed <br/>
+    <button class="btn" data-toggle="modal" data-target="#modalExample">Launch Modal 1</button>
+</p>
+
+<p>
+    Launch a modal that contains an input but no form - input should be focussed <br />
+    <button class="btn" data-toggle="modal" data-target="#modalTwo">Launch Modal 2</button>
+</p>
+
+<p>
+    Launch a modal that doesn't contant a form, or inputs, or close X button - cancel button should be focussed <br/>
+    <button class="btn" data-toggle="modal" data-target="#modalThree">Launch Modal 3</button>
+</p>
+
+<h2>Modal variation examples</h2>
+<p>
+    Launch a modal with a lot of content <br/>
+    <button class="btn" data-toggle="modal" data-target="#modalFour">Launch Long Modal</button>
+</p>
+
+<p>
+    Launch a full page modal, from a link <br/>
+    <a data-toggle="modal" href="#myFullScreenModal" class="btn">Launch Full Screen Modal</a>
+</p>
 
 <div class="modal modal__example" id="modalExample" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modalExample-title" aria-describedby="modalExample-description">
     <div class="modal__dialog">
         <div class="modal__content">
-            <div class="modal__header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close modal dialog"><span aria-hidden="true">&times;</span></button>
-                <h1 class="modal__title" id="modalExample-title">A simple example</h1>
-            </div>
-            <div class="modal__body">
-                <p id="modalExample-description" class="hide">Here goes a short description (a couple of lines) about the modal's purpose, if needed.</p>
-                <p>The modal body might have instructions, a form, or other stuff.</p>
-            </div>
-            <div class="modal__footer">
-                <button type="button" class="btn btn--primary">Save Changes</button>
-                <button type="button" class="btn btn--naked" data-dismiss="modal">Cancel</button>
-            </div>
+            <form>
+                <div class="modal__header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close modal dialog"><span aria-hidden="true">&times;</span></button>
+                    <h1 class="modal__title" id="modalExample-title">A simple example</h1>
+                </div>
+                <div class="modal__body">
+                    <p id="modalExample-description" class="hide">Here goes a short description (a couple of lines) about the modal's purpose, if needed.</p>
+                    <p>The modal body might have instructions, a form, or other stuff.</p>
+                </div>
+                <div class="modal__footer">
+                    <button type="button" class="btn btn--primary">Save Changes</button>
+                    <button type="button" class="btn btn--naked" data-dismiss="modal">Cancel</button>
+                </div>
+            </form>
         </div><!-- /.modal__content -->
     </div><!-- /.modal__dialog -->
 </div><!-- /.modal -->
@@ -36,6 +60,13 @@
                 <p id="modalTwo-description" class="hide">Here goes a short description (a couple of lines) about the modal's purpose, if needed.</p>
                 <p>We mainly use modals to get you to stop and confirm that you really want to delete something, and remind you that this action cannot be reversed.</p>
                 <p>A modal's action buttons should be written so that if a user only reads the buttons, they should get an idea of the action they're about to perform instead of blindly clicking 'OK' or 'Confirm'.</p>
+
+                {{
+                    form.checkbox_inline({
+                        'id': 'guid-' ~ random(),
+                        'label': 'I understand something bad might happen'
+                    })
+                }}
             </div>
             <div class="modal__footer">
                 <button type="button" class="btn btn--danger">Delete Everything</button>
@@ -45,13 +76,34 @@
     </div><!-- /.modal__dialog -->
 </div><!-- /.modal -->
 
-<div class="modal" id="modalThree" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modalThree-title" aria-describedby="modalThree-description">
+<div class="modal modal__example" id="modalThree" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modalThree-title" aria-describedby="modalThree-description">
+    <div class="modal__dialog">
+        <div class="modal__content">
+            <form>
+                <div class="modal__header">
+                    <h1 class="modal__title" id="modalThree-title">A simple example</h1>
+                </div>
+                <div class="modal__body">
+                    <p id="modalThree-description" class="hide">Here goes a short description (a couple of lines) about the modal's purpose, if needed.</p>
+                    <p>The modal body might have instructions, a form, or other stuff.</p>
+                </div>
+                <div class="modal__footer">
+                    <button type="button" class="btn btn--primary">Save Changes</button>
+                    <button type="button" class="btn btn--naked" data-dismiss="modal">Cancel</button>
+                </div>
+            </form>
+        </div><!-- /.modal__content -->
+    </div><!-- /.modal__dialog -->
+</div><!-- /.modal -->
+
+
+<div class="modal" id="modalFour" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modalFour-title" aria-describedby="modalFour-description">
     <div class="modal__dialog">
         <div class="modal__content">
             <form>
                 <div class="modal__header">
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close modal dialog"><span aria-hidden="true">&times;</span></button>
-                    <h1 class="modal__title" id="modalThree-title">Standard modal</h1>
+                    <h1 class="modal__title" id="modalFour-title">Standard modal</h1>
                 </div>
                 <div class="modal__body">
 
@@ -62,7 +114,7 @@
                         })
                     }}
 
-                    <p id="modalThree-description" class="hide">Here goes a short description (a couple of lines) about the modal's purpose, if needed.</p>
+                    <p id="modalFour-description" class="hide">Here goes a short description (a couple of lines) about the modal's purpose, if needed.</p>
 
                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pharetra dui ac congue fringilla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nunc sit amet feugiat diam. Proin eu condimentum elit. Donec facilisis urna sed tortor semper tincidunt. Maecenas tortor justo, rhoncus a luctus eget, consectetur suscipit est. In molestie posuere lectus. Vestibulum sit amet ligula odio. Nulla lobortis neque ac porta accumsan.</p>
 


### PR DESCRIPTION
This branch fixes #1280 

**New behaviour**

When a modal is opened focus is set on:
- The first focusable element, regardless of presence of a `form`
- The close X button in the modal header, if there are no focusable elements in the modal body
- The `Cancel` button in the modal footer, if there are no focusable elements in the modal body and there is no close X button in the modal header.