### PR TITLE
Fix error text contrast vs sidebar bg

### DIFF
--- a/stylesheets/_palette.base.scss
+++ b/stylesheets/_palette.base.scss
@@ -186,7 +186,7 @@ $palette-alias: (
     background: (
         base:      map-get(map-get($palette-monochromes, gray), off-white),
         dark:      map-get(map-get($palette-monochromes, gray), lightest),
-        light:     lighten(map-get(map-get($palette-monochromes, gray), off-white), 2),
+        light:     lighten(map-get(map-get($palette-monochromes, gray), off-white), 2.1),
         selected:  map-get(map-get($palette-states, info), light),
         focus:     #fd0
     ),

--- a/views/lexicon/patterns/settings-panel/tab.html.twig
+++ b/views/lexicon/patterns/settings-panel/tab.html.twig
@@ -64,13 +64,15 @@
             form.text({
                 'id': 'guid-' ~ random(),
                 'label': 'Text',
+                'error': 'Please complete this field'
             })
         }}
 
         {{
             form.textarea({
                 'id': 'guid-' ~ random(),
-                'label': 'Textarea'
+                'label': 'Textarea',
+                'error': 'Please complete this field'
             })
         }}
 
@@ -78,6 +80,7 @@
             form.password({
                 'id': 'guid-' ~ random(),
                 'label': 'Password',
+                'error': 'Please complete this field'
             })
         }}
 
@@ -85,27 +88,31 @@
             form.date({
                 'id': 'guid-' ~ random(),
                 'label': 'Date',
+                'error': 'Please complete this field'
             })
         }}
 
         {{
             form.time({
                 'id': 'guid-' ~ random(),
-                'label': 'Time'
+                'label': 'Time',
+                'error': 'Please complete this field'
             })
         }}
 
         {{
             form.file({
                 'id': 'guid-' ~ random(),
-                'label': 'File'
+                'label': 'File',
+                'error': 'Please complete this field'
             })
         }}
 
         {{
             form.color({
                 'id': 'guid-' ~ random(),
-                'label': 'Color'
+                'label': 'Color',
+                'error': 'Please complete this field'
             })
         }}
 
@@ -113,6 +120,7 @@
             form.select({
                 'label': 'Select',
                 'id': 'guid-' ~ random(),
+                'error': 'Please complete this field',
                 'options': [
                     {
                         'label': 'Value one',
@@ -130,6 +138,7 @@
             form.select2({
                 'label': 'Select2',
                 'id': 'guid-' ~ random(),
+                'error': 'Please complete this field',
                 'options': [
                     {
                         'label': 'Value one',
@@ -149,7 +158,7 @@
                 'id': 'guid-' ~ random(),
                 'inputs': [
                     {
-                        
+
                         'label': 'Value',
                         'id': 'value-0',
                         'maxlength': '3',
@@ -290,7 +299,7 @@
                 'id': 'guid-' ~ random(),
                 'inputs': [
                     {
-                        
+
                         'label': 'Value',
                         'id': 'value-0',
                         'maxlength': '3',
@@ -492,6 +501,6 @@
                     })
                 ]
             })
-        }} 
+        }}
 
 {% endblock tab_content %}


### PR DESCRIPTION
This branch slightly lightens the sidebar bg colour so that when error text is displayed within a sidebar, AA contrast is met.

Before (radio: 4.41:1):
![image](https://user-images.githubusercontent.com/756393/90776353-e8dcc680-e2f1-11ea-8465-3651ac3afdbe.png)


After (ratio 4.61:1):
![image](https://user-images.githubusercontent.com/756393/90776223-be8b0900-e2f1-11ea-9130-8c7c60d0a36b.png)

