### PR TITLE
Table caption styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add CHANGELOG.md file [#1352](https://github.com/jadu/pulsar/pull/1352)
 - Add ability for textareas to use common appended/prepended options [#1314](https://github.com/jadu/pulsar/pull/1314)
+- Add table caption styles [#1361](https://github.com/jadu/pulsar/pull/1361)
 
 ### Changed
 - Sticky sidebar behaviour (used by XFP) is now more consistent and visually stable regardless of main content height [#1326](https://github.com/jadu/pulsar/pull/1326)

--- a/stylesheets/_component.tables.scss
+++ b/stylesheets/_component.tables.scss
@@ -2,6 +2,11 @@
     border-collapse: collapse;
     margin-bottom: 24px;
 
+    caption {
+        display: table-caption;
+        text-align: left;
+    }
+
     [href],
     .continuum-cms & [href]:link {
         border-bottom: 1px dotted color(grey, light);

--- a/stylesheets/_component.tables.scss
+++ b/stylesheets/_component.tables.scss
@@ -4,7 +4,17 @@
 
     caption {
         display: table-caption;
+        padding-bottom: $padding-large-vertical;
         text-align: left;
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            margin-bottom: 0;
+        }
     }
 
     [href],

--- a/views/lexicon/tables/basic.html.twig
+++ b/views/lexicon/tables/basic.html.twig
@@ -2,7 +2,7 @@
 
 {% block tab_content %}
     <table class="table table--full">
-        <caption class="hide">A list of Servers</caption>
+        <caption>A list of Servers</caption>
         <thead>
             <tr>
                 <th>Name</th>


### PR DESCRIPTION
This branch adds basic styling to table `<caption>` elements.

Before (chrome default styling):
![Screenshot 2021-01-08 at 15 30 39](https://user-images.githubusercontent.com/756393/104032764-86b02f80-51c6-11eb-8b25-bdf46b438257.png)

After:
![Screenshot 2021-01-08 at 15 30 48](https://user-images.githubusercontent.com/756393/104032777-8ca61080-51c6-11eb-8401-f9a733184715.png)

Fixes #1347 