### PR TITLE
Fix ConfigExtension paths in app entry scripts

### DIFF
--- a/app/app.php
+++ b/app/app.php
@@ -27,7 +27,7 @@ $twig = new Twig_Environment($loader,
 
 $twig->addExtension(new ArrayExtension());
 $twig->addExtension(new AttributeParserExtension());
-$twig->addExtension(new ConfigExtension($baseDir . 'pulsar.json'));
+$twig->addExtension(new ConfigExtension($baseDir . '/pulsar.json'));
 $twig->addExtension(new ConstantDefinedExtension());
 $twig->addExtension(new HelperOptionsModifierExtension());
 $twig->addExtension(new GetConstantExtension());

--- a/app/test.php
+++ b/app/test.php
@@ -24,7 +24,7 @@ $twig = new Twig_Environment($loader,
 
 $twig->addExtension(new ArrayExtension());
 $twig->addExtension(new AttributeParserExtension());
-$twig->addExtension(new ConfigExtension($baseDir . 'pulsar.json'));
+$twig->addExtension(new ConfigExtension($baseDir . '/pulsar.json'));
 $twig->addExtension(new RelativeTimeExtension());
 $twig->addExtension(new UrlParamsExtension($_GET));
 $twig->addExtension(new TabsExtension());


### PR DESCRIPTION
## Summary
- fix `ConfigExtension` path concatenation in `app/app.php`
- fix path in `app/test.php`

## Testing
- `phpunit --configuration phpunit.xml.dist`
- verify sample pages at `/app/app.php/lexicon` load via PHP dev server

------
https://chatgpt.com/codex/tasks/task_b_68471a1631388322a1ff3539062eb3e6