### PR TITLE
Remove debugger comment from DropZone test

### DIFF
--- a/tests/js/web/DropZone/DropZoneComponentTest.js
+++ b/tests/js/web/DropZone/DropZoneComponentTest.js
@@ -182,7 +182,6 @@ describe('DropZoneComponent', () => {
             instanceManager.getFiles.returns(rawFiles);
             dropZoneComponent.processInputNode($fileInput[0], 0, options.showInputNode);
             $fileInput[0].dispatchEvent(change);
-            //debugger;
             const dataTransferFile = getDTFileList($fileInput[0])[0];
             const inputFile = $fileInput[0].files[0];
             expect(inputFile.name).to.equal(dataTransferFile.name);


### PR DESCRIPTION
## Summary
- delete stray `//debugger;` line from `DropZoneComponentTest.js`

## Testing
- `npm run test:headless` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_b_68483d32687c832280978a4d1d551e5a