### PR TITLE
Fix misnamed unit test reference

### DIFF
--- a/src/Jadu/Pulsar/Twig/Extension/AttributeParserExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/AttributeParserExtension.php
@@ -8,7 +8,7 @@ namespace Jadu\Pulsar\Twig\Extension;
  * Takes an array of attributes to be converted into HTML formatted attributes
  * ready for use in an HTML element.
  *
- * Unit tests: tests/unit/AttributeParserExtensionTest.php
+ * Unit tests: tests/unit/Jadu/Pulsar/Twig/Extension/AttributeParserExtensionTest.php
  */
 class AttributeParserExtension extends \Twig_Extension
 {

--- a/src/Jadu/Pulsar/Twig/Extension/AttributeParserExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/AttributeParserExtension.php
@@ -8,7 +8,7 @@ namespace Jadu\Pulsar\Twig\Extension;
  * Takes an array of attributes to be converted into HTML formatted attributes
  * ready for use in an HTML element.
  *
- * Unit tests: tests/unit/AttribuetParserExtensionTest.php
+ * Unit tests: tests/unit/AttributeParserExtensionTest.php
  */
 class AttributeParserExtension extends \Twig_Extension
 {


### PR DESCRIPTION
## Summary
- fix comment path for `AttributeParserExtensionTest`

## Testing
- `phpunit --configuration phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_b_6847185bca948322bc18f49386f12810