### PR TITLE
Improvements to sign-in screens following Connect integration

### DIFF
--- a/js/area/signin/signin.js
+++ b/js/area/signin/signin.js
@@ -33,7 +33,7 @@ SignInComponent.prototype.init = function () {
 
 	component.$alert = $('.alert');
 	component.successMessage = 'Signed in successfully';
-	component.signInFailMessage = 'Your username and/or password was incorrect';
+	component.signInFailMessage = '<i class="icon icon-exclamation-triangle"></i> Your username and/or password was incorrect';
 
 	component.hint = '<i class="signin__hint"></i>',
 	component.infoText = component.$info.text(),
@@ -106,7 +106,7 @@ SignInComponent.prototype.init = function () {
 	this.$html.find('[name="signin-submit"]').on('click', function(e) {
 		e.preventDefault();
 
-		var infoText = 'Enter your username and password';
+		var infoText = '<i class="icon icon-exclamation-triangle"></i> Enter your username and password';
 
 		if (!component.$usernameField.val() || !component.$passwordField.val()) {
 			component.$container
@@ -116,7 +116,7 @@ SignInComponent.prototype.init = function () {
 				});
 
 			if (component.$usernameField.val() && !component.$passwordField.val()) {
-				infoText = 'Enter your password';
+				infoText = '<i class="icon icon-exclamation-triangle"></i> Enter your password';
 
 				component.$passwordField.focus();
 
@@ -133,7 +133,7 @@ SignInComponent.prototype.init = function () {
 						});
 				};
 			} else if (!component.$usernameField.val() && component.$passwordField.val()) {
-				infoText = 'Enter your username';
+				infoText = '<i class="icon icon-exclamation-triangle"></i> Enter your username';
 				component.$usernameField.focus();
 
 				if (!component.$usernameField.prev('.signin__hint').length) {

--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -282,7 +282,7 @@ th.sorting_disabled:hover {
     background: transparent;
     border: 0;
     box-sizing: border-box;
-    color: color(jadu-blue);
+    color: color(jadu-purple);
     cursor: pointer;
     display: none;
     font-size: $font-size-base;

--- a/stylesheets/_component.modals.scss
+++ b/stylesheets/_component.modals.scss
@@ -76,8 +76,6 @@
 
 // Modal background
 .modal__backdrop {
-    -webkit-backdrop-filter: blur(2px);
-    backdrop-filter: blur(2px);
     position: fixed;
     top: 0;
     right: 0;

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -1,491 +1,601 @@
 // scss-lint:disable UrlFormat
 
-$signin-full-width:					500px;
-$signin-mobile-width:				320px;
-$signin-panel-full-width:		460px;
+$signin-full-width:			500px;
+$signin-mobile-width:		320px;
+$signin-panel-full-width:	460px;
 $signin-panel-mobile-width:	300px;
 
 .signin-backdrop {
-	background: #fff;
-	background-image: url('../images/signin-backdrop.jpg');
-	background-attachment: fixed;
-	background-position: center center;
-	background-repeat: no-repeat;
-	background-size: cover;
-	bottom: 0;
-	left: 0;
-	position: fixed;
-	right: 0;
-	top: 0;
-	z-index: -1;
+    background: #fff;
+    background-image: url('../images/signin-backdrop.jpg');
+    background-attachment: fixed;
+    background-position: center center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    bottom: 0;
+    left: 0;
+    position: fixed;
+    right: 0;
+    top: 0;
+    z-index: -1;
 }
 
 .signin-brand {
-	border-top: 1px solid #ccc;
-	bottom: 0;
-	display: block;
-	height: 46px;
-	left: 0;
-	margin: 0;
-	position: fixed;
-	right: 0;
-	text-align: center;
-	width: $signin-mobile-width;
+    bottom: 0;
+    display: none;
+    height: 46px;
+    margin: 0;
+    position: fixed;
+    text-align: right;
+    width: calc(100% - 20px);
 
-	@include respond-min(540px) {
-		border: 0;
-		left: auto;
-		right: 10px;
-		width: 200px;
-	}
+    @include respond-min($screen-tablet) {
+        display: block;
+    }
 
-	> img {
-		filter: brightness(0);
-		vertical-align: bottom;
-		width: 200px;
-
-		@include respond-min(540px) {
-			filter: drop-shadow(0 0 10px #000);
-		}
-	}
+    > img {
+        filter: drop-shadow(0 0 3px #000);
+        -webkit-filter: drop-shadow(0 0 3px #000);
+        vertical-align: bottom;
+        width: 150px;
+    }
 }
 
 .signin-container {
-	display: flex;
+    display: flex;
+    // position: fixed;
+    width: 100%;
 }
 
 .signin {
-	margin: 0;
-	width: $signin-mobile-width - 40px;
-	transition: width .25s, padding .25s;
+    background-color: $signin-bg-color;
+    box-shadow: 0 0 0 10px rgba(0, 0, 0, .3);
+    margin: 0 auto 20px;
+    width: $signin-mobile-width;
+    transition: width .25s, padding .25s;
 
-	@include respond-min($screen-tablet) {
-		width: $signin-full-width - 40px;
-		margin: 40px;
-	}
+    @include respond-min(340px) {
+        margin-top: 10px;
+    }
 
-	&--error {
-		.loading--circle i {
-			border: 1px solid rgba(0, 0, 0, .2);
-			border-top-color: color(white);
-		}
-	}
+    @include respond-min(360px) {
+        margin-top: 20px;
+    }
+
+    @include respond-min($screen-tablet) {
+        width: $signin-full-width - 40px;
+        margin: 40px;
+    }
+
+    &--error {
+        .loading--circle i {
+            border: 1px solid rgba(0, 0, 0, .2);
+            border-top-color: color(white);
+        }
+    }
 }
 
 .signin__inner {
-	float: left;
-	height: calc(100% - 100px);
-	margin-left: 10px;
-	margin-top: -95px;
-	transition: width .25s, padding .25s;
-	width: $signin-panel-mobile-width * 6;
+    float: left;
+    height: calc(100% - 100px);
+    margin-left: 10px;
+    transition: width .25s, padding .25s;
+    width: $signin-panel-mobile-width * 6;
 
-	@include respond-min($screen-tablet) {
-		height: 100%;
-		margin-left: 0;
-		margin-top: -75px;
-		width: $signin-panel-full-width * 6;
-	}
+    @include respond-min($screen-tablet) {
+        height: 100%;
+        margin-left: 0;
+        width: $signin-panel-full-width * 6;
+    }
 
-	.signin__inner::-webkit-scrollbar-track {
-		background-color: rgba(57, 57, 57, 0);
-		border-radius: 8px;
-	}
+    .signin__inner::-webkit-scrollbar-track {
+        background-color: rgba(57, 57, 57, 0);
+        border-radius: 8px;
+    }
 
-	.signin__inner::-webkit-scrollbar {
-		-webkit-appearance: none;
-		width: 7px;
-	}
+    .signin__inner::-webkit-scrollbar {
+        -webkit-appearance: none;
+        width: 7px;
+    }
 
-	.signin__inner::-webkit-scrollbar-thumb {
-		border-radius: 4px;
-		background-color: transparent;
-		box-shadow: 0 0 1px rgba(255, 255, 255, .5);
-	}
+    .signin__inner::-webkit-scrollbar-thumb {
+        border-radius: 4px;
+        background-color: transparent;
+        box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+    }
 
-	.active-reset & {
-		position: relative;
-		margin-left: -$signin-panel-mobile-width + 10px;
+    .active-reset & {
+        position: relative;
+        margin-left: -$signin-panel-mobile-width + 10px;
 
-		@include respond-min($screen-tablet) {
-			margin-left: -$signin-panel-full-width;
-		}
-	}
+        @include respond-min($screen-tablet) {
+            margin-left: -$signin-panel-full-width;
+        }
+    }
 
-	.active-forgot & {
-		position: relative;
-		margin-left: -$signin-panel-mobile-width * 2 + 10px;
+    .active-forgot & {
+        position: relative;
+        margin-left: -$signin-panel-mobile-width * 2 + 10px;
 
-		@include respond-min($screen-tablet) {
-			margin-left: -$signin-panel-full-width * 2;
-		}
-	}
+        @include respond-min($screen-tablet) {
+            margin-left: -$signin-panel-full-width * 2;
+        }
+    }
 
-	.active-success.active-success & {
-		position: relative;
-		margin-left: -$signin-panel-mobile-width * 4 + 10px;
+    .active-success.active-success & {
+        position: relative;
+        margin-left: -$signin-panel-mobile-width * 4 + 10px;
 
-		@include respond-min($screen-tablet) {
-			margin-left: -$signin-panel-full-width * 4;
-		}
-	}
+        @include respond-min($screen-tablet) {
+            margin-left: -$signin-panel-full-width * 4;
+        }
+    }
 
-	.active-twostep & {
-		position: relative;
-		margin-left: -$signin-panel-mobile-width * 3 + 10px;
+    .active-twostep & {
+        position: relative;
+        margin-left: -$signin-panel-mobile-width * 3 + 10px;
 
-		@include respond-min($screen-tablet) {
-			margin-left: -$signin-panel-full-width * 3;
-		}
+        @include respond-min($screen-tablet) {
+            margin-left: -$signin-panel-full-width * 3;
+        }
 
-		.signin-form,
-		.signin-reset {
-			visibility: hidden;
-			z-index: -1;
-		}
+        .signin-form,
+        .signin-reset {
+            visibility: hidden;
+            z-index: -1;
+        }
 
-		.signin-twostep {
-			z-index: 1;
-		}
-	}
+        .signin-twostep {
+            z-index: 1;
+        }
+    }
 
-	.active-success & {
-		.signin-form,
-		.signin-reset,
-		.signin-twostep {
-			visibility: hidden;
-			z-index: -1;
-		}
+    .active-success & {
+        .signin-form,
+        .signin-reset,
+        .signin-twostep {
+            visibility: hidden;
+            z-index: -1;
+        }
 
-		.signin-success {
-			z-index: 1;
-		}
-	}
-
+        .signin-success {
+            z-index: 1;
+        }
+    }
 }
 
 .signin__panel {
-	background-color: $signin-bg-color;
-	border-top: 1px solid #ccc;
-	box-shadow: 0 0 0 10px rgba(0, 0, 0, .3);
-	float: left;
-	padding: 75px 20px 20px;
-	transition: width .25s, padding .25s, z-index .25s;
-	width: $signin-panel-mobile-width;
+    float: left;
+    padding: 0 20px 20px;
+    transition: width .25s, padding .25s, z-index .25s;
+    width: $signin-panel-mobile-width;
 
-	@include respond-min($screen-tablet) {
-		padding: 75px 40px 40px;
-		width: $signin-panel-full-width;
-	}
+    @include respond-min($screen-tablet) {
+        padding: 0 40px 40px;
+        width: $signin-panel-full-width;
+    }
 
-	&[aria-hidden="true"] {
-		visibility: hidden;
-	}
+    &[aria-hidden="true"] {
+        visibility: hidden;
+    }
 }
 
 // form alignment
-.signin .form {
-	fieldset {
-		padding: 0;
-	}
+.signin form {
+    background-color: transparent;
+}
 
-	p {
-		margin-bottom: $line-height-base / 2;
-	}
+.signin {
+    p {
+        margin: ($line-height-base / 2) 0;
+    }
 
-	.legend {
-		border-bottom: 1px solid color(border);
-		line-height: $line-height-base;
-		margin-bottom: 5px;
-	}
+    fieldset {
+        padding: 0;
+    }
 
-	.form__group {
-		margin-bottom: 0;
-	}
+    hr {
+        margin: 2em 0;
+    }
 
-	.form__group--top .control__label {
-		margin-bottom: 0;
-	}
+    .legend {
+        border-bottom: 1px solid color(border);
+        line-height: $line-height-base;
+        margin-bottom: 5px;
+        padding-top: 40px;
+        width: 100%;
+    }
 
-	.form__actions {
-		border-top: 0;
-		padding-bottom: 0;
-	}
+    .form__group {
+        margin-bottom: 0;
+    }
 
-	.input-group-btn .btn {
-		border: 2px solid color(black);
-		line-height: 44px;
-	}
+    .form__group--top .control__label {
+        margin: 0 0 5px;
+    }
+
+    .help-block {
+        margin: 0;
+    }
+
+    .form__actions {
+        border-top: 0;
+        padding-bottom: 0;
+    }
+
+    .input-group-btn .btn {
+        border: 2px solid color(black);
+        line-height: 48px;
+    }
+
+    .input-group-btn:last-child > span > .btn {
+        margin-left: 6px;
+    }
+
+    .has-error {
+        background-color: color(white);
+        padding: 0 20px;
+        margin: 0 -30px;
+        width: calc(100% + 60px);
+
+        @include respond-min($screen-tablet) {
+            padding: 0 40px;
+            margin: 0 -40px;
+            width: calc(100% + 80px);
+        }
+
+        .btn {
+            border: 0 !important;
+            color: color(black) !important;
+            outline: 2px solid color(danger);
+        }
+
+        .btn--naked {
+            outline: none;
+        }
+
+        .control__label {
+            color: color(danger) !important;
+        }
+
+        .form__control.form__control {
+            outline: 2px solid color(danger);
+        }
+    }
+
+    .has-error .help-block {
+        background-color: color(white);
+        color: color(danger) !important;
+        font-family: $font-family-regular;
+        padding: 0 20px 1em;
+        margin: 0 -20px;
+
+        @include respond-min($screen-tablet) {
+            padding: 0 40px 1em;
+            margin: 0 -40px;
+        }
+
+        i {
+            color: color(danger) !important;
+            font-size: 1.5em;
+            margin-right: .25em;
+            vertical-align: text-bottom;
+        }
+    }
 }
 
 .signin__input,
 .signin .form__control.form__control {
-	background-color: none;
-	border: 2px solid color(black);
-	display: inline-block;
-	margin: 0 auto 1em;
+    background-color: none;
+    border: 0;
+    color: color(text) !important;
+    display: inline-block;
+    margin: 0 auto 1em;
+    outline: 2px solid rgba(0, 0, 0, .5);
 
-	&:not(.select) {
-		padding: 10px;
-	}
+    &:not(.select) {
+        padding: .5em;
+    }
 
-	&.checkbox {
-		margin: 0 1em 0 0;
-	}
+    &.checkbox {
+        margin: 0 1em 0 0;
 
-	&:not(.checkbox) {
-		width: 100%;
-	}
+        // check position
+        &::before {
+            height: .5em;
+            left: .25em;
+            line-height: 1.4em;
+            top: 0;
+        }
+    }
 
-	&:focus {
-		@include pulsar-input-focused;
-	}
+    &:not(.checkbox) {
+        width: 100%;
+    }
+
+    &:focus {
+        @include pulsar-input-focused;
+    }
 }
 
 .signin__code1.signin__code1,
 .signin__code2.signin__code2 {
-	@extend .signin__input;
-	display: inline-block;
-	font-family: courier;
-	letter-spacing: 5px;
-	margin: 0 5px 1em 0;
-	padding: 10px 10px 10px 12px;
-	width: 81px;
+    @extend .signin__input;
+    display: inline-block;
+    font-family: courier;
+    letter-spacing: 5px;
+    margin: 0 5px 1em 0;
+    padding: 10px 10px 10px 12px;
+    width: 81px;
 
-	@include respond-min($screen-tablet) {
-		padding: 10px 10px 10px 20px;
-	}
+    @include respond-min($screen-tablet) {
+        padding: 10px 10px 10px 20px;
+    }
 }
 
-.signin__actions + .signin__actions {
-	border-top: 1px solid #ccc;
-	margin-top: 2em;
-	padding-top: 1.5em;
+.signin__actions {
+    margin-top: 2em;
 }
 
 .signin__action {
-	display: block;
-	margin: 0 0 1em;
-	width: 100%;
+    display: block;
+    margin: 0 0 1em;
+    width: 100%;
 }
 
 .signin__submit {
-	display: inline-block;
-	margin: 0 auto;
-	width: 40%;
+    display: inline-block;
+    margin: 0 auto;
+    width: 40%;
 
-	.loading {
-		margin: 0 auto;
-	}
+    .loading {
+        margin: 0 auto;
+    }
 }
 
 .signin__alt {
-	background-color: color(white);
-	border-radius: 20px;
-	display: block;
-	margin-top: 1em;
-	text-align: left;
-	width: 100%;
+    background-color: color(white);
+    border-radius: 20px;
+    display: block;
+    margin-top: 1em;
+    text-align: left;
+    width: 100%;
 
-	.svg-inline--fa {
-		margin-right: 10px;
-	}
+    .svg-inline--fa {
+        margin-right: 10px;
+    }
 }
 
 .connect-logo {
-	&::before {
-		background: url('../images/branding/jadu-connect-logomark.svg');
-    background-size: 19px 19px;
-		background-repeat: no-repeat;
-		content: '';
-    display: inline-block;
-		height: 19px;
-		text-align: center;
-		vertical-align: middle;
-    width: 19px;
-	}
+    &::before {
+        background: url('../images/branding/jadu-connect-logomark.svg');
+        background-size: 19px 19px;
+        background-repeat: no-repeat;
+        content: '';
+        display: inline-block;
+        height: 19px;
+        text-align: center;
+        vertical-align: middle;
+        width: 19px;
+    }
+}
+
+.signin__brand {
+    margin-left: 30px;
+    margin-right: 10px;
+    position: relative;
+    top: 20px;
+    width: 100px;
+
+    @include respond-min($screen-tablet) {
+        margin-left: 40px;
+    }
 }
 
 .signin__action-separator {
-	display: inline-block;
-	text-align: center;
-	width: 18%;
+    display: inline-block;
+    text-align: center;
+    width: 18%;
 }
 
 .signin__heading {
-	color: color(gray, darker);
-	font-family: $font-family-heading;
-	margin: 0 $padding-base 0 10px;
-	padding: 20px;
-	position: relative;
-	text-align: left;
-	top: 10px;
-	width: $signin-mobile-width - 20px;
-	z-index: 1;
+    color: color(gray, darker);
+    font-family: $font-family-heading;
+    font-size: 1.5em;
+    margin: 10px 30px 20px;
+    padding: 0;
+    position: relative;
+    text-align: left;
+    top: 10px;
+    word-break: break-word;
+    z-index: 1;
 
-	@include respond-min($screen-tablet) {
-		margin: 0;
-		padding: 20px 0 20px 40px;
-		width: $signin-full-width - 40px;
-	}
+    @include respond-min($screen-tablet) {
+        font-size: 1.75em;
+        margin: 0 40px;
+        padding: 20px 0;
+    }
 }
 
 .signin__info {
-	display: block;
-	margin: 1em 0;
+    display: block;
+    margin: 1em 0;
 }
 
 .signin__link {
-	display: inline-block;
-	margin-top: .5em;
+    display: inline-block;
+    margin-top: .5em;
 }
 
-.signin__group {
-	clear: left;
-	position: relative;
+.signin__group,
+.form__group {
+    clear: left;
+    margin: 0;
+    position: relative;
 }
 
 .signin__hint {
-	animation-duration: 1s;
-	animation-fill-mode: both;
-	animation-iteration-count: infinite;
-	animation-name: hint-wobble-small;
-	display: inline-block;
-	font-size: 1em;
-	left: -16px;
-	position: absolute;
-	width: 25px;
-	top: 32px;
+    animation-duration: 1s;
+    animation-fill-mode: both;
+    animation-iteration-count: infinite;
+    animation-name: hint-wobble-small;
+    display: inline-block;
+    font-size: 1em;
+    left: -16px;
+    position: absolute;
+    width: 25px;
+    top: 32px;
 
-	@include respond-min($screen-tablet) {
-		animation-name: hint-wobble;
-		font-size: 1.5em;
-		left: -30px;
-		top: 32px;
-	}
+    @include respond-min($screen-tablet) {
+        animation-name: hint-wobble;
+        font-size: 1.5em;
+        left: -30px;
+        top: 32px;
+    }
 
-	&::before {
-		content: '\f0a4';
-		font-family: $font-family-icons;
-		font-style: normal;
-	}
+    &::before {
+        content: '\f0a4';
+        font-family: $font-family-icons;
+        font-style: normal;
+    }
 
-	.signin-twostep & {
-		left: -17px;
-		top: 10px;
+    .signin-twostep & {
+        left: -17px;
+        top: 10px;
 
-		@include respond-min($screen-tablet) {
-			left: -30px;
-		}
-	}
+        @include respond-min($screen-tablet) {
+            left: -30px;
+        }
+    }
 
-	.signin__code2 + & {
-		left: 175px;
+    .signin__code2 + & {
+        left: 175px;
 
-		@include respond-min($screen-tablet) {
-			left: 180px;
-		}
+        @include respond-min($screen-tablet) {
+            left: 180px;
+        }
 
-		&::before {
-			content: '\f0a5';
-			font-family: $font-family-icons;
-			font-style: normal;
-		}
-	}
+        &::before {
+            content: '\f0a5';
+            font-family: $font-family-icons;
+            font-style: normal;
+        }
+    }
 }
 
 .signin__icon {
-	display: block;
-	float: left;
-	margin: 1em 5px 0 0;
+    display: block;
+    float: left;
+    margin: 1em 5px 0 0;
 
-	.signin--error &,
-	.signin-success & {
-		&::before {
-			font-family: $font-family-icons;
-			font-style: normal;
-			font-weight: 600;
-		}
-	}
+    .signin--error &,
+    .signin-success & {
+        &::before {
+            font-family: $font-family-icons;
+            font-style: normal;
+            font-weight: 600;
+        }
+    }
 
-	.signin--error &::before {
-		content: '\f06a';
-		color: color(danger);
-	}
+    .signin--error &::before {
+        content: '\f06a';
+        color: color(danger);
+    }
 
-	.active-success .signin-success & {
-		height: 150px;
-		position: relative;
-		text-align: center;
-		top: 60px;
-		width: 100%;
+    .active-success .signin-success & {
+        height: 150px;
+        position: relative;
+        text-align: center;
+        top: 60px;
+        width: 100%;
 
-		&::before {
-			content: '\f058';
-			color: color(success);
-			font-size: 100px;
-			width: 100px;
-		}
-	}
+        &::before {
+            content: '\f058';
+            color: color(success);
+            font-size: 100px;
+            width: 100px;
+        }
+    }
 }
 
 .signin-twostep label {
-	display: none;
+    display: none;
 }
 
 // 2FA code input in control centre UI
 .form__group .controls,
 .modal {
-	.form__control.signin__code1,
-	.form__control.signin__code2 {
-		display: inline-block;
-		font-family: courier;
-		letter-spacing: 2px;
-		padding: 0 10px;
-		width: 55px;
-	}
+    .form__control.signin__code1,
+    .form__control.signin__code2 {
+        display: inline-block;
+        font-family: courier;
+        letter-spacing: 2px;
+        padding: 0 10px;
+        width: 55px;
+    }
 }
 
 .signin-credits {
-	bottom: 10px;
-	color: #fff;
-	display: none;
-	font-size: $font-size-small;
-	position: absolute;
-	right: 10px;
+    bottom: 10px;
+    color: #fff;
+    display: none;
+    font-size: $font-size-small;
+    position: absolute;
+    right: 10px;
 
-	a {
-		color: #fff;
-	}
+    a {
+        color: #fff;
+    }
 
-	a:focus {
-		color: #000;
-	}
+    a:focus {
+        color: #000;
+    }
 }
 
-@keyframes hint-wobble {
-	0%, 50%, 100% {
-		transform: translateX(0);
-	}
+// scss-lint:disable SelectorFormat
+// Show/hide password on invitation invite
+.hideShowPassword-toggle {
+    @extend .btn;
+    @extend .btn--naked;
+    color: #6a6a6a !important;
+    margin-right: 3px;
+    padding: 3px 6px;
+    text-transform: uppercase;
+    z-index: 3;
+}
+// scss-lint:enable SelectorFormat
 
-	25%, 75% {
-		transform: translateX(-5px);
-	}
+@keyframes hint-wobble {
+    0%, 50%, 100% {
+        transform: translateX(0);
+    }
+
+    25%, 75% {
+        transform: translateX(-5px);
+    }
 }
 
 @keyframes hint-wobble-small {
-	0%, 50%, 100% {
-		transform: translateX(0);
-	}
+    0%, 50%, 100% {
+        transform: translateX(0);
+    }
 
-	25%, 75% {
-		transform: translateX(-2px);
-	}
+    25%, 75% {
+        transform: translateX(-2px);
+    }
 }
 
 [id="recaptcha_widget_div"] {
-	display: inline-block;
-	margin: 0 auto 1em;
+    display: inline-block;
+    margin: 0 auto 1em;
 }
+
+// scss-lint:disable SelectorFormat
+// stop inline styles added by js component preventing responsive width change
+// on viewport resize
+.hideShowPassword-wrapper {
+    width: 100% !important;
+}
+// scss-lint:enable SelectorFormat
 
 // scss-lint:enable UrlFormat

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -249,7 +249,7 @@ $signin-panel-mobile-width:	300px;
     }
 
     .panel--danger,
-    .signin--error .signin__info {
+    &.signin--error .signin__info {
         border-bottom: 2px solid color(white) !important;
         border-top: 2px solid color(white) !important;
         margin: 20px -30px;
@@ -270,7 +270,7 @@ $signin-panel-mobile-width:	300px;
         }
     }
 
-    .signin--error .signin__info {
+    &.signin--error .signin__info {
         @extend .panel--danger;
         padding: 10px 40px;
     }

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -199,6 +199,10 @@ $signin-panel-mobile-width:	300px;
         color: inherit;
     }
 
+    .form {
+        background-color: inherit;
+    }
+
     .legend,
     .form .legend.legend {
         border-bottom: 1px solid inherit;

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -47,34 +47,6 @@ $signin-panel-mobile-width:	300px;
     width: 100%;
 }
 
-.signin {
-    background-color: $signin-bg-color;
-    box-shadow: 0 0 0 10px rgba(0, 0, 0, .3);
-    margin: 0 auto 20px;
-    width: $signin-mobile-width;
-    transition: width .25s, padding .25s;
-
-    @include respond-min(340px) {
-        margin-top: 10px;
-    }
-
-    @include respond-min(360px) {
-        margin-top: 20px;
-    }
-
-    @include respond-min($screen-tablet) {
-        width: $signin-full-width - 40px;
-        margin: 40px;
-    }
-
-    &--error {
-        .loading--circle i {
-            border: 1px solid rgba(0, 0, 0, .2);
-            border-top-color: color(white);
-        }
-    }
-}
-
 .signin__inner {
     float: left;
     height: calc(100% - 100px);
@@ -180,18 +152,44 @@ $signin-panel-mobile-width:	300px;
     }
 }
 
-// form alignment
-.signin form {
-    background-color: transparent;
-}
-
 .signin {
-    p {
-        margin: ($line-height-base / 2) 0;
+    background-color: $signin-bg-color;
+    box-shadow: 0 0 0 10px rgba(0, 0, 0, .3);
+    margin: 0 auto 20px;
+    width: $signin-mobile-width;
+    transition: width .25s, padding .25s;
+
+    @include respond-min(340px) {
+        margin-top: 10px;
     }
 
+    @include respond-min(360px) {
+        margin-top: 20px;
+    }
+
+    @include respond-min($screen-tablet) {
+        width: $signin-full-width - 40px;
+        margin: 40px;
+    }
+
+    &--error {
+        .loading--circle i {
+            border: 1px solid rgba(0, 0, 0, .2);
+            border-top-color: color(white);
+        }
+    }
+
+    form {
+        background-color: transparent;
+    }
+
+    
     fieldset {
         padding: 0;
+    }
+
+    p {
+        margin: ($line-height-base / 2) 0;
     }
 
     hr {
@@ -200,6 +198,7 @@ $signin-panel-mobile-width:	300px;
 
     .legend {
         border-bottom: 1px solid color(border);
+        font-size: $font-size-large;
         line-height: $line-height-base;
         margin-bottom: 5px;
         padding-top: 40px;
@@ -230,6 +229,24 @@ $signin-panel-mobile-width:	300px;
 
     .input-group-btn:last-child > span > .btn {
         margin-left: 6px;
+    }
+
+    .panel--danger {
+        border-bottom: 2px solid color(white) !important;
+        border-top: 2px solid color(white) !important;
+        margin-left: -40px;
+        margin-right: -40px;
+        
+        .panel__body {
+            padding: 10px 40px;
+        }
+
+        &,
+        .panel__body,
+        span,
+        i {
+            color: color(white) !important;
+        }
     }
 
     .has-error {

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -179,7 +179,8 @@ $signin-panel-mobile-width:	300px;
         }
     }
 
-    form {
+    form,
+    .form {
         background-color: transparent;
     }
 
@@ -197,10 +198,6 @@ $signin-panel-mobile-width:	300px;
 
     a:hover {
         color: inherit;
-    }
-
-    .form {
-        background-color: inherit;
     }
 
     .legend,

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -247,7 +247,9 @@ $signin-panel-mobile-width:	300px;
         margin-left: 6px;
     }
 
-    .panel--danger {
+    .panel--danger,
+    .signin__info {
+        @extend .panel--danger;
         border-bottom: 2px solid color(white) !important;
         border-top: 2px solid color(white) !important;
         margin: 20px -30px;
@@ -266,6 +268,10 @@ $signin-panel-mobile-width:	300px;
         i {
             color: color(white) !important;
         }
+    }
+
+    .signin__info {
+        padding: 10px 40px;
     }
 
     .has-error {

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -213,6 +213,10 @@ $signin-panel-mobile-width:	300px;
 
     .form__group {
         margin-bottom: 0;
+
+        > .control__label {
+            color: inherit;
+        }
     }
 
     .form__group--top .control__label {
@@ -455,16 +459,6 @@ $signin-panel-mobile-width:	300px;
 .signin__link {
     display: inline-block;
     margin-top: .5em;
-}
-
-.form__group {
-    clear: left;
-    margin: 0;
-    position: relative;
-
-    > .control__label {
-        color: inherit;
-    }
 }
 
 .signin__hint {

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -195,8 +195,13 @@ $signin-panel-mobile-width:	300px;
         margin: 2em 0;
     }
 
-    .legend {
-        border-bottom: 1px solid color(border);
+    a:hover {
+        color: inherit;
+    }
+
+    .legend,
+    .form .legend {
+        border-bottom: 1px solid inherit;
         font-size: $font-size-large;
         line-height: $line-height-base;
         margin-bottom: 5px;

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -449,11 +449,14 @@ $signin-panel-mobile-width:	300px;
     margin-top: .5em;
 }
 
-.signin__group,
 .form__group {
     clear: left;
     margin: 0;
     position: relative;
+
+    > .control__label {
+        color: inherit;
+    }
 }
 
 .signin__hint {

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -183,7 +183,6 @@ $signin-panel-mobile-width:	300px;
         background-color: transparent;
     }
 
-    
     fieldset {
         padding: 0;
     }

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -247,7 +247,8 @@ $signin-panel-mobile-width:	300px;
         margin-left: 6px;
     }
 
-    .panel--danger {
+    .panel--danger,
+    .signin--error .signin__info {
         border-bottom: 2px solid color(white) !important;
         border-top: 2px solid color(white) !important;
         margin: 20px -30px;
@@ -266,6 +267,11 @@ $signin-panel-mobile-width:	300px;
         i {
             color: color(white) !important;
         }
+    }
+
+    .signin--error .signin__info {
+        @extend .panel--danger;
+        padding: 10px 40px;
     }
 
     .has-error {

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -201,6 +201,10 @@ $signin-panel-mobile-width:	300px;
         color: inherit;
     }
 
+    a:focus {
+        color: color(black);
+    }
+
     .legend,
     .form .legend.legend {
         border-bottom: 1px solid inherit;

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -234,9 +234,8 @@ $signin-panel-mobile-width:	300px;
     .panel--danger {
         border-bottom: 2px solid color(white) !important;
         border-top: 2px solid color(white) !important;
-        margin-left: -40px;
-        margin-right: -40px;
-        
+        margin: 20px -40px;
+
         .panel__body {
             padding: 10px 40px;
         }

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -200,8 +200,9 @@ $signin-panel-mobile-width:	300px;
     }
 
     .legend,
-    .form .legend {
+    .form .legend.legend {
         border-bottom: 1px solid inherit;
+        border-color: inherit;
         font-size: $font-size-large;
         line-height: $line-height-base;
         margin-bottom: 5px;

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -233,7 +233,11 @@ $signin-panel-mobile-width:	300px;
     .panel--danger {
         border-bottom: 2px solid color(white) !important;
         border-top: 2px solid color(white) !important;
-        margin: 20px -40px;
+        margin: 20px -30px;
+
+        @include respond-min($screen-tablet) {
+            margin: 20px -40px;
+        }
 
         .panel__body {
             padding: 10px 40px;
@@ -305,6 +309,8 @@ $signin-panel-mobile-width:	300px;
     border: 0;
     color: color(text) !important;
     display: inline-block;
+    height: 48px;
+    line-height: 48px;
     margin: 0 auto 1em;
     outline: 2px solid rgba(0, 0, 0, .5);
 
@@ -313,6 +319,7 @@ $signin-panel-mobile-width:	300px;
     }
 
     &.checkbox {
+        height: 22px;
         margin: 0 1em 0 0;
 
         // check position

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -247,9 +247,7 @@ $signin-panel-mobile-width:	300px;
         margin-left: 6px;
     }
 
-    .panel--danger,
-    .signin__info {
-        @extend .panel--danger;
+    .panel--danger {
         border-bottom: 2px solid color(white) !important;
         border-top: 2px solid color(white) !important;
         margin: 20px -30px;
@@ -268,10 +266,6 @@ $signin-panel-mobile-width:	300px;
         i {
             color: color(white) !important;
         }
-    }
-
-    .signin__info {
-        padding: 10px 40px;
     }
 
     .has-error {

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -229,8 +229,8 @@ $signin-panel-mobile-width:	300px;
     }
 
     .input-group-btn .btn {
-        border: 2px solid color(black);
-        line-height: 48px;
+        border: 2px solid inherit;
+        line-height: 44px;
     }
 
     .input-group-btn:last-child > span > .btn {

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -196,6 +196,7 @@ $signin-panel-mobile-width:	300px;
         margin: 2em 0;
     }
 
+    a:active,
     a:hover {
         color: inherit;
     }

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -230,7 +230,8 @@ $signin-panel-mobile-width:	300px;
 
     .input-group-btn .btn {
         border: 2px solid inherit;
-        line-height: 44px;
+        line-height: 48px;
+        margin-top: -2px;
     }
 
     .input-group-btn:last-child > span > .btn {

--- a/stylesheets/_component.signin.scss
+++ b/stylesheets/_component.signin.scss
@@ -218,6 +218,7 @@ $signin-panel-mobile-width:	300px;
 
     .form__group {
         margin-bottom: 0;
+        position: relative;
 
         > .control__label {
             color: inherit;

--- a/views/playground/login/index.html.twig
+++ b/views/playground/login/index.html.twig
@@ -11,6 +11,7 @@
 	<div class="signin-container">
 
 		<div class="signin signin--recapt t-signin-bg">
+			<img src="../../../images/branding/jadu-connect-logomark.svg?v=1" class="signin__brand" alt="Jadu Support logo">
 			<h1 class="signin__heading" role="alert" aria-atomic="true">Pulsar City Council</h1>
 			<div class="signin__inner">
 				

--- a/views/playground/login/index.html.twig
+++ b/views/playground/login/index.html.twig
@@ -14,14 +14,8 @@
 			<img src="../../../images/branding/jadu-connect-logomark.svg?v=1" class="signin__brand" alt="Jadu Support logo">
 			<h1 class="signin__heading" role="alert" aria-atomic="true">Pulsar City Council</h1>
 			<div class="signin__inner">
-				
+
 				<form id="signin" class="signin__panel signin-form" aria-hidden="false">
-
-					<div class="signin__icon t-signin-icon"></div>
-
-					<span class="signin__info" role="alert" aria-atomic="true">
-						<i aria-hidden="true" class="icon-warning-sign"></i> Incorrect email or password
-					</span>
 
 					<div class="signin__group">
 						<label for="username">Username <span class="hide">required</span></label>

--- a/views/playground/login/index.html.twig
+++ b/views/playground/login/index.html.twig
@@ -16,8 +16,12 @@
 			<div class="signin__inner">
 				
 				<form id="signin" class="signin__panel signin-form" aria-hidden="false">
+
 					<div class="signin__icon t-signin-icon"></div>
 
+					<span class="signin__info" role="alert" aria-atomic="true">
+						<i aria-hidden="true" class="icon-warning-sign"></i> Incorrect email or password
+					</span>
 
 					<div class="signin__group">
 						<label for="username">Username <span class="hide">required</span></label>


### PR DESCRIPTION
Previously, a lot of branding related overrides were held in Connect's pre-authorisation view, these have been significantly streamlined so the signin.scss file can make more use of inheritance. Other changes include:

# Signin Changes
## Organisation name (h1)

Long organisation names now break-word instead of break-all, avoiding situations where a single word is split onto two lines.

## Danger panel

Danger panel presentation improved, they should now 

- Span the width of the container
- Have a red danger background colour
- Have white text, and a white exclamation icon
- Have white top and bottom border to visually separate it from dark background colours

![image](https://user-images.githubusercontent.com/18653/181448770-ac784023-0dbf-4a0f-9d07-57d9e770ba74.png)

## Responsive mode

When viewing on a mobile device, or narrow viewport, the sign in UI is now centered instead of being left-aligned. 
At very narrow widths, the sign in UI will also close the gap at the top of the viewport.

![image](https://user-images.githubusercontent.com/18653/181448381-151277ef-8bd4-454e-84ea-8206a9a854af.png)

## Error messages on fields

Fields in an error state now adopt a solid white background to allow the field labels, and subsequent help text to adopt the ‘danger’ red colour.

The field borders will also be red.

![image](https://user-images.githubusercontent.com/18653/181448501-ab517591-1a58-45d3-a0d0-5f0db47990ca.png)

## 

# Other Changes
## Modals
Blur effect on modal backdrop has been removed.

![image](https://user-images.githubusercontent.com/18653/181448933-16203e6e-9318-408b-94ad-38d3fbb1defd.png)

## Datatable

Collapsing datatables which show a plus icon when columns are hidden are now purple instead of light blue