### PR TITLE
Restore expected field widths on form components in rules UI

### DIFF
--- a/stylesheets/_component.forms.scss
+++ b/stylesheets/_component.forms.scss
@@ -385,7 +385,6 @@ fieldset {
         .form__group--#{$variant}.form__group--#{$variant} .form__control:not(.checkbox):not(.radio),
         .form__group--#{$variant}.form__group--#{$variant} .control__label + .controls > .form__control:not(.checkbox):not(.radio),
         .form__group--#{$variant}.form__group--#{$variant} .control__label + .controls > .form__control + .select2 {
-            max-width: 100%;
             width: #{$width};
         }
     }


### PR DESCRIPTION
I believe this rule was introduced when addressing styling issues for the Sign In UIs, especially for Jadu Connect and had the unintended consequence of negatively affecting Rules as demonstrated below.

Removing doesn't seem to have a negative effect on Sign In anymore, tested using the sign in testbed (private Jadu repo).

Before:
![Screenshot 2022-09-09 at 08 44 02](https://user-images.githubusercontent.com/18653/189299310-f9032491-47f6-4532-a7b2-09a1891387e6.png)

After:
![Screenshot 2022-09-09 at 08 43 06](https://user-images.githubusercontent.com/18653/189300270-123e5b1e-3894-4e58-bf25-006774c67125.png)

