### PR TITLE
Set a consistent font size for card titles so that any heading tag can be used

### DIFF
--- a/stylesheets/_component.cards.scss
+++ b/stylesheets/_component.cards.scss
@@ -27,6 +27,7 @@
 
 .card__title {
     font-family: $font-family-regular;
+    font-size: $font-size-large;
 }
 
 .card__body {

--- a/stylesheets/_component.cards.scss
+++ b/stylesheets/_component.cards.scss
@@ -26,8 +26,11 @@
 }
 
 .card__title {
+    display: inline-block;
     font-family: $font-family-regular;
     font-size: $font-size-large;
+    line-height: 1em;
+    margin: 0 0 1em;
 }
 
 .card__body {


### PR DESCRIPTION
Requiring cards to use a h3 means we might be using inappropriate heading levels. This change also allows non `h*` tags to be used.

**Before**
![Screenshot 2020-09-16 at 14 03 38](https://user-images.githubusercontent.com/18653/93341917-9aeeac00-f826-11ea-993f-5552b5cde04d.png)
**After**
![Screenshot 2020-09-16 at 14 02 21](https://user-images.githubusercontent.com/18653/93341930-9f1ac980-f826-11ea-8bf5-cdab613ba542.png)
