### PR TITLE
Stop flush inputs inheriting nowrap from horizontal table cells

### DIFF
--- a/stylesheets/_component.tables.scss
+++ b/stylesheets/_component.tables.scss
@@ -282,6 +282,11 @@ td.row__actions {
     th,
     td {
         white-space: nowrap;
+
+        // Maintain expected behaviour of flush inputs
+        .form__group--flush {
+            white-space: normal;
+        }
     }
 }
 


### PR DESCRIPTION
Flush inputs are being affected by the `nowrap` rule which forces tables to maintain horizontal width and rely on scrolling. This change allows flush inputs to wrap and put the input on the left edge as expected.

**Example**
![table-flush-inputs](https://user-images.githubusercontent.com/18653/93351344-8a8ffe80-f831-11ea-890b-e4ee04458819.gif)

