### PR TITLE
Prepend form error text with visually hidden “Error:”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Sticky sidebar behaviour (used by XFP) is now more consistent and visually stable regardless of main content height [#1326](https://github.com/jadu/pulsar/pull/1326)
+- Form helper outputted error text is now prepended with a visually hidden `Error:` to improve SR experience [#1364](https://github.com/jadu/pulsar/pull/1364)
 
 ### Fixed
 - Progress bar with warning state and a visible value failed colour contrast [#1350](https://github.com/jadu/pulsar/pull/1350)

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/button_group-error.html
@@ -6,6 +6,6 @@
         <label class="control__label">FM</label>
         <input name="bands" type="radio" class="form__control radio" />
         <label class="control__label">MW</label>
-        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/checkbox-error.html
@@ -1,6 +1,6 @@
 <div class="form__group has-error form-checkbox">
     <div class="controls">
         <input type="checkbox" aria-describedby="guid-1" class="form__control checkbox" />
-        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/choice-error.html
@@ -12,6 +12,6 @@
             <input name="choice" value="baz" aria-describedby="guid-1" type="radio" class="form__control radio" />
             <span class="form-choice__label">Baz</span>
         </label>
-        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </fieldset>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/content-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/content-error.html
@@ -1,6 +1,6 @@
 <div class="form__group has-error">
     <div class="controls">
         <p>foo</p>
-        <span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/date-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/date-error.html
@@ -1,6 +1,6 @@
 <div class="form__group has-error">
     <div class="controls">
         <input placeholder="dd/mm/yyyy" data-datepicker="true" data-format="default" type="text" aria-describedby="guid-1" class="form__control" />
-        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/error-multiple.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/error-multiple.html
@@ -1,2 +1,2 @@
-<span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> foo</span>
-<span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> bar</span>
+<span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> foo</span>
+<span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> bar</span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/error-single.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/error-single.html
@@ -1,1 +1,1 @@
-<span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> foo</span>
+<span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> foo</span>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/file-error.html
@@ -1,6 +1,6 @@
 <div class="form__group has-error">
     <div class="controls">
         <input type="file" aria-describedby="guid-1" class="form__control file" />
-        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/password-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/password-error.html
@@ -1,6 +1,6 @@
 <div class="form__group has-error">
     <div class="controls">
         <input type="password" aria-describedby="guid-1" class="form__control" />
-        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio-error.html
@@ -1,6 +1,6 @@
 <div class="form__group has-error form-radio">
     <div class="controls">
         <input type="radio" aria-describedby="guid-1" class="form__control radio" />
-        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio_inline-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/radio_inline-error.html
@@ -1,6 +1,6 @@
 <div class="form__group has-error form-radio-inline">
     <div class="controls">
         <label class="control__label"><input type="radio" aria-describedby="guid-1" class="form__control radio" />foo</label>
-        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select-error.html
@@ -4,6 +4,6 @@
             <option value="foo">bar</option>
             <option value="bar">baz</option>
         </select>
-        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/select2-error.html
@@ -4,6 +4,6 @@
             <option value="foo">bar</option>
             <option value="bar">baz</option>
         </select>
-        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/text-error.html
@@ -1,6 +1,6 @@
 <div class="form__group has-error">
     <div class="controls">
         <input type="text" class="form__control" />
-        <span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/textarea-error.html
@@ -1,6 +1,6 @@
 <div class="form__group has-error">
     <div class="controls">
         <textarea aria-describedby="guid-1" class="form__control textarea"></textarea>
-        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/time-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/time-error.html
@@ -1,6 +1,6 @@
 <div class="form__group has-error">
     <div class="controls">
         <input placeholder="hh:mm" data-timepicker="true" type="text" aria-describedby="guid-1" class="form__control" />
-        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+        <span class="help-block is-error" id="guid-1"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
     </div>
 </div>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-error.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/form/toggle_switch-error.html
@@ -4,7 +4,7 @@
         <span class="controls">
             <input id="toggletest" type="checkbox" class="form__control toggle-switch" />
             <span class="toggle-switch-label"></span>
-            <span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> my error</span>
+            <span class="help-block is-error"><i aria-hidden="true" class="icon-warning-sign"></i> <span class="hide">Error:</span> my error</span>
         </span>
     </label>
 </div>

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -1012,7 +1012,7 @@ class   | string | A space separated list of class names
 {% macro end(options) %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
     {% spaceless %}
-    
+
     {% if options.actions is defined %}
         <div{{
             attributes(options
@@ -1080,13 +1080,13 @@ value  | string, array  | The string, or array of strings to render inside the e
         {% if options.error_ids is defined and options.error_ids is not empty %}
             {% for error in errors %}
                 <span class="help-block is-error" id="{{ attribute(options.error_ids, loop.index0) }}">
-                    {{ html.icon('warning-sign') }} {{ error|raw -}}
+                    {{ html.icon('warning-sign') }} <span class="hide">Error:</span> {{ error|raw -}}
                 </span>
             {% endfor %}
         {% else %}
             {% for error in errors %}
                 <span class="help-block is-error">
-                    {{ html.icon('warning-sign') }} {{ error|raw -}}
+                    {{ html.icon('warning-sign') }} <span class="hide">Error:</span> {{ error|raw -}}
                 </span>
             {% endfor %}
         {% endif %}


### PR DESCRIPTION
This branch adds  a visually hidden but accessible`<span class="hide">Error: </span>` to helper outputted form error text.

This improves SR experience making it more obvious to SR users when a field has an error. Inspired by the GDS error message pattern.

There is no visual difference in error text.

Tested in JAWS, NVDA and Voiceover.

Fixes #1348 