### PR TITLE
Add responsive modal modifier class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8484,7 +8484,7 @@
     "jquery-mousewheel": {
       "version": "3.1.13",
       "resolved": "https://registry.npmjs.org/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz",
-      "integrity": "sha1-BvAzXxbjU6aV5yBr9QUDy1I6buU="
+      "integrity": "sha512-GXhSjfOPyDemM005YCEHvzrEALhKDIswtxSHSR2e4K/suHVJKJxxRCGz3skPjNxjJjQa9AVSGGlYjv1M3VLIPg=="
     },
     "jquery-placeholder": {
       "version": "2.3.1",
@@ -12617,8 +12617,8 @@
       "dev": true
     },
     "select2": {
-      "version": "github:jadu/selectWoo#5ca5b68213071ffa28d02685426b7347c8b3aa8c",
-      "from": "github:jadu/selectWoo#jadu-1.1.3",
+      "version": "github:jadu/selectWoo#13c8ab4fa0f605da95aaec4ab3e2d8f1f6d74513",
+      "from": "github:jadu/selectWoo#jadu-1.1.4",
       "requires": {
         "almond": "~0.3.1",
         "jquery-mousewheel": "~3.1.13"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "normalize.css": "^8.0.1",
     "pikaday": "^1.8.2",
     "pulsar-date-picker": "^1.0.0",
-    "select2": "github:jadu/selectWoo#jadu-1.1.3",
+    "select2": "github:jadu/selectWoo#jadu-1.1.4",
     "spectrum-colorpicker": "^1.8.1",
     "timepicker": "^1.13.18",
     "tippy.js": "^5.2.1",

--- a/stylesheets/_component.modals.scss
+++ b/stylesheets/_component.modals.scss
@@ -1,4 +1,3 @@
-//
 // Modals
 // --------------------------------------------------
 
@@ -7,6 +6,7 @@
 // .modal__dialog       - positioning shell for the actual modal
 // .modal__content      - actual modal w/ bg and corners
 // .modal--full-screen  - modifier for a full screen modal
+//
 
 
 // Kill the scroll on the body
@@ -53,6 +53,14 @@
 
 .modal--large .modal__dialog {
     max-width: 800px;
+}
+
+.modal--responsive {
+    width: 100%;
+
+    .modal__dialog {
+        max-width: 70%;
+    }
 }
 
 // Actual modal

--- a/views/lexicon/tabs/modals.html.twig
+++ b/views/lexicon/tabs/modals.html.twig
@@ -29,6 +29,11 @@
 </p>
 
 <p>
+    Launch a responsive modal<br/>
+    <button class="btn" data-toggle="modal" data-target="#modalResponsive">Launch Responsive Modal</button>
+</p>
+
+<p>
     Launch a full page modal, from a link <br/>
     <a data-toggle="modal" href="#myFullScreenModal" class="btn">Launch Full Screen Modal</a>
 </p>
@@ -295,6 +300,274 @@
                     </figure>
                 </div>
             </div>
+        </div><!-- /.modal__content -->
+    </div><!-- /.modal__dialog -->
+</div><!-- /.modal -->
+
+
+<div class="modal modal--responsive modal__example" id="modalResponsive" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modalResponsive-title" aria-describedby="modalResponsive-description">
+    <div class="modal__dialog">
+        <div class="modal__content">
+            <form>
+                <div class="modal__header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close modal dialog"><span aria-hidden="true">&times;</span></button>
+                    <h1 class="modal__title" id="modalResponsive-title">A simple example with error summary</h1>
+                </div>
+                <div class="modal__body">
+                    <p id="modalResponsive-description" class="hide">Here goes a short description (a couple of lines) about the modal's purpose, if needed.</p>
+                    <p>The modal body might have instructions, a form, or other stuff.</p>
+
+                    {{
+                        form.error_summary({
+                            'heading': 'There is a problem',
+                            'errors': [
+                                {
+                                    'label': 'Enter your first name',
+                                    'href': 'first-name'
+                                },
+                                {
+                                    'label': 'Enter your last name',
+                                    'href': 'last-name'
+                                }
+                            ]
+                        })
+                    }}
+
+                    {{ form.fieldset_start({'legend': 'Example form with errors'}) }}
+
+                        {{
+                            form.text({
+                                'label': 'First name',
+                                'id': 'first-name',
+                                'required': true,
+                                'error': 'Enter your first name'
+                            })
+                        }}
+
+                        {{
+                            form.text({
+                                'label': 'Last name',
+                                'id': 'last-name',
+                                'required': true,
+                                'error': 'Enter your last name'
+                            })
+                        }}
+
+                        {{
+                            form.text({
+                                'label': 'Last name',
+                                'id': 'last-name',
+                                'required': true,
+                                'error': 'Enter your last name'
+                            })
+                        }}
+
+                        {{
+                            form.checkbox({
+                                'label': 'Are you human?',
+                                'id': 'are-you-human'
+                            })
+                        }}
+
+                        {{
+                            form.select2({
+                                'label': 'Favourite colours',
+                                'id': 'select',
+                                'multiple': true,
+                                'options': {
+                                    'colour_red': 'Red',
+                                    'colour_blue': 'Blue'
+                                }
+                            })
+                        }}
+
+                        {{
+                            form.choice({
+                                'label': 'Assign blame to',
+                                'multiple': true,
+                                'options': [
+                                    {
+                                        'label': 'Sunshine',
+                                        'name': 'choice-a2',
+                                        'value': 'sun'
+                                    },
+                                    {
+                                        'label': 'Moonlight',
+                                        'name': 'choice-a2',
+                                        'value': 'moon'
+                                    },
+                                    {
+                                        'label': 'Good times',
+                                        'name': 'choice-a2',
+                                        'value': 'good'
+                                    },
+                                    {
+                                        'label': 'Boogie',
+                                        'name': 'choice-a2',
+                                        'value': 'boogie'
+                                    }
+                                ]
+                            })
+                        }}
+                    {{ form.fieldset_end() }}
+
+                    {{ form.fieldset_start({ 'legend': 'Grid Sizes' }) }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'One column',
+                            'class': 'form__control-col--1',
+                            'name': 'inputTextMini',
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Two columns',
+                            'class': 'form__control-col--2',
+                            'name': 'inputTextSmall'
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Three columns',
+                            'class': 'form__control-col--3',
+                            'name': 'inputTextMedium'
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Four columns',
+                            'class': 'form__control-col--4',
+                            'name': 'inputTextRegular'
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Five columns',
+                            'class': 'form__control-col--5',
+                            'name': 'inputTextLarge'
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Six columns',
+                            'class': 'form__control-col--6',
+                            'name': 'inputTextXLarge'
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Seven columns',
+                            'class': 'form__control-col--7',
+                            'name': 'inputTextFull'
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Eight columns',
+                            'class': 'form__control-col--8',
+                            'name': 'inputTextFull'
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Nine columns',
+                            'class': 'form__control-col--9',
+                            'name': 'inputTextFull'
+                        })
+                    }}
+
+                    {{ form.fieldset_end() }}
+                    {{ form.fieldset_start({ 'legend': 'Legacy Sizes' }) }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Mini',
+                            'class': 'form__group--mini',
+                            'name': 'inputTextMini'
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Small',
+                            'class': 'form__group--small',
+                            'name': 'inputTextSmall'
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Medium',
+                            'class': 'form__group--medium',
+                            'name': 'inputTextMedium'
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Regular',
+                            'class': 'form__group--regular',
+                            'name': 'inputTextRegular'
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Large',
+                            'class': 'form__group--large',
+                            'name': 'inputTextLarge'
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Extra Large',
+                            'class': 'form__group--xlarge',
+                            'name': 'inputTextXLarge'
+                        })
+                    }}
+
+                    {{
+                        form.text({
+                            'id': 'guid-' ~ random(),
+                            'label': 'Full',
+                            'class': 'form__group--full',
+                            'name': 'inputTextFull'
+                        })
+                    }}
+
+                    {{ form.fieldset_end() }}
+
+                </div>
+                <div class="modal__footer">
+                    <button type="submit" class="btn btn--primary">Save Changes</button>
+                    <button type="button" class="btn btn--naked" data-dismiss="modal">Cancel</button>
+                </div>
+            </form>
         </div><!-- /.modal__content -->
     </div><!-- /.modal__dialog -->
 </div><!-- /.modal -->


### PR DESCRIPTION
Adding `modal--responsive` will set the modal to be 70% of the viewport size. Implementations will likely need careful consideration of which width classes are used for each field.

Showing how standard modal header and form error summary responds.
![responsive-modal-1](https://user-images.githubusercontent.com/18653/186699320-147484a6-1ed4-43f7-a681-40079cf68452.gif)

Showing how grid size modifiers respond.
![responsive-modal-2](https://user-images.githubusercontent.com/18653/186699339-e10c7f15-958f-43fc-b965-945ecc45152e.gif)

Showing how common legacy classes respond.
![responsive-modal-3](https://user-images.githubusercontent.com/18653/186699353-d9a5ae69-6ab1-40ed-bcba-5a71fc0a7d56.gif)

Closes #1425 