### PR TITLE
Make sure horizontal scrollbar is visible for tabbed navigation inside piano content

### DIFF
--- a/stylesheets/_component.piano.scss
+++ b/stylesheets/_component.piano.scss
@@ -329,15 +329,3 @@ $piano-bg: #fafafa;
 .setting__actions {
     padding: 10px;
 }
-
-.piano-wrapper {
-
-    .tab__content {
-        display: table;
-    }
-
-    .tabs__content {
-        display: table;
-        width: 100%;
-    }
-}


### PR DESCRIPTION
Related to CMS-6986

This rule causes the scrollbar to not be visible, the git history says that it was added to resolve an issue with full screen tables in the Perceptive Content integrations UI.

I’ve tested this UI with and without this ruleset active, in the usual browsers, and there is no negative effect with removing it, the presumption at this time is that there have been other changes to either Pianos or Tables which render this changeset redundant.