### PR TITLE
Add tight spacing option for form groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add CHANGELOG.md file [#1352](https://github.com/jadu/pulsar/pull/1352)
 - Add ability for textareas to use common appended/prepended options [#1314](https://github.com/jadu/pulsar/pull/1314)
-- Add `.form__group--tight` modifier to reduce vertical spacing between form groups
+- Add `.form__group--tight` modifier to reduce vertical spacing between form groups [#1360](https://github.com/jadu/pulsar/pull/1360)
 
 ### Changed
 - Sticky sidebar behaviour (used by XFP) is now more consistent and visually stable regardless of main content height [#1326](https://github.com/jadu/pulsar/pull/1326)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add CHANGELOG.md file [#1352](https://github.com/jadu/pulsar/pull/1352)
 - Add ability for textareas to use common appended/prepended options [#1314](https://github.com/jadu/pulsar/pull/1314)
+- Add `.form__group--tight` modifier to reduce vertical spacing between form groups
 
 ### Changed
 - Sticky sidebar behaviour (used by XFP) is now more consistent and visually stable regardless of main content height [#1326](https://github.com/jadu/pulsar/pull/1326)

--- a/stylesheets/_structure.forms.scss
+++ b/stylesheets/_structure.forms.scss
@@ -57,6 +57,11 @@
     @include col-span($form-control-cols, false);
 }
 
+// Tight spacing to bring related controls closer together
+.form__group.form__group--tight {
+    margin-bottom: $margin-base-vertical;
+}
+
 // inputs can be aligned next to each other if required
 .form__group--inline > .controls {
 


### PR DESCRIPTION
Adds a `.form__group--tight` modifier to reduce the vertical margins of a form group to allow related controls to be brought closer together.

This change is required to address a scratch rule currently in use in XFP.

**Before**
![Screenshot 2021-01-08 at 08 55 25](https://user-images.githubusercontent.com/18653/103994715-484b4e00-518f-11eb-9dc5-7b09d5575c69.png)

**After**
![Screenshot 2021-01-08 at 08 55 52](https://user-images.githubusercontent.com/18653/103994732-513c1f80-518f-11eb-86fd-55f6d9d87059.png)

Closes #711