### PR TITLE
Qu 4501 (round two)

### DIFF
--- a/js/DropZone/DropZone.js
+++ b/js/DropZone/DropZone.js
@@ -110,7 +110,7 @@ export default class DropZone {
             // add processed files to file store
             this.files = [...this.files, ...processedFiles];
 
-            //<QU-4501> We need to manually update the datatransfer.files object as it is not updated by the browser due to security reasons
+            //We need to manually update the datatransfer.files object as it is not updated by the browser due to security reasons
             const dataTransfer = new DataTransfer();
             let wasFile = false;
             for (let i = 0; i < this.files.length; i++) {
@@ -123,7 +123,6 @@ export default class DropZone {
                 // this guard exists as some js tests do not provide a file type as the input value.
                 document.getElementById(this.options.inputNodeId).files = dataTransfer.files;
             }
-            //</QU-4501>
         }
 
         // fire dropped callback

--- a/js/DropZone/DropZone.js
+++ b/js/DropZone/DropZone.js
@@ -114,7 +114,7 @@ export default class DropZone {
             const dataTransfer = new DataTransfer();
             let wasFile = false;
             for (let i = 0; i < this.files.length; i++) {
-                if (this.files[i].raw instanceof File){
+                if (this.files[i] && this.files[i].raw instanceof File){
                     dataTransfer.items.add(this.files[i].raw);
                     wasFile = true;
                 }

--- a/js/DropZone/DropZone.js
+++ b/js/DropZone/DropZone.js
@@ -109,6 +109,21 @@ export default class DropZone {
         if (valid) {
             // add processed files to file store
             this.files = [...this.files, ...processedFiles];
+
+            //<QU-4501> We need to manually update the datatransfer.files object as it is not updated by the browser due to security reasons
+            const dataTransfer = new DataTransfer();
+            let wasFile = false;
+            for (let i = 0; i < this.files.length; i++) {
+                if (this.files[i].raw instanceof File){
+                    dataTransfer.items.add(this.files[i].raw);
+                    wasFile = true;
+                }
+            }
+            if (wasFile){
+                // this guard exists as some js tests do not provide a file type as the input value.
+                document.getElementById(this.options.inputNodeId).files = dataTransfer.files;
+            }
+            //</QU-4501>
         }
 
         // fire dropped callback


### PR DESCRIPTION
The exact same bug fixed in https://github.com/jadu/pulsar/pull/1556 can still occur if you use the drag-and-drop feature instead of just selecting to browse files. We need to replicate the change for drag and dropped attachments.
