### PR TITLE
Patch areas in tooltip code where malicious selectors could be passed through tooltip options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Form labels for choice block components are now properly aligned vertically with the inputs [#1332](https://github.com/jadu/pulsar/pull/1332)
 
 ### Security
+- Stop (old) tooltip.js from directly interpreting selectors passed through options [#1359](https://github.com/jadu/pulsar/pull/1359)
 - Add escaping on values which are extracted from DOM notes then output in the view [#1331](https://github.com/jadu/pulsar/pull/1331)
 - Upgrade datatables.net-responsive-dt from 2.2.3 to 2.2.6 [#1336](https://github.com/jadu/pulsar/pull/1336)
 - Upgrade datatables from 1.10.22 to 1.10.23 [#1346](https://github.com/jadu/pulsar/pull/1346)

--- a/js/libs/tooltip.js
+++ b/js/libs/tooltip.js
@@ -50,7 +50,7 @@ var $ = require('jquery'),
     this.type      = type
     this.$element  = $(element)
     this.options   = this.getOptions(options)
-    this.$viewport = this.options.viewport && $(this.options.viewport.selector || this.options.viewport)
+    this.$viewport = this.options.viewport && $.find(this.options.viewport.selector || this.options.viewport)
 
     var triggers = this.options.trigger.split(' ')
 
@@ -159,7 +159,7 @@ var $ = require('jquery'),
         .css({ top: 0, left: 0, display: 'block' })
         .addClass(placement)
 
-      this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
+      this.options.container ? $tip.appendTo($.find(this.options.container)) : $tip.insertAfter(this.$element)
 
       var pos          = this.getPosition()
       var actualWidth  = $tip[0].offsetWidth


### PR DESCRIPTION
There is a low chance of this being exploited as it would need code access to change the options of the tooltip init code.

2 fixed alerts
Unsafe jQuery plugin (js/libs/tooltip.js#L53)
Unsafe jQuery plugin (js/libs/tooltip.js#L162)