### PR TITLE
Improve obviousness of responsive datatable expand/collapse control

### DIFF
--- a/js/PulsarUIComponent.js
+++ b/js/PulsarUIComponent.js
@@ -86,7 +86,7 @@ PulsarUIComponent.getDatatableOptions = function ($table) {
                 className: 'control',
                 orderable: false,
                 searchable: false,
-                targets: 0
+                targets: -1
             }
         ];
     }

--- a/stylesheets/_component.datatables.scss
+++ b/stylesheets/_component.datatables.scss
@@ -285,24 +285,26 @@ th.sorting_disabled:hover {
     color: color(jadu-purple);
     cursor: pointer;
     display: none;
-    font-size: $font-size-base;
-    font-weight: normal;
+    font-size: $font-size-large;
     line-height: normal;
     margin: 0;
-    padding: 4px 7px 0;
     position: relative;
     text-align: center;
     text-decoration: none;
     user-select: none;
     vertical-align: top;
     white-space: nowrap;
-
+    
     &:focus {
         @include pulsar-button-focused;
     }
-
+    
     &:hover {
         color: color(black);
+    }
+
+    i {
+        font-weight: 400;
     }
 
     .collapsed & {
@@ -311,8 +313,8 @@ th.sorting_disabled:hover {
 }
 
 .parent .table-child-toggle i::before {
-    color: color(jadu-red);
-    // content: $minus-sign;
+    content: '\f32c';
+    font-weight: 900;
 }
 
 .datatable .child ul {

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -1575,32 +1575,25 @@ Datatable - https://jadu.github.io/pulsar/components/datatable/
         {% endif %}
         <thead>
             <tr>
+                {% for column in options.data.columns %}
+                    {% if loop.first %}
+                        {% if options['data-select'] is not defined or (options['data-select'] is defined and options['data-select'] != 'false') %}
+                            <th scope="col" class="table-selection" data-orderable="false">
+                                <span class="hide">Row selection controls</span>
+                                <input type="checkbox" class="form__control checkbox js-select-all" aria-label="Select all rows" data-tippy-content="Select all rows" data-tippy-placement="right" />
+                            </th>
+                        {% endif %}
+                    {% endif %}
+                    <th{{ attributes(column.attrs|default) }} scope="col">{{ column.title }}</th>
+                {% endfor %}
                 {% if overflow == 'collapse' %}
                     <td><span class="hide">Table controls</span></td>
                 {% endif %}
-                    {% for column in options.data.columns %}
-                        {% if loop.first %}
-                            {% if options['data-select'] is not defined or (options['data-select'] is defined and options['data-select'] != 'false') %}
-                                <th scope="col" class="table-selection" data-orderable="false">
-                                    <span class="hide">Row selection controls</span>
-                                    <input type="checkbox" class="form__control checkbox js-select-all" aria-label="Select all rows" data-tippy-content="Select all rows" data-tippy-placement="right" />
-                                </th>
-                            {% endif %}
-                        {% endif %}
-                        <th{{ attributes(column.attrs|default) }} scope="col">{{ column.title }}</th>
-                    {% endfor %}
             </tr>
         </thead>
         <tbody>
             {% for row in options.data.data %}
                 <tr>
-                    {% if overflow == 'collapse' %}
-                        <td class="table-responsive">
-                            <button class="table-child-toggle">
-                                {{ html.icon('plus-sign', { 'label': 'Toggle this rows collapsed columns' }) }}
-                            </button>
-                        </td>
-                    {% endif %}
                     {% if options['data-select'] is not defined or (options['data-select'] is defined and options['data-select'] != 'false') %}
                         <td class="table-selection">
                             <input type="checkbox" class="form__control checkbox js-select" aria-label="Select row" />
@@ -1615,6 +1608,13 @@ Datatable - https://jadu.github.io/pulsar/components/datatable/
                             <td>{{ val }}</td>
                         {% endif %}
                     {% endfor %}
+                    {% if overflow == 'collapse' %}
+                        <td class="table-responsive">
+                            <button class="table-child-toggle">
+                                {{ html.icon('chevron-down', { 'label': 'Toggle this rows collapsed columns' }) }}
+                            </button>
+                        </td>
+                    {% endif %}
                 </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
This attempts to address a usability concern regarding the collapsing datatables control to increase obviousness and visibility.

Commonly, expand controls are positioned at the right hand edge of applicable components, and a caret icon is commonly associated with elements that expand or 'drop down'.

![Screenshot 2023-01-10 at 13 32 45](https://user-images.githubusercontent.com/18653/211565578-52b1adc8-dfcd-48bd-88fd-d8bee726eba7.png)

This won't be a seamless change, products typically implement their own datatable initialisation code so this would likely be a breaking change if products are using the html.datatable helper in conjunction with their own javascript.

In practice, I can't see that Central or Connect use html.datatable, so this change will need to be applied to relevant instances of collapsing datatables in product and their associated js.

