### PR TITLE
Darken help text to fix contrast warning in IBM a11y tool

### DIFF
--- a/stylesheets/_palette.base.scss
+++ b/stylesheets/_palette.base.scss
@@ -59,7 +59,7 @@ $palette-monochromes: (
     gray:  (
         darker:      rgb(62, 62, 62),
         dark:        rgb(95, 95, 95),
-        dull:        rgb(117, 117, 117),
+        dull:        rgb(110, 110, 110),
         base:        rgb(126, 126, 126),
         light:       rgb(157, 157, 157),
         lighter:     rgb(190, 190, 190),


### PR DESCRIPTION
To be merged into `CMS/flatcap-july` and included into products when CMS request `beta2`