### PR TITLE
Tab enhancement fixes

### DIFF
--- a/js/TabEnhancements/TabEnhancements.js
+++ b/js/TabEnhancements/TabEnhancements.js
@@ -18,6 +18,9 @@ class TabEnhancements {
         // Make sure tab panes are at least as high as the tab list (cms legacy tabs list)
         this.$html.find('.tabs > .tabs__content > .tab__pane').css('min-height', this.$html.find('.tabs__list').height());
 
+        // Remove skip target IDs set in markup
+        this.$html.find('main.tab__content').removeAttr('id');
+
         // Add the skip-target ID to the active main
         this.$html.find('.tab__pane.is-active main.tab__content').attr('id', 'skip-target');
 

--- a/js/TabEnhancements/TabEnhancements.js
+++ b/js/TabEnhancements/TabEnhancements.js
@@ -18,47 +18,19 @@ class TabEnhancements {
         // Make sure tab panes are at least as high as the tab list (cms legacy tabs list)
         this.$html.find('.tabs > .tabs__content > .tab__pane').css('min-height', this.$html.find('.tabs__list').height());
 
-        // Switch the first active tab to use <main> with the skip target
-        this.changeActiveTabElementToMain(this.$html.find('.tab__pane.is-active'));
+        // Add the skip-target ID to the active main
+        this.$html.find('.tab__pane.is-active main.tab__content').attr('id', 'skip-target');
 
-        // Make the current tabs .tab__content <main> and the previous tabs .tab__content <div>
-        // to avoid multiple <main>'s in the DOM at one time
+        // On tab change
         this.$html.find('.nav-inline [data-toggle="tab"]').on('show.bs.tab', (event) => {
             const $activeTab = this.$html.find($(event.target).attr('href'));
-            const $previousTab = this.$html.find($(event.relatedTarget).attr('href'));
 
-            this.changeActiveTabElementToMain($activeTab);
-            this.changePreviousTabElementToDiv($previousTab);
+            // Remove previously set skip target IDs on other tabs
+            this.$html.find('main.tab__content').removeAttr('id');
+
+            // Add skip target ID to new active tab main
+            $activeTab.find('main.tab__content').attr('id', 'skip-target');
         });
-
-    }
-
-    /**
-     * Change the active tab's main element from a <div> to a <main> and add the skip target ID
-     * @param {jQuery} $activeTab - a jQuery wrapper of the newly active tab
-     */
-    changeActiveTabElementToMain($activeTab) {
-        const $activeTabInner = $activeTab.find('.tab__inner');
-        const $activeTabChildrenOfMain = $activeTab.find('.tab__content').contents();
-        const $activeTabNewMain = $('<main class="tab__content" id="skip-target"></main>').append($activeTabChildrenOfMain);
-        const $activeTabOldMain = $activeTab.find('.tab__content');
-
-        $activeTabOldMain.remove();
-        $activeTabNewMain.prependTo($activeTabInner);
-    }
-
-    /**
-     * Change the previous tab's main element from a <main> to a <div>
-     * @param {jQuery} $previousTab - a jQuery wrapper of the previously active tab
-     */
-    changePreviousTabElementToDiv($previousTab) {
-        const $previousTabInner = $previousTab.find('.tab__inner');
-        const $previousTabChildrenOfMain = $previousTab.find('.tab__content').contents();
-        const $previousTabNewMain = $('<div class="tab__content"></div>').append($previousTabChildrenOfMain);
-        const $previousTabOldMain = $previousTab.find('.tab__content');
-
-        $previousTabOldMain.remove();
-        $previousTabNewMain.prependTo($previousTabInner);
     }
 }
 

