### PR TITLE
Add lexicon example of modal with error summary

### DIFF
--- a/views/lexicon/tabs/modals.html.twig
+++ b/views/lexicon/tabs/modals.html.twig
@@ -17,6 +17,11 @@
     <button class="btn" data-toggle="modal" data-target="#modalThree">Launch Modal 3</button>
 </p>
 
+<p>
+    Launch a modal with error summary<br/>
+    <button class="btn" data-toggle="modal" data-target="#modalErrorSummary">Launch Modal</button>
+</p>
+
 <h2>Modal variation examples</h2>
 <p>
     Launch a modal with a lot of content <br/>
@@ -41,7 +46,7 @@
                     <p>The modal body might have instructions, a form, or other stuff.</p>
                 </div>
                 <div class="modal__footer">
-                    <button type="button" class="btn btn--primary">Save Changes</button>
+                    <button type="submit" class="btn btn--primary">Save Changes</button>
                     <button type="button" class="btn btn--naked" data-dismiss="modal">Cancel</button>
                 </div>
             </form>
@@ -69,7 +74,7 @@
                 }}
             </div>
             <div class="modal__footer">
-                <button type="button" class="btn btn--danger">Delete Everything</button>
+                <button type="submit" class="btn btn--danger">Delete Everything</button>
                 <button type="button" class="btn btn--naked" data-dismiss="modal">Don't Do Anything</button>
             </div>
         </div><!-- /.modal__content -->
@@ -88,7 +93,7 @@
                     <p>The modal body might have instructions, a form, or other stuff.</p>
                 </div>
                 <div class="modal__footer">
-                    <button type="button" class="btn btn--primary">Save Changes</button>
+                    <button type="submit" class="btn btn--primary">Save Changes</button>
                     <button type="button" class="btn btn--naked" data-dismiss="modal">Cancel</button>
                 </div>
             </form>
@@ -127,13 +132,123 @@
                     <p>Donec urna ex, tincidunt eget diam eu, pulvinar iaculis augue. Phasellus sapien eros, aliquet id egestas nec, ultricies feugiat dui. Vestibulum in massa malesuada, ullamcorper magna non, auctor justo. Sed nisl mi, mollis ut magna in, molestie aliquam est. Mauris ac suscipit risus, sit amet mattis sapien. Nam tincidunt, nisl sit amet tempor auctor, massa lorem maximus metus, vitae aliquam elit sem quis arcu. Suspendisse dolor mauris, facilisis sit amet leo a, molestie aliquet enim. Proin molestie convallis enim non scelerisque. Vivamus finibus ornare nunc ac laoreet. Aliquam dignissim odio purus, convallis facilisis elit imperdiet sed.</p>
                 </div>
                 <div class="modal__footer">
-                    <button type="button" class="btn btn--primary">Save Changes</button>
+                    <button type="submit" class="btn btn--primary">Save Changes</button>
                     <button type="button" class="btn btn--naked" data-dismiss="modal">Cancel</button>
                 </div>
             </form>
         </div><!-- /.modal__content -->
     </div><!-- /.modal__dialog -->
 </div><!-- /.modal -->
+
+
+<div class="modal modal__example" id="modalErrorSummary" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modalErrorSummary-title" aria-describedby="modalErrorSummary-description">
+    <div class="modal__dialog">
+        <div class="modal__content">
+            <form>
+                <div class="modal__header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close modal dialog"><span aria-hidden="true">&times;</span></button>
+                    <h1 class="modal__title" id="modalErrorSummary-title">A simple example with error summary</h1>
+                </div>
+                <div class="modal__body">
+                    <p id="modalErrorSummary-description" class="hide">Here goes a short description (a couple of lines) about the modal's purpose, if needed.</p>
+                    <p>The modal body might have instructions, a form, or other stuff.</p>
+
+                    {{
+                        form.error_summary({
+                            'heading': 'There is a problem',
+                            'errors': [
+                                {
+                                    'label': 'Enter your first name',
+                                    'href': 'first-name'
+                                },
+                                {
+                                    'label': 'Enter your last name',
+                                    'href': 'last-name'
+                                }
+                            ]
+                        })
+                    }}
+
+                    {{ form.fieldset_start({'legend': 'Example form with errors'}) }}
+
+                        {{
+                            form.text({
+                                'label': 'First name',
+                                'id': 'first-name',
+                                'required': true,
+                                'error': 'Enter your first name'
+                            })
+                        }}
+
+                        {{
+                            form.text({
+                                'label': 'Last name',
+                                'id': 'last-name',
+                                'required': true,
+                                'error': 'Enter your last name'
+                            })
+                        }}
+
+                        {{
+                            form.checkbox({
+                                'label': 'Are you human?',
+                                'id': 'are-you-human'
+                            })
+                        }}
+
+                        {{
+                            form.select2({
+                                'label': 'Favourite colours',
+                                'id': 'select',
+                                'multiple': true,
+                                'options': {
+                                    'colour_red': 'Red',
+                                    'colour_blue': 'Blue'
+                                }
+                            })
+                        }}
+
+                        {{
+                            form.choice({
+                                'label': 'Assign blame to',
+                                'multiple': true,
+                                'options': [
+                                    {
+                                        'label': 'Sunshine',
+                                        'name': 'choice-a2',
+                                        'value': 'sun'
+                                    },
+                                    {
+                                        'label': 'Moonlight',
+                                        'name': 'choice-a2',
+                                        'value': 'moon'
+                                    },
+                                    {
+                                        'label': 'Good times',
+                                        'name': 'choice-a2',
+                                        'value': 'good'
+                                    },
+                                    {
+                                        'label': 'Boogie',
+                                        'name': 'choice-a2',
+                                        'value': 'boogie'
+                                    }
+                                ]
+                            })
+                        }}
+                    {{ form.fieldset_end() }}
+
+                </div>
+                <div class="modal__footer">
+                    <button type="submit" class="btn btn--primary">Save Changes</button>
+                    <button type="button" class="btn btn--naked" data-dismiss="modal">Cancel</button>
+                </div>
+            </form>
+        </div><!-- /.modal__content -->
+    </div><!-- /.modal__dialog -->
+</div><!-- /.modal -->
+
+
 
 <div class="modal modal--full-screen fade" id="myFullScreenModal" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="fullModal-title" aria-describedby="fullModal-description">
     <div class="modal__dialog">


### PR DESCRIPTION
Added lexicon example to test modal focus management when error summary in use:

![Screenshot 2020-08-10 at 13 46 12](https://user-images.githubusercontent.com/756393/89784180-20888900-db10-11ea-99ef-28785bb686d3.png)
