### PR TITLE
Add null check for missing input node ids

### DIFF
--- a/js/DropZone/DropZone.js
+++ b/js/DropZone/DropZone.js
@@ -119,7 +119,7 @@ export default class DropZone {
                     wasFile = true;
                 }
             }
-            if (wasFile){
+            if (wasFile && this.options.inputNodeId){
                 // this guard exists as some js tests do not provide a file type as the input value.
                 document.getElementById(this.options.inputNodeId).files = dataTransfer.files;
             }


### PR DESCRIPTION
Input nodes may not always be immediately available if the elements load at a later time (_like in a modal)_ or are otherwise manipulated. 