--- a/tests/js/web/TabEnhancements/TabEnhancementsTest.js
+++ b/tests/js/web/TabEnhancements/TabEnhancementsTest.js
@@ -38,7 +38,7 @@ describe('TabEnhancements', () => {
                 <div class="tab__pane is-active" id="tab1">
                     <div class="tab__container">
                         <div class="tab__inner">
-                            <main class="tab__content">
+                            <main class="tab__content id="skip-target">
                                 <p>tab 1 content</p>
                             </main>
                         </div>
@@ -47,7 +47,7 @@ describe('TabEnhancements', () => {
                 <div class="tab__pane" id="tab2">
                     <div class="tab__container">
                         <div class="tab__inner">
-                            <main class="tab__content">
+                            <main class="tab__content" id="skip-target">
                                 <p>tab 2 content</p>
                             </main>
                         </div>
@@ -87,6 +87,10 @@ describe('TabEnhancements', () => {
     describe('When the page loads', () => {
         beforeEach(() => {
             tabEnhancements.init($html);
+        });
+
+        it('should remove any id="skip-target" set in original markup', () => {
+            expect($body.find('#currentTabs #tab2 .tab__content').attr('id')).to.be.undefined;
         });
 
         it('should add id="skip-target" to the active tabs <main>', () => {

--- a/tests/js/web/TabEnhancements/TabEnhancementsTest.js
+++ b/tests/js/web/TabEnhancements/TabEnhancementsTest.js
@@ -38,18 +38,18 @@ describe('TabEnhancements', () => {
                 <div class="tab__pane is-active" id="tab1">
                     <div class="tab__container">
                         <div class="tab__inner">
-                            <div class="tab__content">
+                            <main class="tab__content">
                                 <p>tab 1 content</p>
-                            </div>
+                            </main>
                         </div>
                     </div>
                 </div>
                 <div class="tab__pane" id="tab2">
                     <div class="tab__container">
                         <div class="tab__inner">
-                            <div class="tab__content">
+                            <main class="tab__content">
                                 <p>tab 2 content</p>
-                            </div>
+                            </main>
                         </div>
                     </div>
                 </div>
@@ -89,10 +89,6 @@ describe('TabEnhancements', () => {
             tabEnhancements.init($html);
         });
 
-        it('should change the active tabs main element to <main>', () => {
-            expect($body.find('#currentTabs #tab1 .tab__content').is('main')).to.be.true;
-        });
-
         it('should add id="skip-target" to the active tabs <main>', () => {
             expect($body.find('#currentTabs #tab1 .tab__content').attr('id')).to.equal('skip-target');
         });
@@ -100,46 +96,17 @@ describe('TabEnhancements', () => {
 
     describe('When a new tab is shown', () => {
         beforeEach(() => {
-            sinon.spy(tabEnhancements, 'changePreviousTabElementToDiv');
-
             tabEnhancements.init($html);
 
             $body.find('#tabLink2').trigger('show.bs.tab');
-        });
-
-        it('should change the active tabs main element to <main>', () => {
-            expect($body.find('#currentTabs #tab2 .tab__content').is('main')).to.be.true;
         });
 
         it('should add id="skip-target" to the active tabs <main>', () => {
             expect($body.find('#currentTabs #tab2 .tab__content').attr('id')).to.equal('skip-target');
         });
 
-        it('should copy the contents active tabs main element over to the the new <main>', () => {
-            expect($body.find('#currentTabs #tab2 .tab__content').html().trim()).to.equal('<p>tab 2 content</p>');
-        });
-
-        // Test event is missing event.relatedTarget so testing the method is called and behaviour separately
-        it('should reset the previous tab by calling changePreviousTabElementToDiv()', () => {
-            expect(tabEnhancements.changePreviousTabElementToDiv).to.have.been.calledOnce;
-        });
-
-        describe('changePreviousTabElementToDiv()', () => {
-            beforeEach(() => {
-                tabEnhancements.changePreviousTabElementToDiv($body.find('#tab1'));
-            });
-
-            it('should replace the previous tabs <main class="tab__content"> element with <div class="tab__content">', () => {
-                expect($body.find('#currentTabs #tab1 .tab__content').is('div')).to.be.true;
-            });
-
-            it('should remove the id="skip-target"', () => {
-                expect($body.find('#currentTabs #tab1 .tab__content').attr('id')).to.be.undefined;
-            });
-
-            it('should copy the content from the old <main> to the new <div>', () => {
-                expect($body.find('#currentTabs #tab1 .tab__content').html().trim()).to.equal('<p>tab 1 content</p>');
-            });
+        it('should remove the id="skip-target" from the previous tabs main', () => {
+            expect($body.find('#currentTabs #tab1 .tab__content').attr('id')).to.be.undefined;
         });
     });
 });

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-template-active.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-template-active.html
@@ -11,14 +11,14 @@
 <div class="tab__pane" id="alpha">
     <div class="tab__container">
         <div class="tab__inner">
-            <div class="tab__content"></div>
+            <main class="tab__content" id="skip-target"></main>
         </div>
     </div>
 </div>
 <div class="tab__pane is-active" id="bravo">
     <div class="tab__container">
         <div class="tab__inner">
-            <div class="tab__content"></div>
+            <main class="tab__content" id="skip-target"></main>
         </div>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-template.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-template.html
@@ -8,7 +8,7 @@
 <div class="tab__pane is-active" id="foo">
     <div class="tab__container">
         <div class="tab__inner">
-            <div class="tab__content"></div>
+            <main class="tab__content" id="skip-target"></main>
         </div>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-url-href-with-src-active.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-url-href-with-src-active.html
@@ -11,14 +11,14 @@
 <div class="tab__pane" id="alpha">
     <div class="tab__container">
         <div class="tab__inner">
-            <div class="tab__content"></div>
+            <main class="tab__content" id="skip-target"></main>
         </div>
     </div>
 </div>
 <div class="tab__pane is-active" id="bravo">
     <div class="tab__container">
         <div class="tab__inner">
-            <div class="tab__content"></div>
+            <main class="tab__content" id="skip-target"></main>
         </div>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-url-href-with-src.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/tabs/tabs_list-url-href-with-src.html
@@ -8,7 +8,7 @@
 <div class="tab__pane is-active" id="foo">
     <div class="tab__container">
         <div class="tab__inner">
-            <div class="tab__content"></div>
+            <main class="tab__content" id="skip-target"></main>
         </div>
     </div>
 </div>

--- a/views/pulsar/components/tab.html.twig
+++ b/views/pulsar/components/tab.html.twig
@@ -64,9 +64,9 @@
             {{ _settings|raw }}
         </section>
         {% endif %}
-        <div class="tab__content">
+        <main class="tab__content">
             {% block tab_content %}{% endblock %}
-        </div>
+        </main>
         {% if _hasSidebar == true %}
         <aside class="tab__sidebar" aria-label="additional information">
             {{ _sidebar|raw }}

--- a/views/pulsar/components/tab.html.twig
+++ b/views/pulsar/components/tab.html.twig
@@ -64,7 +64,7 @@
             {{ _settings|raw }}
         </section>
         {% endif %}
-        <main class="tab__content">
+        <main class="tab__content" id="skip-target">
             {% block tab_content %}{% endblock %}
         </main>
         {% if _hasSidebar == true %}


### PR DESCRIPTION
This branch contains the following changes:

1. The behaviour added in #1258 and #1284 that swapped the `main` element to a `div` and visa-versa on JS tab changes has been removed.
2. Markup in `tab.html.twig` includes `<main id="skip-target>` to ensure pages that don't use tab.js and reload the page on tab change have the skip target ID set on `<main>`.
3. The swapping of `id="skip-target"` is managed in `TabEnhancements.js`, so that when JS tabs are changed, the skip target ID moves over to the active tabs `main` (and is removed from non-active tabs main)

This does mean that we will see the following markup validation failure for pulsar pages which use JS tabs:
```
A document must not include more than one visible “main” element
```
However, the DOM is valid as other `main`'s outside of the currently active tab are hidden from the a11y tree via `display: none` on non-active `tab__pane`'s. The only way around that would be to add the `hidden` property to non active `main`'s  at a markup or twig level, when we know JS tabs are being used. Something to discuss.