### PR TITLE
Fix html.loading outputting options as attributes

### DIFF
--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/loading-block.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/loading-block.html
@@ -1,0 +1,3 @@
+<div class="loading-block">
+    <span class="loading"><i>Custom loading...</i></span>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/loading-block.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/loading-block.html.twig
@@ -1,0 +1,9 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    html.loading({
+        'label': 'Custom loading...',
+        'type': 'block'
+    })
+}}
+{% endblock %}

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/loading-message.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/loading-message.html
@@ -1,0 +1,4 @@
+<div class="loading-block">
+    <span class="loading"><i>Loading...</i></span>
+    <span class="loading-block__message">Loading content...</span>
+</div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/loading-message.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/html/loading-message.html.twig
@@ -1,0 +1,9 @@
+{% extends '@cssTests/visual-regression-layout.html.twig' %}
+{% block body %}
+{{
+    html.loading({
+        'type': 'block',
+        'message': 'Loading content...'
+    })
+}}
+{% endblock %}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1039,7 +1039,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
         <span{{
             attributes(options
-                |exclude('label')
+                |exclude('label type message')
                 |defaults({
                     'class': 'loading'
                 })


### PR DESCRIPTION
This branch fixes an issue where the `html.loading()` helper would incorrectly output the `type` and `message` options as attributes in the the markup.

**Before:**
```
<span message="Loading content..." type="block" class="loading loading--large"><i>Loading...</i></span>
```

**After:**
```
<span class="loading loading--large"><i>Loading...</i></span>
```