### PR TITLE
Fix contrast issue when danger text/icon colour appears in a table row with hover effect

### DIFF
--- a/stylesheets/_component.status.scss
+++ b/stylesheets/_component.status.scss
@@ -44,8 +44,4 @@
     &.is-offline {
         color: color(danger);
     }
-
-    span {
-        color: color(text);
-    }
 }

--- a/stylesheets/_component.status.scss
+++ b/stylesheets/_component.status.scss
@@ -44,4 +44,8 @@
     &.is-offline {
         color: color(danger);
     }
+
+    span {
+        color: color(text);
+    }
 }

--- a/stylesheets/_palette.base.scss
+++ b/stylesheets/_palette.base.scss
@@ -100,10 +100,10 @@ $palette-states: (
         dark:  darken(#eaa96a, 35)
     ),
     danger: (
-        base:  #c84d40,
-        alt:   pick_best_color(#c84d40, (#fff, #000)),
-        light: lighten(#c84d40, 40),
-        dark:  darken(#c84d40, 5)
+        base:  #c74a3d,
+        alt:   pick_best_color(#c74a3d, (#fff, #000)),
+        light: lighten(#c74a3d, 40),
+        dark:  darken(#c74a3d, 5)
     ),
     info: (
         base:  map-get(map-get($palette-branding, jadu-blue), pale),

--- a/stylesheets/_palette.base.scss
+++ b/stylesheets/_palette.base.scss
@@ -100,10 +100,10 @@ $palette-states: (
         dark:  darken(#eaa96a, 35)
     ),
     danger: (
-        base:  #c74a3d,
-        alt:   pick_best_color(#c74a3d, (#fff, #000)),
-        light: lighten(#c74a3d, 40),
-        dark:  darken(#c74a3d, 5)
+        base:  #b64135,
+        alt:   pick_best_color(#b64135, (#fff, #000)),
+        light: lighten(#b64135, 40),
+        dark:  darken(#b64135, 5)
     ),
     info: (
         base:  map-get(map-get($palette-branding, jadu-blue), pale),


### PR DESCRIPTION
No visual difference, but makes sure danger contrast meets AA when on a background of `#fafafa`

Relates to XFP-4364

![Screenshot 2020-09-18 at 09 29 09](https://user-images.githubusercontent.com/18653/93575344-7105c880-f991-11ea-9106-dac9e26c3463.png)
