### PR TITLE
Remove hardcoded actions menu ID causing dup ID validation failures in JS tabs

### DIFF
--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/actions_menu-dividers.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/actions_menu-dividers.html
@@ -1,5 +1,5 @@
 <div class="btn__group dropdown">
-    <button id="actions_menu" aria-haspopup="true" aria-expanded="false" aria-controls="guid-1" data-toggle="dropdown" class="btn dropdown__toggle">Actions<span aria-label="0 rows selected" style="display: none;" class="badge label--primary js-bulk-actions-badge">0</span>&nbsp;<span class="caret"></span></button>
+    <button aria-haspopup="true" aria-expanded="false" aria-controls="guid-1" data-toggle="dropdown" class="btn dropdown__toggle">Actions<span aria-label="0 rows selected" style="display: none;" class="badge label--primary js-bulk-actions-badge">0</span>&nbsp;<span class="caret"></span></button>
     <ul id="guid-1" class="dropdown__menu pull-left">
         <li>
             <a href="/one">one</a>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/actions_menu-items.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/actions_menu-items.html
@@ -1,5 +1,5 @@
 <div class="btn__group dropdown">
-    <button id="actions_menu" aria-haspopup="true" aria-expanded="false" aria-controls="guid-1" data-toggle="dropdown" class="btn dropdown__toggle">Actions<span aria-label="0 rows selected" style="display: none;" class="badge label--primary js-bulk-actions-badge">0</span>&nbsp;<span class="caret"></span></button>
+    <button aria-haspopup="true" aria-expanded="false" aria-controls="guid-1" data-toggle="dropdown" class="btn dropdown__toggle">Actions<span aria-label="0 rows selected" style="display: none;" class="badge label--primary js-bulk-actions-badge">0</span>&nbsp;<span class="caret"></span></button>
     <ul id="guid-1" class="dropdown__menu pull-left">
         <li>
             <a href="/one">one</a>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/actions_menu.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/actions_menu.html
@@ -1,5 +1,5 @@
 <div class="btn__group dropdown">
-    <button id="actions_menu" aria-haspopup="true" aria-expanded="false" aria-controls="guid-1" data-toggle="dropdown" class="btn dropdown__toggle">Actions<span aria-label="0 rows selected" style="display: none;" class="badge label--primary js-bulk-actions-badge">0</span>&nbsp;<span class="caret"></span>
+    <button aria-haspopup="true" aria-expanded="false" aria-controls="guid-1" data-toggle="dropdown" class="btn dropdown__toggle">Actions<span aria-label="0 rows selected" style="display: none;" class="badge label--primary js-bulk-actions-badge">0</span>&nbsp;<span class="caret"></span>
     </button>
     <ul id="guid-1" class="dropdown__menu pull-left"></ul>
 </div>

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -87,7 +87,6 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {{
         html.button_dropdown({
-            'id': 'actions_menu',
             'label': items.label|default('Actions') ~
                 html.badge({
                     'label': '0',


### PR DESCRIPTION
This branch removes the hardcoded `actions_menu` ID from the actions menu drop down button generated by the `html.actions_menu` helper.

This was causing "multiple elements with same ID" failures In JS tabs, when multiple tabs had an actions menu dropdown button.

Couldn't find any references to this ID in JS in CXM, CMS or XFP.