### PR TITLE
Make sure scrollable nav containers are keyboard accessible

### DIFF
--- a/js/NavMainComponent.js
+++ b/js/NavMainComponent.js
@@ -325,9 +325,7 @@ NavMainComponent.prototype.closeSecondaryNav = function (action) {
 NavMainComponent.prototype.closeTertiaryNav = function () {
     var component = this;
 
-    component.$navTertiary.removeClass('is-open')
-        .attr('aria-hidden', 'true');
-
+    component.$navTertiary.removeClass('is-open').attr('aria-hidden', 'true');
     component.$navTertiary.find('.nav-list').removeClass('is-active');
 
     component.$navMain.find('[aria-expanded=true]')

--- a/js/NavMainComponent.js
+++ b/js/NavMainComponent.js
@@ -223,6 +223,9 @@ NavMainComponent.prototype.openSecondaryNav = function ($triggeringElement, even
     component.$navPrimary.find('.is-active').removeClass('is-active');
     component.$navPrimary.find('[href="' + target + '"], [data-target="' + target + '"]').addClass('is-active');
 
+    // Manage scrollable attributes
+    component.$navSecondary.attr('aria-hidden', 'false');
+
     // Manage focus
     component.focusManagementService.storeElement($triggeringElement);
     component.focusManagementService.focusFirstFocusableElement(component.$navSecondary);
@@ -243,6 +246,9 @@ NavMainComponent.prototype.openQuaternaryNav = function (target, $trigger) {
 
     // Show the target nav-list in the opened nav
     component.$navQuaternary.find('[data-nav="' + target + '"]').addClass('is-active');
+
+    // Manage scrollable attributes
+    component.$navQuaternary.attr('aria-hidden', 'false');
 
     // Manage focus
     component.focusManagementService.storeElement($trigger);
@@ -287,7 +293,8 @@ NavMainComponent.prototype.closeSecondaryNav = function (action) {
 
     component.$navMain.removeClass('is-open');
     component.$navMain.find('[aria-expanded=true]').attr( 'aria-expanded', 'false');
-    component.$navSecondary.removeClass('is-open');
+
+    component.$navSecondary.removeClass('is-open').attr('aria-hidden', 'true');
     component.$primaryNavLinks.removeClass('is-active');
     component.$navMain.find('.nav-item.is-active').removeClass('is-active');
     component.$navSecondary.find('.nav-list').removeClass('is-active');
@@ -318,7 +325,9 @@ NavMainComponent.prototype.closeSecondaryNav = function (action) {
 NavMainComponent.prototype.closeTertiaryNav = function () {
     var component = this;
 
-    component.$navTertiary.removeClass('is-open');
+    component.$navTertiary.removeClass('is-open')
+        .attr('aria-hidden', 'true');
+
     component.$navTertiary.find('.nav-list').removeClass('is-active');
 
     component.$navMain.find('[aria-expanded=true]')
@@ -337,6 +346,9 @@ NavMainComponent.prototype.closeQuaternaryNav = function (action) {
     component.$navQuaternary.removeClass('is-open');
     component.$navQuaternary.find('.nav-list.is-active').removeClass('is-active');
     component.$navTertiary.find('[aria-expanded=true]').attr('aria-expanded', 'false');
+
+    // Manage scrollable attributes
+    component.$navQuaternary.attr('aria-hidden', 'true');
 
     if (action === undefined) {
         return;
@@ -552,8 +564,8 @@ NavMainComponent.prototype.moreIconClickHandler = function ($moreLink) {
     // If tertiary nav is already open
     if (component.$navTertiary.find('.nav-list').hasClass('is-active')) {
         $moreLink.attr('aria-expanded', 'false');
-        component.$navTertiary.removeClass('is-open');
-        component.$navQuaternary.removeClass('is-open');
+        component.$navTertiary.removeClass('is-open').attr('aria-hidden', 'true');
+        component.$navQuaternary.removeClass('is-open').attr('aria-hidden', 'true');
         component.$navTertiary.find('.nav-list').removeClass('is-active');
         component.$navQuaternary.find('.nav-list').removeClass('is-active');
     } else {
@@ -561,7 +573,7 @@ NavMainComponent.prototype.moreIconClickHandler = function ($moreLink) {
 
         // Open $navTertiary
         component.$navTertiary.find('.nav-list').addClass('is-active');
-        component.$navTertiary.addClass('is-open');
+        component.$navTertiary.addClass('is-open').attr('aria-hidden', 'false');
 
         // Manage focus
         component.focusManagementService.storeElement($moreLink);

--- a/js/NavMainComponent.js
+++ b/js/NavMainComponent.js
@@ -341,12 +341,9 @@ NavMainComponent.prototype.closeTertiaryNav = function () {
 NavMainComponent.prototype.closeQuaternaryNav = function (action) {
     var component = this;
 
-    component.$navQuaternary.removeClass('is-open');
+    component.$navQuaternary.removeClass('is-open').attr('aria-hidden', 'true');
     component.$navQuaternary.find('.nav-list.is-active').removeClass('is-active');
     component.$navTertiary.find('[aria-expanded=true]').attr('aria-expanded', 'false');
-
-    // Manage scrollable attributes
-    component.$navQuaternary.attr('aria-hidden', 'true');
 
     if (action === undefined) {
         return;

--- a/stylesheets/_component.navigation.scss
+++ b/stylesheets/_component.navigation.scss
@@ -38,6 +38,11 @@
     padding: 0;
     position: relative;
     vertical-align: top;
+
+    &:focus {
+        border: 2px solid color(border, focus);
+        outline: 2px solid color(black);
+    }
 }
 
 .nav-inline {

--- a/tests/js/web/NavMainComponentTest.js
+++ b/tests/js/web/NavMainComponentTest.js
@@ -44,7 +44,7 @@ describe('NavMainComponent', function () {
                        </li>
                    </ul>
                </div>
-               <div class="nav-secondary nav-flyout" id="aria-secondary-nav">
+               <div class="nav-secondary nav-flyout" id="aria-secondary-nav" tabindex="0" aria-hidden="true">
                    <div class="nav-controls">
                        <button class="nav-controls__close" data-nav-action="close">x</button>
                    </div>
@@ -67,7 +67,7 @@ describe('NavMainComponent', function () {
                        </ul>
                    </div>
                </div>
-               <div class="nav-tertiary nav-flyout" id="aria-tertiary-nav">
+               <div class="nav-tertiary nav-flyout" id="aria-tertiary-nav" tabindex="0" aria-hidden="true">
                    <div class="nav-controls">
                        <button class="nav-controls__close" data-nav-action="close">x</button>
                    </div>
@@ -88,7 +88,7 @@ describe('NavMainComponent', function () {
                        </ul>
                    </div>
                </div>
-               <div class="nav-quaternary nav-flyout" id="aria-quaternary-nav">
+               <div class="nav-quaternary nav-flyout" id="aria-quaternary-nav" tabindex="0" aria-hidden="true">
                    <div class="nav-controls">
                        <button class="nav-controls__close-ltr" data-nav-action="close">x</button>
                    </div>
@@ -363,6 +363,10 @@ describe('NavMainComponent', function () {
             expect(this.$html.find('.nav-main').hasClass('is-open')).to.be.true;
         });
 
+        it('should remove the aria-hidden attribute from the secondary container', function () {
+            expect(this.$html.find('.nav-secondary').attr('aria-hidden')).to.be.equal('false');
+        });
+
         it('should change aria-expanded false to true on the clicked link', function () {
             expect(this.$linkOne.attr('aria-expanded')).to.be.equal('true');
         });
@@ -462,6 +466,10 @@ describe('NavMainComponent', function () {
             expect(this.$linkOne.attr('aria-expanded')).to.be.equal('false');
         });
 
+        it('should set aria-hidden attribute to true for the secondary container', function () {
+            expect(this.$html.find('.nav-secondary').attr('aria-hidden')).to.be.equal('true');
+        });
+
         it('should remove the highlight from that sections primary nav item', function () {
             expect(this.$html.find('.nav-primary .nav-link').hasClass('is-active')).to.be.false;
         });
@@ -484,6 +492,18 @@ describe('NavMainComponent', function () {
 
         it('should close all sub navigations', function () {
             expect(this.$html.find('.nav-main div').hasClass('is-open')).to.be.false;
+        });
+
+        it('should set aria-hidden attribute to true for the secondary container', function () {
+            expect(this.$html.find('.nav-secondary').attr('aria-hidden')).to.be.equal('true');
+        });
+
+        it('should set aria-hidden attribute to true for the tertiary container', function () {
+            expect(this.$html.find('.nav-tertiary').attr('aria-hidden')).to.be.equal('true');
+        });
+
+        it('should set aria-hidden attribute to true for the quaternary container', function () {
+            expect(this.$html.find('.nav-quaternary').attr('aria-hidden')).to.be.equal('true');
         });
     });
 
@@ -526,6 +546,14 @@ describe('NavMainComponent', function () {
             this.$moreIconLink.trigger(this.clickEvent);
 
             expect(this.$html.find('.nav-tertiary').hasClass('is-open')).to.be.true;
+        });
+
+        it('should set aria-hidden attribute to true for the secondary container', function () {
+            expect(this.$html.find('.nav-secondary').attr('aria-hidden')).to.be.equal('true');
+        });
+
+        it('should set aria-hidden attribute to false for the tertiary container', function () {
+            expect(this.$html.find('.nav-tertiary').attr('aria-hidden')).to.be.equal('true');
         });
 
         it('should add the is-active class to nav-tertiary nav-list', function () {
@@ -609,6 +637,10 @@ describe('NavMainComponent', function () {
 
             it('should change the clicked links aria-expanded to true', function () {
                 expect(this.$tertiaryLink.attr('aria-expanded')).to.be.equal('true');
+            });
+
+            it('should set aria-hidden attribute to false for the quaternary container', function () {
+                expect(this.$html.find('.nav-quaternary').attr('aria-hidden')).to.be.equal('false');
             });
 
             it('should focus the quaternary nav close button', function () {

--- a/views/pulsar/v2/helpers/nav.html.twig
+++ b/views/pulsar/v2/helpers/nav.html.twig
@@ -20,7 +20,7 @@
         </ul>
     </div>
 
-    <div class="nav-secondary t-nav-secondary nav-flyout" id="aria-secondary-nav">
+    <div class="nav-secondary t-nav-secondary nav-flyout" id="aria-secondary-nav" tabindex="0" aria-hidden="true">
 
         <div class="nav-controls">
             <button class="nav-controls__close" data-nav-action="close" tabindex="1">{{ html.icon('remove', { 'label': 'Close expanded menu' }) }}</button>
@@ -53,7 +53,7 @@
 
     </div>
 
-    <div class="nav-tertiary t-nav-tertiary nav-flyout" id="aria-tertiary-nav">
+    <div class="nav-tertiary t-nav-tertiary nav-flyout" id="aria-tertiary-nav" tabindex="0" aria-hidden="true">
 
         <div class="nav-controls">
             <button class="nav-controls__close" data-nav-action="close" tabindex="1">{{ html.icon('remove', { 'label': 'Close expanded menu' }) }}</button>
@@ -74,7 +74,7 @@
 
     </div>
 
-    <div class="nav-quaternary t-nav-quaternary nav-flyout" id="aria-quaternary-nav">
+    <div class="nav-quaternary t-nav-quaternary nav-flyout" id="aria-quaternary-nav" tabindex="0" aria-hidden="true">
 
         <div class="nav-controls">
             <button class="nav-controls__close-ltr" data-nav-action="close" tabindex="1">{{ html.icon('remove', { 'label': 'Close expanded menu' }) }}</button>


### PR DESCRIPTION
Stops siteimprove plugin from flagging this as an issue.

Adds a tabindex on the flyout containers which are scrollable and so will now receive focus. A new focus outline has been added to maintain consistency with established focus states.

![Screenshot 2023-01-31 at 11 49 19](https://user-images.githubusercontent.com/18653/215782116-e5f6c310-5f55-40a7-8057-89eceaffa0ba.png)

Closes #1480