### PR TITLE
Fix Select2 placeholder contrast

### DIFF
--- a/stylesheets/_component.select2.scss
+++ b/stylesheets/_component.select2.scss
@@ -47,6 +47,10 @@
     min-height: 32px;
     user-select: none;
     -webkit-user-select: none;
+
+    .select2-search__field {
+        @include placeholder($input-color-placeholder);
+    }
 }
 
 .select2-container .select2-selection--multiple .select2-selection__rendered {
@@ -188,7 +192,7 @@
 }
 
 .select2-container--default .select2-selection--single .select2-selection__placeholder {
-    color: #999;
+    color: color(text, placeholder)
 }
 
 .select2-container--default .select2-selection__arrow {
@@ -220,6 +224,10 @@
 .select2-container--default.select2-container--disabled .select2-selection--single {
     background-color: #eee;
     cursor: default;
+
+    &:focus {
+        outline: none;
+    }
 }
 
 .select2-container--default.select2-container--disabled .select2-selection--single .select2-selection__clear {
@@ -247,7 +255,7 @@
 }
 
 .select2-container--default .select2-selection--multiple .select2-selection__placeholder {
-    color: #999;
+    color: color(text, placeholder);
     margin-top: 5px;
     float: left;
 }
@@ -340,6 +348,10 @@
 .select2-container--default.select2-container--disabled .select2-selection--multiple {
     background-color: #eee;
     cursor: default;
+
+    &:focus {
+        outline: none;
+    }
 }
 
 .select2-container--default.select2-container--disabled .select2-selection__choice__remove {
@@ -475,7 +487,7 @@
 }
 
 .select2-container--classic .select2-selection--single .select2-selection__placeholder {
-    color: #999;
+    color: color(text, placeholder);
 }
 
 .select2-container--classic .select2-selection--single .select2-selection__arrow {

--- a/stylesheets/_mixin.mixins-to-organise.scss
+++ b/stylesheets/_mixin.mixins-to-organise.scss
@@ -177,6 +177,14 @@
         background-color: $background-color;
         background-image: linear-gradient(45deg, transparent 49%, color(text) 49%), linear-gradient(135deg, color(text) 49%, transparent 49%), linear-gradient(to right, darken($background-color, 10%), darken($background-color, 10%));
         border-color: $border-color;
+
+        .select2-selection__placeholder {
+            color: $text-color;
+        }
+
+        &.select2-selection--multiple .select2-search__field {
+            @include placeholder($text-color);
+        }
     }
 }
 

--- a/views/lexicon/forms/select2.html.twig
+++ b/views/lexicon/forms/select2.html.twig
@@ -369,6 +369,7 @@
             'id': 'guid-' ~ random(),
             'label': '"class": "has-changed"',
             'class': 'has-changed',
+            'placeholder': 'Please choose',
             'help': 'Highlight whether an action elsewhere affects an input',
             'options': [
                 {
@@ -387,6 +388,7 @@
             'id': 'guid-' ~ random(),
             'label': '"class": "has-success"',
             'class': 'has-success',
+            'placeholder': 'Please choose',
             'help': 'Something good happened',
             'options': [
                 {
@@ -406,6 +408,7 @@
             'id': 'guid-' ~ random(),
             'label': '"class": "has-warning"',
             'class': 'has-warning',
+            'placeholder': 'Please choose',
             'help': 'Something bad happened',
             'options': [
                 {
@@ -424,6 +427,7 @@
             'id': 'guid-' ~ random(),
             'label': '"class": "has-error"',
             'class': 'has-error',
+            'placeholder': 'Please choose',
             'help': 'Automatically added if using <code>error</code> option',
             'options': [
                 {
@@ -442,6 +446,7 @@
             'id': 'guid-' ~ random(),
             'label': '"disabled": true',
             'disabled': true,
+            'placeholder': 'Please choose',
             'help': 'Stop! Can’t touch this',
             'options': [
                 {
@@ -460,6 +465,7 @@
         form.select2({
             'id': 'guid-' ~ random(),
             'label': 'Disabled option',
+            'placeholder': 'Please choose',
             'options': [
                 {
                     'label': 'Value one',


### PR DESCRIPTION
Select2 placeholder were not meeting AA contrast. This branch contains the following fixes:

1. Single and multiple selection select2 placeholders now meet AA contrast (4.54:1)
2. Single and multiple selection select2 placeholders within css "state" modifiers now meet AA contrast.
4. Disabled select2s showed a blue outline on click, this has been removed.

### Before
---
Default placeholder not meeting contrast:
![Screenshot 2020-08-12 at 16 45 51](https://user-images.githubusercontent.com/756393/90036952-85341700-dcbb-11ea-92e2-7a9d16e2f114.png)

State modifiers placeholders not meeting contrast:
![Screenshot 2020-08-12 at 16 46 52](https://user-images.githubusercontent.com/756393/90036973-8c5b2500-dcbb-11ea-9b45-c9f04dd41121.png)

Disabled select2 outline on click:
![Screenshot 2020-08-12 at 16 48 30](https://user-images.githubusercontent.com/756393/90037112-b0b70180-dcbb-11ea-8c6d-ddba708e6459.png)

### After
---
Default placeholder now meet contrast:
![Screenshot 2020-08-12 at 16 45 00](https://user-images.githubusercontent.com/756393/90037262-e825ae00-dcbb-11ea-8256-6571e53207ce.png)

State modifiers placeholders now meet contrast:
![Screenshot 2020-08-12 at 16 45 08](https://user-images.githubusercontent.com/756393/90037302-f70c6080-dcbb-11ea-9caf-c2c35a102800.png)

No focus outline on disabled select2 click:
![Screenshot 2020-08-12 at 16 52 06](https://user-images.githubusercontent.com/756393/90037557-3e92ec80-dcbc-11ea-8926-742a179c7a5c.png)

