### PR TITLE
Explicitly set html variable where it is used

### DIFF
--- a/views/lexicon/patterns/tab-header/table.html.twig
+++ b/views/lexicon/patterns/tab-header/table.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends '@pulsar/pulsar/components/tab.html.twig' %}
 
 {%- block actions_left -%}

--- a/views/lexicon/tabs/checkgrid.html.twig
+++ b/views/lexicon/tabs/checkgrid.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends '@pulsar/pulsar/components/tab.html.twig' %}
 
 

--- a/views/playground/admin-mappings/index.html.twig
+++ b/views/playground/admin-mappings/index.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends '@pulsar/pulsar/layouts/base.html.twig' %}
 
 {% block tabs_content %}

--- a/views/playground/branding/branding.html.twig
+++ b/views/playground/branding/branding.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
 {% block tab_settings %}

--- a/views/playground/galaxies/admins.html.twig
+++ b/views/playground/galaxies/admins.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
 {%- block actions_left -%}

--- a/views/playground/galaxies/designer.html.twig
+++ b/views/playground/galaxies/designer.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends '@pulsar/lexicon/base.html.twig' %}
 
 {% set heading = 'Continuum Festival' %}

--- a/views/playground/galaxies/security.html.twig
+++ b/views/playground/galaxies/security.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
 {%- block actions_left -%}

--- a/views/playground/galaxies/settings.html.twig
+++ b/views/playground/galaxies/settings.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
 {%- block actions_left -%}

--- a/views/playground/galaxies/sites.html.twig
+++ b/views/playground/galaxies/sites.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
 {%- block actions_left -%}

--- a/views/playground/galaxies/theme.html.twig
+++ b/views/playground/galaxies/theme.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
 {%- block actions_left -%}

--- a/views/playground/rebooking/index.html.twig
+++ b/views/playground/rebooking/index.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends '@pulsar/pulsar/layouts/base.html.twig' %}
 
 {% block tabs_content %}

--- a/views/playground/slider/index.html.twig
+++ b/views/playground/slider/index.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends '@pulsar/pulsar/layouts/base.html.twig' %}
 
 {% block body %}

--- a/views/playground/sortable/tab.html.twig
+++ b/views/playground/sortable/tab.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
 {% block tab_content %}

--- a/views/playground/xfp-received/index.html.twig
+++ b/views/playground/xfp-received/index.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends '@pulsar/lexicon/base.html.twig' %}
 
 {% set heading = 'Ref 5431 - Blue Badge Application Form' %}

--- a/views/playground/xfp-received/log.html.twig
+++ b/views/playground/xfp-received/log.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends '@pulsar/pulsar/components/tab.html.twig' %}
 
 {% block tab_content %}

--- a/views/playground/xfp-received/tab.html.twig
+++ b/views/playground/xfp-received/tab.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
 {%- block actions_left -%}

--- a/views/pulsar/components/toolbar.html.twig
+++ b/views/pulsar/components/toolbar.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 <div class="toolbar">
     <a href="#" class="mobile-menu-button">Menu</a>
 

--- a/views/pulsar/layouts/pulsar.html.twig
+++ b/views/pulsar/layouts/pulsar.html.twig
@@ -1,3 +1,4 @@
+{% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 {% extends '@pulsar/pulsar/layouts/base.html.twig' %}
 
 {% block body %}


### PR DESCRIPTION
It's a recent requirement (how recent I don't actually know) to explicitly define macros you're using in a child template even if they're defined in a parent template. This PR adds them where they're missing.