### PR TITLE
Lighten table form backgrounds to fix error contrast

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -445,16 +445,6 @@ fieldset {
   }
 }
 
-.table__form .form__group:not(.form__group--partial-state) {
-    &.has-warning {
-      @include form__group-validation(darken($state-warning-text, 5), color(warning), $state-warning-bg);
-    }
-
-    &.has-error {
-      @include form__group-validation(darken($state-danger-text, 5), color(danger), $state-danger-bg);
-    }
-  }
-
 .form__group--partial-state {
     &.has-changed {
         @include form__group-partial-validation($state-info-text, color(info, dark));

--- a/stylesheets/_component.tables.scss
+++ b/stylesheets/_component.tables.scss
@@ -240,7 +240,7 @@ td.table__form {
 
 td.table__form,
 .table__form td {
-    background-color: color(background);
+    background-color: color(background, light);
 
     .help-block {
         color: color(text);


### PR DESCRIPTION
Previous solve for this didn’t fix all instances, changing the background (as previously suggested) should fix all contrast state issues.