### PR TITLE
Update breadcrumb markup scheme to match a11y guidelines

### DIFF
--- a/stylesheets/_component.breadcrumb.scss
+++ b/stylesheets/_component.breadcrumb.scss
@@ -4,6 +4,21 @@
     margin: 0 0 ($line-height-base / 2);
     width: 100%;
 
+    li {
+        display: inline;
+        list-style-type: none;
+        margin-right: 5px;
+
+        &::after {
+            content: '/';
+            margin-left: 5px;
+        }
+
+        &:last-child::after {
+            content: '';
+        }
+    }
+
     a {
         color: color(gray, dark); // must be AA 4.5:1
 

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/nav/breadcrumb-items.html
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/nav/breadcrumb-items.html
@@ -1,5 +1,13 @@
 <nav class="breadcrumb" aria-label="breadcrumbs">
-    <a href="#foo">foo</a> /
-    <a href="#bar">bar</a> /
-    <a href="#baz" aria-current="page">baz</a>
+    <ol>
+        <li>
+            <a>foo</a>
+        </li>
+        <li>
+            <a href="#bar">bar</a>
+        </li>
+        <li>
+            <a aria-current="page">baz</a>
+        </li>
+    </ol>
 </nav>

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/nav/breadcrumb-items.html.twig
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures/nav/breadcrumb-items.html.twig
@@ -2,9 +2,9 @@
 {% block body %}
 {%
     set breadcrumbs = [
-        {'label': 'foo', 'href': '#foo'},
+        {'label': 'foo'},
         {'label': 'bar', 'href': '#bar'},
-        {'label': 'baz', 'href': '#baz'}
+        {'label': 'baz'}
     ]
 %}
 {{ nav.breadcrumbs(breadcrumbs) }}

--- a/views/lexicon/base.html.twig
+++ b/views/lexicon/base.html.twig
@@ -9,9 +9,9 @@
 
 {%
     set breadcrumbs = [
-        {'label': 'Bread', 'href': '/bread'},
+        {'label': 'Bread'},
         {'label': 'Crumb', 'href': '/crumb'},
-        {'label': 'Trail', 'href': '/trail'}
+        {'label': 'Trail'}
     ]
 %}
 

--- a/views/lexicon/tables/basic.html.twig
+++ b/views/lexicon/tables/basic.html.twig
@@ -33,7 +33,7 @@
                 <td>4 GB</td>
                 <td class="centered">2</td>
                 <td>
-                    {{ html.link({ 'label': 'Reboot', 'class': 'table-action' }) }}<!--
+                    {{ html.link({ 'label': html.icon('ok') ~ ' Reboot', 'class': 'table-action' }) }}<!--
                     -->{{ html.link({ 'label': 'Suspend', 'class': 'table-action' }) }}<!--
                     -->{{ html.link({ 'label': 'Shutdown', 'class': 'table-action' }) }}<!--
                     -->{{ html.link({ 'label': 'Console', 'class': 'table-action' }) }}

--- a/views/pulsar/v2/helpers/nav.html.twig
+++ b/views/pulsar/v2/helpers/nav.html.twig
@@ -154,17 +154,23 @@
     {% spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
     <nav class="breadcrumb" aria-label="breadcrumbs">
+    {%- if items is defined and items is not empty %}
+        <ol>
+    {%- endif -%}
     {%- for item in items -%}
-        {% if loop.last %}
-            {% set item = item|merge({
-                'aria-current': 'page'
-            }) %}
-        {% endif %}
+            <li>
+                {% if loop.last %}
+                    {% set item = item|merge({
+                        'aria-current': 'page'
+                    }) %}
+                {% endif %}
 
-        {{ html.link(item) }}
-
-        {%- if not loop.last -%}/{%- endif -%}
+                {{ html.link(item) }}
+            </li>
     {%- endfor -%}
+    {%- if items is defined and items is not empty %}
+        </ol>
+    {%- endif -%}
     </nav>
     {% endspaceless %}
 {%- endmacro -%}


### PR DESCRIPTION
* Render breadcrumbs with an ordered list
* Remove hardcoded items separators and move that to CSS

https://www.w3.org/TR/wai-aria-practices-1.1/examples/breadcrumb/index.html