### PR TITLE
Filter bar accessibility improvements

### DIFF
--- a/js/FilterBarComponent.js
+++ b/js/FilterBarComponent.js
@@ -45,6 +45,9 @@ function showFilterBar (component, $filterbar) {
 
         // Show filter bar
         $filterbar.removeClass('u-display-none');
+
+        // Focus add button
+        $addFilterButton.trigger('focus');
     });
 }
 
@@ -56,11 +59,11 @@ function createFilterListButton ($filterbar) {
 
     // Loop through form groups
     $formGroups.each(function() {
-        $filterList.append('<li><a href="#" class="filter-bar__list-item" data-ui="filter-item" data-filter-id="'+ $(this).find('.form__control').attr('id') +'" data-filter-title="'+ $(this).find('.control__label').text() +'">'+ $(this).find('.control__label').text() +'</a></li>');
+        $filterList.append('<li><a href="#" role="button" class="filter-bar__list-item" data-ui="filter-item" data-filter-id="'+ $(this).find('.form__control').attr('id') +'" data-filter-title="'+ $(this).find('.control__label').text() +'">'+ $(this).find('.control__label').text() +'</a></li>');
     });
 
     // Build up list and mark up for Add filter button
-    $addFilterButton = $('<button class="btn filter-bar__add" type="button" data-ui="show-filter-list" data-toggle="popover" data-trigger="click" title="Filter by" data-html="true" data-placement="bottom" data-content="" aria-haspopup="true"><i class="icon-plus"><span class="hide">Add</span></i></button>');
+    $addFilterButton = $('<button class="btn filter-bar__add" type="button" aria-expanded="false" data-ui="show-filter-list" data-toggle="popover" data-trigger="click" title="Filter by" data-html="true" data-placement="bottom" data-content="" aria-haspopup="true"><i class="icon-plus"><span class="hide">Add filter</span></i></button>');
     $addFilterButton.attr('data-content', $filterList[0].outerHTML);
 
     // Append button and label wrapper
@@ -70,9 +73,16 @@ function createFilterListButton ($filterbar) {
     // Initialize popover
     $addFilterButton.popover();
 
-    // Prevent default on button
     $filterbar.on('click', '[data-ui="show-filter-list"]', function(e) {
         e.preventDefault();
+
+        var $addFilterButton = $(this);
+
+        if ($addFilterButton.attr('aria-expanded') == 'false') {
+            $addFilterButton.attr('aria-expanded', 'true');
+        } else {
+            $addFilterButton.attr('aria-expanded', 'false');
+        }
     });
 }
 
@@ -112,6 +122,8 @@ function showAddFilterPopover ($filterbar) {
         filterId = $(this).attr('data-filter-id');
         $field = $filterbar.find('#' + filterId);
 
+        $addFilterButton.attr('aria-expanded', 'false');
+
         // Hide the filter item in the list
         updateFilterList($addFilterButton, filterId, 'hide');
 
@@ -130,7 +142,7 @@ function showAddFilterPopover ($filterbar) {
 
             // Add the remove button to the label
             filterId = $filterLabel.attr('data-filter-id');
-            $filterLabel.append('<button type="button" data-ui="filter-cancel" class="btn remove-button" data-filter-id="'+ filterId +'"><i class="icon-remove-sign"></i></button>');
+            $filterLabel.append('<button type="button" data-ui="filter-cancel" class="btn remove-button" data-filter-id="'+ filterId +'"><i class="icon-remove-sign"><span class="hide">Remove '+ filterTitle +' filter</span></i></button>');
 
             // Add the label
             $filterLabel
@@ -142,6 +154,13 @@ function showAddFilterPopover ($filterbar) {
 
             // Check if save button should be visible
             formActionsVisibility($filterbar);
+
+            // Focus the add button or, if that's not visible, focus the save button
+            if (!$addFilterButton.hasClass('u-display-none')) {
+                $addFilterButton.trigger('focus');
+            } else {
+                $filterbar.find('.form__actions .btn--primary').trigger('focus');
+            }
 
         } else {
 
@@ -198,7 +217,7 @@ function showAddFilterPopover ($filterbar) {
 
             // Focus on field to avoid unnecessary extra click
             if ($field.hasClass('js-select2') && $field.data('init') !== false) {
-                $field.select2('open');
+                $field.select2('focus');
             } else {
                 /* istanbul ignore next: difficult to test due to generated popover content */
                 $field.focus();
@@ -235,7 +254,8 @@ function addFilter ($filterbar) {
             $legend = $filterbar.find('form fieldset legend'),
             values,
             valueForLabel = null,
-            filterId;
+            filterId,
+            initalLabelText = $label.text();;
 
         e.preventDefault();
 
@@ -263,7 +283,7 @@ function addFilter ($filterbar) {
 
         // Add the remove button to the label
         filterId = $label.attr('data-filter-id');
-        $label.append('<button type="button" data-ui="filter-cancel" class="btn remove-button" data-filter-id="'+ filterId +'"><i class="icon-remove-sign"></i></button>');
+        $label.append('<button type="button" data-ui="filter-cancel" class="btn remove-button" data-filter-id="'+ filterId +'"><i class="icon-remove-sign"><span class="hide">Remove '+ initalLabelText + ' filter</span></i></button>');
 
         // Swap classes
         $label
@@ -286,6 +306,13 @@ function addFilter ($filterbar) {
 
         // Check if save button should be visible
         formActionsVisibility($filterbar);
+
+        // Focus the add button or, if that's not visible, focus the save button
+        if (!$addFilterButton.hasClass('u-display-none')) {
+            $addFilterButton.trigger('focus');
+        } else {
+            $filterbar.find('.form__actions .btn--primary').trigger('focus');
+        }
     });
 }
 
@@ -348,6 +375,9 @@ function removeFilter ($filterbar) {
 
         // Check if save button should be visible
         formActionsVisibility($filterbar);
+
+        // Shift focus to add button
+        $addFilterButton.trigger('focus')
     });
 }
 
@@ -438,7 +468,8 @@ function populateFilterList ($filterbar) {
             $filterField = $this.find('.form__control'),
             filterId = $filterField.attr('id'),
             filterLabel = $this.find('.control__label').text().trim(),
-            filterValue = $filterField.val();
+            filterValue = $filterField.val(),
+            initalLabelText = filterLabel;
 
         if ($filterField.hasClass('select')) {
             if ($filterField.prop('multiple')) {
@@ -459,7 +490,7 @@ function populateFilterList ($filterbar) {
         }
 
         if (filterValue !== '' && filterValue !== null && filterValue.length !== 0) {
-            $labelContainer.prepend('<span class="label label--large label--inverse label--removable" data-filter-id="' + filterId + '"><span class="label__text">' + filterLabel + filterValue + '</span><button type="button" data-ui="filter-cancel" class="btn remove-button" data-filter-id="'+ filterId +'"><i class="icon-remove-sign"></i></button></span>');
+            $labelContainer.prepend('<span class="label label--large label--inverse label--removable" data-filter-id="' + filterId + '"><span class="label__text">' + filterLabel + filterValue + '</span><button type="button" data-ui="filter-cancel" class="btn remove-button" data-filter-id="'+ filterId +'"><i class="icon-remove-sign"><span class="hide">Remove '+ initalLabelText +' filter</span></i></button></span>');
 
             // Keep track of how many filters have already been applied
             hiddenFormGroups++;

--- a/tests/js/web/FilterBarComponentTest.js
+++ b/tests/js/web/FilterBarComponentTest.js
@@ -5,8 +5,8 @@ var $ = require('jquery'),
 
 describe('FilterBarComponent', function () {
 	beforeEach(function() {
-		this.$html = $('<html></html>');
-		this.$body = $('<body></body>').appendTo(this.$html);
+		this.$html = $('html');
+		this.$body = $('body');
 		this.$showFilterBarLink = $('<a href="#" data-ui="show-filter-bar">Add filter</a>').appendTo(this.$body);
 		this.$container = $(
 			'<div class="filter-bar u-display-none">' +
@@ -154,6 +154,12 @@ describe('FilterBarComponent', function () {
 
 			expect(this.$showFilterListButton.hasClass('u-display-none')).to.be.false;
 		});
+
+		it('should focus the filter bar add button', function () {
+			this.$showFilterBarLink.trigger(this.clickEvent);
+
+			expect(this.$showFilterListButton.is(':focus')).to.be.true;
+		});
 	});
 
 	describe('When filter list button is clicked', function() {
@@ -222,27 +228,62 @@ describe('FilterBarComponent', function () {
 
 			beforeEach(function() {
 		        this.$popoverFilterLink = this.$container.find('.filter-bar__list [data-filter-id="inStock"]');
-				this.$popoverFilterLink.trigger(this.clickEvent);
 			});
 
 			it('should add a label to the filter bar for the clicked filter', function () {
+				this.$popoverFilterLink.trigger(this.clickEvent);
+
 				expect(this.$container.find('span.label--inverse[data-filter-id="inStock"]')).to.have.length(1);
 			});
 
 			it('should add the correct data-filter-id to the label', function () {
+				this.$popoverFilterLink.trigger(this.clickEvent);
+
 				expect(this.$container.find('span[data-filter-id="inStock"]')).to.have.length(1);
 			});
 
 			it('should close the filter list popover', function () {
+				this.$popoverFilterLink.trigger(this.clickEvent);
+
 				expect($.fn.popover).to.have.been.calledWith('hide');
 			});
 
 			it('should check the checkbox', function () {
+				this.$popoverFilterLink.trigger(this.clickEvent);
+
 				expect(this.$container.find('input#inStock').prop('checked')).to.be.true;
 			});
 
 			it('should add the remove button to the label', function () {
+				this.$popoverFilterLink.trigger(this.clickEvent);
+
 				expect(this.$container.find('span[data-filter-id="inStock"] button[data-ui="filter-cancel"]')).to.have.length(1);
+			});
+
+			it('should the correct accessible text to the label remove button', function () {
+				this.$popoverFilterLink.trigger(this.clickEvent);
+
+				var $removeButton = this.$container.find('span[data-filter-id="inStock"] button[data-ui="filter-cancel"]');
+
+				expect($removeButton.find('.hide').text()).to.be.equal('Remove In Stock filter');
+			});
+
+			it('should focus the add button, if it is visible', function () {
+				this.$popoverFilterLink.trigger(this.clickEvent);
+
+				expect(this.$container.find('[data-ui="show-filter-list"]').is(':focus')).to.be.true;
+			});
+
+			it('should focus the save button, if there are no more filter options', function () {
+				var addFilterButtonList = this.$showFilterListButton.attr('data-content'),
+				$addFilterButtonList = $(addFilterButtonList),
+				$filterItemParents = $addFilterButtonList.find('li');
+				$filterItemParents.addClass('u-display-none');
+				this.$showFilterListButton.attr('data-content', $addFilterButtonList[0].outerHTML);
+
+				this.$popoverFilterLink.trigger(this.clickEvent);
+
+				expect(this.$container.find('.form__actions .btn--primary').is(':focus')).to.be.true;
 			});
 		});
 
@@ -373,6 +414,12 @@ describe('FilterBarComponent', function () {
 				this.$removeFilterButton2.trigger(this.clickEvent);
 
 				expect(this.$container.find('.form__actions:not(.u-display-none)')).to.have.length(1);
+			});
+
+			it('should focus the add button', function () {
+				this.$removeFilterButton.trigger(this.clickEvent);
+
+				expect(this.$container.find('[data-ui="show-filter-list"]').is(':focus')).to.be.true;
 			});
 		});
 
@@ -510,7 +557,7 @@ describe('FilterBarComponent', function () {
 			this.filterBar.init();
 
 			expect(this.$container.find('span[data-filter-id="size"]')).to.have.length(1);
-			expect(this.$container.find('span[data-filter-id="size"]').text()).to.be.equal('Size: Medium');
+			expect(this.$container.find('span[data-filter-id="size"] .label__text').text()).to.be.equal('Size: Medium');
 		});
 
 		it('should add a comma separated label to the filterbar for select inputs with the multiple attribute', function () {
@@ -519,7 +566,23 @@ describe('FilterBarComponent', function () {
 			this.filterBar.init();
 
 			expect(this.$container.find('span[data-filter-id="colour"]')).to.have.length(1);
-			expect(this.$container.find('span[data-filter-id="colour"]').text()).to.be.equal('Colour: Red, Blue');
+			expect(this.$container.find('span[data-filter-id="colour"] .label__text').text()).to.be.equal('Colour: Red, Blue');
+		});
+
+		it('should the correct accessible text to the label remove button for checkbox fields', function () {
+			this.filterBar.init();
+
+			var $checkboxLabelRemoveButtonA11yText = this.$container.find('span[data-filter-id="inStock"] .remove-button .hide').text();
+
+			expect($checkboxLabelRemoveButtonA11yText).to.be.equal('Remove In stock filter');
+		});
+
+		it('should the correct accessible text to the label remove button for other fields', function () {
+			this.filterBar.init();
+
+			var $textInputLabelRemoveButtonA11yText = this.$container.find('span[data-filter-id="foo"] .remove-button .hide').text();
+
+			expect($textInputLabelRemoveButtonA11yText).to.be.equal('Remove Text field example filter');
 		});
 
 		it('should hide the add filter button if all filters have been used', function () {

--- a/views/lexicon/patterns/filters/create-filter.html.twig
+++ b/views/lexicon/patterns/filters/create-filter.html.twig
@@ -36,9 +36,8 @@
                     form.select2({
                         'label': 'Colour (single + ph)',
                         'id': 'colour-' ~ random(),
-                        'data-placeholder': 'Select One',
+                        'placeholder': 'Select One',
                         'options': {
-                            '': 'Select one',
                             'colour_red': 'Red',
                             'colour_blue': 'Blue'
                         }
@@ -50,7 +49,7 @@
                         'label': 'Colour 3 (multi + ph)',
                         'id': 'colour-' ~ random(),
                         'multiple': true,
-                        'data-placeholder': 'Select one or more',
+                        'placeholder': 'Select one or more',
                         'options': {
                             'colour_red': 'Red',
                             'colour_blue': 'Blue'
@@ -80,6 +79,7 @@
 
                 {{
                     form.date({
+                        'data-pulsar-datepicker': 'true',
                         'label': 'Added from',
                         'id': 'addedFrom-' ~ random(),
                         'class': 'form__group--full'
@@ -88,6 +88,7 @@
 
                 {{
                     form.date({
+                        'data-pulsar-datepicker': 'true',
                         'label': 'Added to',
                         'id': 'addedTo-' ~ random(),
                         'class': 'form__group--full'
@@ -96,6 +97,7 @@
 
                 {{
                     form.checkbox({
+                        'data-pulsar-datepicker': 'true',
                         'label': 'In stock',
                         'id': 'inStock-' ~ random(),
                     })

--- a/views/lexicon/patterns/filters/load-filter.html.twig
+++ b/views/lexicon/patterns/filters/load-filter.html.twig
@@ -36,9 +36,8 @@
                     form.select2({
                         'label': 'Colour (single + ph)',
                         'id': 'colour-' ~ random(),
-                        'data-placeholder': 'Select One',
+                        'placeholder': 'Select One',
                         'options': {
-                            '': 'Select One',
                             'colour_red': 'Red',
                             'colour_blue': 'Blue'
                         }
@@ -49,10 +48,9 @@
                     form.select2({
                         'label': 'Colour (single + ph + preselected)',
                         'id': 'colour-' ~ random(),
-                        'data-placeholder': 'Select One',
+                        'placeholder': 'Select One',
                         'selected': 'colour_blue',
                         'options': {
-                            '': 'Select One',
                             'colour_red': 'Red',
                             'colour_blue': 'Blue'
                         }
@@ -64,7 +62,7 @@
                         'label': 'Colour 3 (multi + ph)',
                         'id': 'colour-' ~ random(),
                         'multiple': true,
-                        'data-placeholder': 'Select one or more',
+                        'placeholder': 'Select one or more',
                         'options': {
                             'colour_red': 'Red',
                             'colour_blue': 'Blue'
@@ -102,21 +100,26 @@
                     form.text({
                         'label': 'Text field example',
                         'id': 'foo-' ~ random(),
+                        'class': 'form__group--full'
                     })
                 }}
 
                 {{
                     form.date({
+                        'data-pulsar-datepicker': 'true',
                         'label': 'Added from',
                         'id': 'addedFrom-' ~ random(),
+                        'class': 'form__group--full'
                     })
                 }}
 
                 {{
                     form.date({
+                        'data-pulsar-datepicker': 'true',
                         'label': 'Added to',
                         'id': 'addedTo-' ~ random(),
-                        'value': '04/07/2017'
+                        'value': '04/07/2017',
+                        'class': 'form__group--full'
                     })
                 }}
 


### PR DESCRIPTION
This branch contains the following changes:

1. When the actions menu "New filter" option is clicked, focus is set on the add filter (+) button.
2. When a new filter is added, focus is moved to the add filter (+) button. If the add button is not visible, the save button is focussed.
3. When a filter option is removed (via the label remove button), the add filter (+) button is focussed.
4. The add filter button (+) now uses `aria-expanded`.
5. Filter option links in the initial choose filter popover now have `role="button"`.
6. Filter label remove buttons have better accessible text. Rather than just `remove` they read `remove {filter-label} filter`. 
7. Select2 fields in filter popovers are no longer automatically opened. Instead they are focussed in the same way as other input types.

Screen reader tested in:
- MacOS Safari VO
- IE11 JAWS 2020
- IE11 NVDA
- Edge JAWS 2020
- Edge NVDA