### PR TITLE
Make sure help blocks wrap properly when in a table—horizontal form

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -496,6 +496,7 @@ fieldset {
     color: color(text, help);
     display: block;
     font-size: $font-size-base;
+    white-space: normal;
 }
 
 // if a control label is in the help block (like a bare input) it doesn't need


### PR DESCRIPTION
This stops the `nowrap` in horizontal tables from affecting help blocks.

**Before**
![Screenshot 2020-09-18 at 10 13 34](https://user-images.githubusercontent.com/18653/93580427-ad3c2780-f997-11ea-9d43-6df264206dc9.png)

**After**
![Screenshot 2020-09-18 at 10 13 47](https://user-images.githubusercontent.com/18653/93580441-b1684500-f997-11ea-9373-6d8688b5d664.png)
