### PR TITLE
Added CK editor focus styles

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -793,3 +793,12 @@ fieldset.form__group {
     line-height: $line-height-large;
     text-align: center;
 }
+
+// CK editor focus styles. Plugin used in all products. Chained for specificity bump.
+// scss-lint:disable SelectorFormat
+.cke_focus.cke_focus {
+    border: 3px solid color(black);
+    border-radius: 0;
+    outline: 3px solid color(border, focus);
+    outline-offset: 0;
+}


### PR DESCRIPTION
Add focus styling for CK editor (previously scratched in XFP) with a few small tweaks to make it consistent with other input focus styles. Tested in CXM.

![image](https://user-images.githubusercontent.com/756393/105176224-e094eb80-5b1c-11eb-88c7-8ae819480a58.png)

Fixes #1365 