### PR TITLE
Upgrade Twig dependency to v3.27 to fix security vulnerabilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     },
     "require": {
-        "twig/twig": "^2.0"
+        "twig/twig": "^3.27"
     },
     "require-dev": {
         "symfony/yaml": "*"

--- a/src/Jadu/Pulsar/Twig/Extension/ArrayExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/ArrayExtension.php
@@ -2,7 +2,10 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
-class ArrayExtension extends \Twig_Extension
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class ArrayExtension extends AbstractExtension
 {
 
 	/**
@@ -13,12 +16,12 @@ class ArrayExtension extends \Twig_Extension
 	public function getFilters()
 	{
 		$filters = array(
-			new \Twig_SimpleFilter(
+			new TwigFilter(
 				'exclude',
 				array($this, 'excludeFromArray'),
 				$options = array()
 			),
-			new \Twig_SimpleFilter(
+			new TwigFilter(
 				'only',
 				array($this, 'onlyFromArray'),
 				$options = array()

--- a/src/Jadu/Pulsar/Twig/Extension/AttributeParserExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/AttributeParserExtension.php
@@ -2,6 +2,10 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
 /**
  * Attribute parser
  *
@@ -10,7 +14,7 @@ namespace Jadu\Pulsar\Twig\Extension;
  *
  * Unit tests: tests/unit/AttributeParserExtensionTest.php
  */
-class AttributeParserExtension extends \Twig_Extension
+class AttributeParserExtension extends AbstractExtension
 {
     /**
      * Get the name of this extension
@@ -30,7 +34,7 @@ class AttributeParserExtension extends \Twig_Extension
     public function getFilters()
     {
         $filters = array(
-            new \Twig_SimpleFilter(
+            new TwigFilter(
                 'defaults',
                 array($this, 'defaultAttributes'),
                 array('is_safe' => array('html'))
@@ -47,7 +51,7 @@ class AttributeParserExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'attributes',
                 array($this, 'parseAttributes'),
                 array('is_safe' => array('html'))

--- a/src/Jadu/Pulsar/Twig/Extension/ConfigExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/ConfigExtension.php
@@ -2,6 +2,9 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+
 /**
  * Config
  *
@@ -10,7 +13,7 @@ namespace Jadu\Pulsar\Twig\Extension;
  *
  * Unit tests: tests/unit/ConfigExtensionTest.php
  */
-class ConfigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
+class ConfigExtension extends AbstractExtension implements GlobalsInterface
 {
 
     protected $configFile;
@@ -20,12 +23,12 @@ class ConfigExtension extends \Twig_Extension implements \Twig_Extension_Globals
         $this->configFile = $configFile;
     }
 
-    public function getName() 
+    public function getName()
     {
         return 'config_extension';
     }
 
-    public function getGlobals()
+    public function getGlobals(): array
     {
         return $this->getConfigVars();
     }

--- a/src/Jadu/Pulsar/Twig/Extension/ConstantDefinedExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/ConstantDefinedExtension.php
@@ -2,15 +2,15 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
-use Twig_Extension;
-use Twig_SimpleFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class ConstantDefinedExtension extends \Twig_Extension
+class ConstantDefinedExtension extends AbstractExtension
 {
     public function getFunctions()
     {
         return array(
-            new Twig_SimpleFunction('constant_defined', 'defined'),
+            new TwigFunction('constant_defined', 'defined'),
         );
     }
 

--- a/src/Jadu/Pulsar/Twig/Extension/GetConstantExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/GetConstantExtension.php
@@ -2,10 +2,10 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
-use Twig_Extension;
-use Twig_SimpleFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class GetConstantExtension extends Twig_Extension
+class GetConstantExtension extends AbstractExtension
 {
 
     /**
@@ -16,7 +16,7 @@ class GetConstantExtension extends Twig_Extension
     public function getFunctions()
     {
         return array(
-            new Twig_SimpleFunction('get_constant', array($this, 'getConstant')),
+            new TwigFunction('get_constant', array($this, 'getConstant')),
         );
     }
 

--- a/src/Jadu/Pulsar/Twig/Extension/HelperOptionsModifierExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/HelperOptionsModifierExtension.php
@@ -2,7 +2,10 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
-class HelperOptionsModifierExtension extends \Twig_Extension
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class HelperOptionsModifierExtension extends AbstractExtension
 {
     /**
      * Name of this extension
@@ -22,7 +25,7 @@ class HelperOptionsModifierExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('modify_options', array($this, 'modifyOptions'))
+            new TwigFunction('modify_options', array($this, 'modifyOptions'))
         );
     }
 

--- a/src/Jadu/Pulsar/Twig/Extension/RelativeTimeExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/RelativeTimeExtension.php
@@ -2,6 +2,9 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
 /**
  * Relative Time
  *
@@ -12,7 +15,7 @@ namespace Jadu\Pulsar\Twig\Extension;
  *
  * Unit tests: tests/unit/RelativeTimeExtensionTest.php
  */
-class RelativeTimeExtension extends \Twig_Extension
+class RelativeTimeExtension extends AbstractExtension
 {
 
     public function getName()
@@ -23,7 +26,7 @@ class RelativeTimeExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFilter('time_ago', array($this, 'timeAgo'))
+            new TwigFilter('time_ago', array($this, 'timeAgo'))
         );
     }
 

--- a/src/Jadu/Pulsar/Twig/Extension/TabsExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/TabsExtension.php
@@ -2,7 +2,10 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
-class TabsExtension extends \Twig_Extension
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class TabsExtension extends AbstractExtension
 {
     public function getName()
     {
@@ -12,7 +15,7 @@ class TabsExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('get_active_tab', array($this, 'getActiveParentTabID'))
+            new TwigFunction('get_active_tab', array($this, 'getActiveParentTabID'))
             );
     }
 

--- a/src/Jadu/Pulsar/Twig/Extension/UrlParamsExtension.php
+++ b/src/Jadu/Pulsar/Twig/Extension/UrlParamsExtension.php
@@ -2,6 +2,9 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+
 /**
  * Url Parameters
  *
@@ -10,7 +13,7 @@ namespace Jadu\Pulsar\Twig\Extension;
  *
  * Unit tests: tests/unit/UrlParamsExtensionTest.php
  */
-class UrlParamsExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
+class UrlParamsExtension extends AbstractExtension implements GlobalsInterface
 {
     /**
      * Query string parameters
@@ -28,7 +31,7 @@ class UrlParamsExtension extends \Twig_Extension implements \Twig_Extension_Glob
         return 'url_params_extension';
     }
 
-    public function getGlobals()
+    public function getGlobals(): array
     {
         return array(
             'active_tab' => $this->getActiveTab(),

--- a/tests/unit/Jadu/Pulsar/Twig/Extension/ArrayExtensionTest.php
+++ b/tests/unit/Jadu/Pulsar/Twig/Extension/ArrayExtensionTest.php
@@ -2,6 +2,9 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
 class ArrayExtensionTest extends \PHPUnit\Framework\TestCase
 {
 	public $loader;
@@ -12,8 +15,8 @@ class ArrayExtensionTest extends \PHPUnit\Framework\TestCase
 	public function setUp(): void
 	{
 		parent::setUp();
-		$this->loader = new \Twig_Loader_Filesystem();
-		$this->env = new \Twig_Environment($this->loader);
+		$this->loader = new FilesystemLoader();
+		$this->env = new Environment($this->loader);
 		$this->ext = new ArrayExtension(array());
 		$this->data = array('slim' => 'shady', 'marshall' => 'mathers', 'eminem' => true, 'class' => 'wrapper');
 	}

--- a/tests/unit/Jadu/Pulsar/Twig/Extension/ConstantDefinedExtensionTest.php
+++ b/tests/unit/Jadu/Pulsar/Twig/Extension/ConstantDefinedExtensionTest.php
@@ -2,8 +2,8 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
-use Twig_Environment;
-use Twig_Loader_Array;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 class ConstantDefinedExtensionTest extends \PHPUnit\Framework\TestCase
 {
@@ -21,11 +21,11 @@ class ConstantDefinedExtensionTest extends \PHPUnit\Framework\TestCase
 
     public function testConstantDefinedFunction()
     {
-        $loader = new Twig_Loader_Array(array(
+        $loader = new ArrayLoader(array(
             'index.html' => '{% if constant_defined("FOO") %}true{% endif %}',
         ));
 
-        $twig = new Twig_Environment($loader);
+        $twig = new Environment($loader);
         $twig->addExtension(new ConstantDefinedExtension());
 
         define('FOO', true);

--- a/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
+++ b/tests/unit/Jadu/Pulsar/Twig/Extension/GetConstantExtensionTest.php
@@ -2,8 +2,8 @@
 
 namespace Jadu\Pulsar\Twig\Extension;
 
-use Twig_Environment;
-use Twig_Loader_Array;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 class GetConstantExtensionTest extends \PHPUnit\Framework\TestCase
 {
@@ -27,11 +27,11 @@ class GetConstantExtensionTest extends \PHPUnit\Framework\TestCase
 
     public function testGetConstantFunction()
     {
-        $loader = new Twig_Loader_Array(array(
+        $loader = new ArrayLoader(array(
             'index.html' => '{{ get_constant("STRING") }}',
         ));
 
-        $twig = new Twig_Environment($loader);
+        $twig = new Environment($loader);
         $twig->addExtension(new GetConstantExtension());
 
         $this->assertEquals('foo', $twig->render('index.html'));

--- a/tests/unit/Jadu/Pulsar/Twig/Macro/MacroTest.php
+++ b/tests/unit/Jadu/Pulsar/Twig/Macro/MacroTest.php
@@ -10,12 +10,12 @@ use Jadu\Pulsar\Twig\Extension\HelperOptionsModifierExtension;
 use Jadu\Pulsar\Twig\Extension\RelativeTimeExtension;
 use Jadu\Pulsar\Twig\Extension\UrlParamsExtension;
 use Jadu\Pulsar\Twig\Extension\TabsExtension;
-use Twig_Environment;
-use Twig_Loader_Filesystem;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RecursiveRegexIterator;
 use RegexIterator;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 class MacroTest extends \PHPUnit\Framework\TestCase
 {
@@ -26,12 +26,12 @@ class MacroTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
         $baseDir = __DIR__ . '/../../../../../../';
 
-        $loader = new Twig_Loader_Filesystem($this->getFixturesPath());
+        $loader = new FilesystemLoader($this->getFixturesPath());
         $loader->addPath($baseDir . 'views', 'pulsar');
         $loader->addPath($baseDir . 'tests/unit/Jadu/Pulsar/Twig/Macro/Fixtures', 'tests');
         $loader->addPath($baseDir . 'tests/css', 'cssTests');
 
-        $this->twig = new Twig_Environment($loader, array(
+        $this->twig = new Environment($loader, array(
             'cache' => false,
             'strict_variables' => true,
         ));
@@ -85,7 +85,7 @@ class MacroTest extends \PHPUnit\Framework\TestCase
 
         // Normalise random ids generated and used by help text
         $output = preg_replace('/(guid-)\w+/', 'guid-1', $output);
-        
+
         return $output;
     }
 

--- a/views/lexicon/tabs/pagination.html.twig
+++ b/views/lexicon/tabs/pagination.html.twig
@@ -1,7 +1,7 @@
 {% extends "@pulsar/pulsar/components/tab.html.twig" %}
 
 {% block tab_content %}
-{% spaceless %}
+{% apply spaceless %}
 <div class="u-margin-bottom--large">
     <h2 class="heading">Previous link hidden on first page</h2>
     <nav aria-label="Table pagination" class="pagination">
@@ -15,9 +15,9 @@
         </ul>
     </nav>
 </div>
-{% endspaceless %}
+{% endapply %}
 
-{% spaceless %}
+{% apply spaceless %}
 <div class="u-margin-bottom--large">
     <h2 class="heading">Previous and next link shown when previous or next pages exist</h2>
     <nav aria-label="Table pagination" class="pagination">
@@ -32,9 +32,9 @@
         </ul>
     </nav>
 </div>
-{% endspaceless %}
+{% endapply %}
 
-{% spaceless %}
+{% apply spaceless %}
 <div>
     <h2 class="heading">Next link hidden on last page</h2>
     <nav aria-label="Table pagination" class="pagination">
@@ -48,5 +48,5 @@
         </ul>
     </nav>
 </div>
-{% endspaceless %}
+{% endapply %}
 {% endblock tab_content %}

--- a/views/pulsar/components/flash.html.twig
+++ b/views/pulsar/components/flash.html.twig
@@ -1,4 +1,4 @@
-{% spaceless %}
+{% apply spaceless %}
 <div class="flash-container js-flash-container">
 {% if flash_message is defined %}
 {% import '@pulsar/pulsar/v2/helpers/flash.html.twig' as flash %}
@@ -11,4 +11,4 @@
 }}
 {% endif %}
 </div>
-{% endspaceless %}
+{% endapply %}

--- a/views/pulsar/v2/forms.html.twig
+++ b/views/pulsar/v2/forms.html.twig
@@ -120,7 +120,7 @@
 
 {# Main form_row block, used to generate complete form rows including pulsar mark up and labels/fields#}
 {% block form_row %}
-    {% spaceless %}
+    {% apply spaceless %}
         <div class="form__group{% if errors|length > 0 %} has-error{% endif %}{% if attr.class is defined %} {{ attr.class }}{% endif %}">
             {{ form_label(form) }}
             <div class="controls">
@@ -195,7 +195,7 @@
                 {% endif %}
             </div>
         </div>
-    {% endspaceless %}
+    {% endapply %}
 {% endblock form_row %}
 
 {% block button_row %}
@@ -222,18 +222,18 @@
 {% endblock form_start %}
 
 {% block form_errors %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% for error in errors %}
             <p class="help-block">
                 {{ error.message }}
             </p>
         {% endfor %}
-    {% endspaceless %}
+    {% endapply %}
 {% endblock form_errors %}
 
 {# Used when form_row is used to generate a group of compound fields, such as a group of check boxes #}
 {% block form_rows %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% for child in form %}
             <label class="control__label">
                 {{ form_widget(child, {attr: attr}) }}
@@ -244,14 +244,14 @@
                 {% endif %}
             </label>
         {% endfor %}
-    {% endspaceless %}
+    {% endapply %}
 {% endblock form_rows %}
 
 {# Used when form_row is used to generate a group of repeated fields, such as 2 text inputs #}
 {% block form_rows_repeated %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% for child in form %}
             {{ form_row(child, {attr: repeated_attr is defined ? repeated_attr : {}}) }}
         {% endfor %}
-    {% endspaceless %}
+    {% endapply %}
 {% endblock form_rows_repeated %}

--- a/views/pulsar/v2/helpers/elem.html.twig
+++ b/views/pulsar/v2/helpers/elem.html.twig
@@ -36,7 +36,7 @@ value       | string | Specifies the value of the input
 
 #}
 {% macro input(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     {% if options.naked is not defined or options.naked != true %}
@@ -62,7 +62,7 @@ value       | string | Specifies the value of the input
 
     <input{{ attributes(options|exclude('append bare has_error help_id input_placement prepend naked')) }} />
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -96,7 +96,7 @@ name    | string | The name of this control
 #}
 {% macro label(options) %}
 
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     {% set labelVisibilityClass = '' %}
@@ -126,7 +126,7 @@ name    | string | The name of this control
         </{{ tag }}>
     {% endif %}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -157,7 +157,7 @@ value   | string | Specifies the value of the paragraph
 
 #}
 {% macro paragraph(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     {% if options.value is not empty %}
@@ -166,7 +166,7 @@ value   | string | Specifies the value of the paragraph
         </p>
     {% endif %}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -203,7 +203,7 @@ value       | string | Specifies the value of the input
 
 #}
 {% macro select(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     {# Build aria-described string of guids for help blocks and errors #}
@@ -300,7 +300,7 @@ value       | string | Specifies the value of the input
 
     </select>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -337,7 +337,7 @@ value       | string | Specifies the value of the input
 
 #}
 {% macro select2(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as elem %}
 
     {% if options.label is defined and options.label is not empty %}
@@ -356,7 +356,7 @@ value       | string | Specifies the value of the input
 
     {{ elem.select(options|merge({'class': 'select js-select2'})|exclude('placeholder') ) }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -391,7 +391,7 @@ value       | string  | Specifies the value of the input
 
 #}
 {% macro textarea(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     {# Build aria-described string of guids for help blocks and errors #}
@@ -427,5 +427,5 @@ value       | string  | Specifies the value of the input
     {%- endif -%}
     </textarea>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}

--- a/views/pulsar/v2/helpers/flash.html.twig
+++ b/views/pulsar/v2/helpers/flash.html.twig
@@ -1,5 +1,5 @@
 {% macro message(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 
     {% if options.type is defined and options.type == 'success' %}
@@ -24,5 +24,5 @@
         {% endif %}
     </section>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}

--- a/views/pulsar/v2/helpers/form.html.twig
+++ b/views/pulsar/v2/helpers/form.html.twig
@@ -49,7 +49,7 @@ items         | array  | An array of items to put in the dropdown list (usually 
 
 #}
 {% macro button_group(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -105,7 +105,7 @@ items         | array  | An array of items to put in the dropdown list (usually 
             'inputs': items
         })
     }}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -153,7 +153,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro checkbox(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -179,7 +179,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
         })
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -230,7 +230,7 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro checkbox_inline(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -285,7 +285,7 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
         })
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 {# -----------------------------------------------------------------------------
@@ -338,7 +338,7 @@ required | bool   | Visually indicates that the field must be completed
 
 #}
 {% macro checkbox_simple(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
     {{
@@ -357,7 +357,7 @@ required | bool   | Visually indicates that the field must be completed
         )
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -411,7 +411,7 @@ show-label | bool   | Control visibility of the `<label>` element without affect
 
 #}
 {% macro choice(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -552,7 +552,7 @@ show-label | bool   | Control visibility of the `<label>` element without affect
 
     {% endif %}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -601,7 +601,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro color(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -617,7 +617,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
     {{ form.text(options) }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -632,7 +632,7 @@ https://jadu.github.io/pulsar/form-helpers/compound
 
 #}
 {% macro compound(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
@@ -707,7 +707,7 @@ https://jadu.github.io/pulsar/form-helpers/compound
     </div>
 </fieldset>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -755,7 +755,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro content(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -774,7 +774,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
         })
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -831,7 +831,7 @@ attribute on the `form` element will be set to `POST`.
 
 #}
 {% macro create(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -866,7 +866,7 @@ attribute on the `form` element will be set to `POST`.
 
     {{ methodInput|default }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -921,7 +921,7 @@ data-pulsar-datepicker-trigger-label | string | Label for the pulsar date picker
 
 #}
 {% macro date(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 
@@ -971,7 +971,7 @@ data-pulsar-datepicker-trigger-label | string | Label for the pulsar date picker
 
     {{ form.text(options) }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1011,7 +1011,7 @@ class   | string | A space separated list of class names
 #}
 {% macro end(options) %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
-    {% spaceless %}
+    {% apply spaceless %}
 
     {% if options.actions is defined %}
         <div{{
@@ -1028,7 +1028,7 @@ class   | string | A space separated list of class names
         </div>
     {% endif %}
     </form>
-    {% endspaceless %}
+    {% endapply %}
 {% endmacro %}
 
 
@@ -1069,7 +1069,7 @@ value  | string, array  | The string, or array of strings to render inside the e
 #}
 {% macro error(options) %}
 {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
-{% spaceless %}
+{% apply spaceless %}
     {% if options.value is defined and options.value is not empty %}
         {% if options.value is not iterable %}
             {% set errors = [options.value] %}
@@ -1091,7 +1091,7 @@ value  | string, array  | The string, or array of strings to render inside the e
             {% endfor %}
         {% endif %}
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1124,7 +1124,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro fieldset_start(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     <fieldset{{ attributes(options|exclude('legend')) }}>
@@ -1135,7 +1135,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
         <legend class="legend">{{ options.legend|raw }}</legend>
     {% endif %}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1153,11 +1153,11 @@ Used in conjunction with `fieldset.start()` and closes the `<fieldset>`.
 
 #}
 {% macro fieldset_end() %}
-{% spaceless %}
+{% apply spaceless %}
 
     </fieldset>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1206,7 +1206,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 *
 #}
 {% macro file(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -1225,7 +1225,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
         })
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 {# -----------------------------------------------------------------------------
@@ -1519,7 +1519,7 @@ value  | string | The string or html markup to render inside the help block
 
 #}
 {% macro help(options) %}
-{% spaceless %}
+{% apply spaceless %}
 
     {% if options.value is defined and options.value is not empty %}
         <span class="help-block"{% if options.id is defined and options.id is not empty %} id="{{- options.id -}}"{% endif %}>
@@ -1527,7 +1527,7 @@ value  | string | The string or html markup to render inside the help block
         </span>
     {% endif %}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1563,7 +1563,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro hidden(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
     {{
@@ -1576,7 +1576,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
         )
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1628,12 +1628,12 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro password(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
 
     {{ form.text(options|defaults({'type': 'password'})) }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1681,7 +1681,7 @@ data-*     | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro radio(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -1706,7 +1706,7 @@ data-*     | string | Data attributes, eg: `'data-foo': 'bar'`
         })
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1755,7 +1755,7 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro radio_inline(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -1809,7 +1809,7 @@ data-*          | string | Data attributes, eg: `'data-foo': 'bar'`
         })
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1864,7 +1864,7 @@ required | bool   | Visually indicates that the field must be completed
 
 #}
 {% macro radio_simple(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
     {{
@@ -1883,7 +1883,7 @@ required | bool   | Visually indicates that the field must be completed
         )
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1934,7 +1934,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro range(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
 
     {{ form.text(options
@@ -1942,7 +1942,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
         |defaults({'type': 'range', 'class': 'form-range'}))
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1997,7 +1997,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro select(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -2016,7 +2016,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
         })
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -2073,7 +2073,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro select2(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -2090,7 +2090,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
         })
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -2128,7 +2128,7 @@ data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro submit(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 
     {{
@@ -2138,7 +2138,7 @@ data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
         }))
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -2193,7 +2193,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro text(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -2212,7 +2212,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
         })
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -2266,7 +2266,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro textarea(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -2284,7 +2284,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
         })
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -2334,7 +2334,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro time(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
 
     {%
@@ -2345,7 +2345,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
     %}
 
     {{ form.text(options) }}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -2393,7 +2393,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro toggle_switch(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as form %}
     {% import '@pulsar/pulsar/v2/helpers/elem.html.twig' as elem %}
 
@@ -2421,7 +2421,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
         })
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 {# -----------------------------------------------------------------------------
@@ -2477,7 +2477,7 @@ actions-column-text     | string | The text content of the actions column header
 {% import _self as form %}
 {% set headingLength = options.headings|length %}
 {% set values = options.values|default([]) %}
-{% spaceless %}
+{% apply spaceless %}
     <div
         class="repeater"
         data-repeater
@@ -2518,12 +2518,12 @@ actions-column-text     | string | The text content of the actions column header
                         <td class="table__form" colspan="{{ headingLength + 1 }}">
                             <div data-repeater-new-group-controls>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 {% macro repeater_end() %}
 {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
-{% spaceless %}
+{% apply spaceless %}
                             </div>
                             <div class="form__actions repeater__group-actions">
                                 {{
@@ -2559,7 +2559,7 @@ actions-column-text     | string | The text content of the actions column header
             </div>
         </div>
     </div>
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -2599,7 +2599,7 @@ errors                  | Array  | An array of error objects. Label should match
 
 #}
 {% macro error_summary(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if options.errors is defined and options.errors is not empty %}
     <section{{
         attributes(options
@@ -2624,5 +2624,5 @@ errors                  | Array  | An array of error objects. Label should match
         </ul>
     </section>
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}

--- a/views/pulsar/v2/helpers/html.html.twig
+++ b/views/pulsar/v2/helpers/html.html.twig
@@ -47,7 +47,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro actions_menu(items) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 
     {% set actions = [] %}
@@ -99,7 +99,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
         })
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -128,7 +128,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro badge(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     <span{{
@@ -142,7 +142,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
         {{- options.label|default|raw -}}
     </span>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -193,7 +193,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro block_list(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as html %}
 
     {% set mainTag = 'ul' %}
@@ -242,7 +242,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
     {% endif %}
     </{{ mainTag }}>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -275,7 +275,7 @@ data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro button(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -328,7 +328,7 @@ data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
         </button>
 
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -364,7 +364,7 @@ data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro button_group(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     <div{{
@@ -380,7 +380,7 @@ data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
         {% endfor %}
     </div>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -430,7 +430,7 @@ placement    | string | the alignment of the dropdown menu, `left` (default) or 
 
 #}
 {% macro button_dropdown(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -469,7 +469,7 @@ placement    | string | the alignment of the dropdown menu, `left` (default) or 
         }}
     </div>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -506,7 +506,7 @@ data-*     | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro countdown(options) %}
-{% spaceless %}
+{% apply spaceless %}
 
     {%
         set options = options|default({})|merge({
@@ -526,7 +526,7 @@ data-*     | string | Data attributes, eg: `'data-foo': 'bar'`
         {{- options.label|default|raw -}}
     </span>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -557,13 +557,13 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro div(options) %}
-{% spaceless %}
+{% apply spaceless %}
 
     <div{{ attributes(options|exclude('value')) }}>
         {{- options.value|raw -}}
     </div>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -581,9 +581,9 @@ Used in html.dropdown to insert lines between items.
 
 #}
 {% macro divider() %}
-{% spaceless %}
+{% apply spaceless %}
     <span class="divider"></span>
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -617,7 +617,7 @@ data-*    | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro edit_button(options) %}
-    {% spaceless %}
+    {% apply spaceless %}
         {% import _self as html %}
         {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -637,7 +637,7 @@ data-*    | string | Data attributes, eg: `'data-foo': 'bar'`
             )
         }}
 
-    {% endspaceless %}
+    {% endapply %}
 {% endmacro %}
 
 {# -----------------------------------------------------------------------------
@@ -666,7 +666,7 @@ class  | string | CSS classes, space separated
 
 #}
 {% macro icon(icon_name, options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     {% set mime_types = {
@@ -719,7 +719,7 @@ class  | string | CSS classes, space separated
         )
     }}>{{ label|default|raw }}</i>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -751,7 +751,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro label(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -786,7 +786,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
             }}
         {% endif %}
     </span>
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -865,7 +865,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro list(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
     {% set list_type = options.type|default('ul') %}
@@ -891,7 +891,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
     </{{ list_type }}>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -928,7 +928,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro link_list(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
     {% set items = [] %}
@@ -955,7 +955,7 @@ data-*      | string | Data attributes, eg: `'data-foo': 'bar'`
         })
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -986,14 +986,14 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro li(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     <li{{ attributes(options|exclude('value')) }}>
         {{- options.value|raw -}}
     </li>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1025,7 +1025,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro loading(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     {% set type = 'inline' %}
@@ -1056,7 +1056,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
     </div>
     {% endif %}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1101,7 +1101,7 @@ data-*      | string    | Data attributes, eg: `'data-foo': 'bar'`
 #}
 {% macro media(options) %}
 {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
-{% spaceless %}
+{% apply spaceless %}
 
     {% set type = 'div' %}
     {% if options.type is defined and options.type == 'link' %}
@@ -1134,7 +1134,7 @@ data-*      | string    | Data attributes, eg: `'data-foo': 'bar'`
         </div>
     </{{ type }}>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1170,7 +1170,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro metadata(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     <dl{{
@@ -1189,7 +1189,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
     {% endfor %}
     </dl>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1225,7 +1225,7 @@ data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro panel(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -1274,7 +1274,7 @@ data-*  | string | Data attributes, eg: `'data-foo': 'bar'`
         {% endif %}
     </{{ tag }}>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1308,7 +1308,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
 
 #}
 {% macro progress(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
     <div class="progress">
@@ -1338,7 +1338,7 @@ data-*        | string | Data attributes, eg: `'data-foo': 'bar'`
         </div>
     </div>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1373,7 +1373,7 @@ label     | string | SR friendly hidden label
 
 #}
 {% macro remove_button(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -1399,7 +1399,7 @@ label     | string | SR friendly hidden label
         )
     }}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1447,7 +1447,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 #}
 {% macro status(state, options) %}
 {% import _self as html %}
-{% spaceless %}
+{% apply spaceless %}
 
 {% if options.title is not defined %}
     {% set options = options|default({})|merge({ 'title': state|default('active') }) %}
@@ -1492,7 +1492,7 @@ data-* | string | Data attributes, eg: `'data-foo': 'bar'`
 
 {% endif %}
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
@@ -1527,7 +1527,7 @@ data-dropzone-file-node-type        | boolean   | Show file type in file html | 
     {% set files = options['data-dropzone-max-files'] is defined ? options['data-dropzone-max-files'] : '5' %}
     {% set state = options['data-dropzone-passive']|default('false') == 'true' ? 'passive' : 'idle' %}
     {% set idle = options['data-dropzone-idle-html']|default('your files here or <button class="dropzone__browse btn" aria-label="Browse files to upload">Browse Files</button>') %}
-    {% spaceless %}
+    {% apply spaceless %}
         <div{{ attributes(options|defaults(
             {
                 'class': 'dropzone dropzone--' ~ state ~ ' dropzone--files-' ~ files
@@ -1547,7 +1547,7 @@ data-dropzone-file-node-type        | boolean   | Show file type in file html | 
                 {{ options['data-helper-content']|default('Helper content')|raw }}
             </p>
         </div>
-    {% endspaceless %}
+    {% endapply %}
 {% endmacro %}
 
 {# -----------------------------------------------------------------------------

--- a/views/pulsar/v2/helpers/nav.html.twig
+++ b/views/pulsar/v2/helpers/nav.html.twig
@@ -1,5 +1,5 @@
 {% macro primary(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as nav %}
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
 
@@ -108,12 +108,12 @@
     </div>
 </nav>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro nav_item(options, heading_id, aria_controls) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
     {% import '@pulsar/pulsar/v2/helpers/util.html.twig' as util %}
 
@@ -147,11 +147,11 @@
         </{{ tag }}>
     </li>
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 {%- macro breadcrumbs(items) -%}
-    {% spaceless %}
+    {% apply spaceless %}
     {% import '@pulsar/pulsar/v2/helpers/html.html.twig' as html %}
     <nav class="breadcrumb" aria-label="breadcrumbs">
     {%- if items is defined and items is not empty %}
@@ -172,7 +172,7 @@
         </ol>
     {%- endif -%}
     </nav>
-    {% endspaceless %}
+    {% endapply %}
 {%- endmacro -%}
 
 

--- a/views/pulsar/v2/helpers/rules.html.twig
+++ b/views/pulsar/v2/helpers/rules.html.twig
@@ -1,5 +1,5 @@
 {% macro block_when(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as rule %}
 
     {% if options['show_and'] is not defined or options['show_and'] != false %}
@@ -16,11 +16,11 @@
             })
         )
     }}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 {% macro block_and(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as rule %}
 
     {% if options['show_and'] is not defined or options['show_and'] != false %}
@@ -37,11 +37,11 @@
             })
         )
     }}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 {% macro block_or(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as rule %}
 
     {% if options['show_and'] is not defined or options['show_and'] != false %}
@@ -58,11 +58,11 @@
             })
         )
     }}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 {% macro block_then(options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% import _self as rule %}
 
     {% if options['show_and'] is not defined or options['show_and'] != false %}
@@ -79,13 +79,13 @@
             })
         )
     }}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro block(options) %}
 {% import '@pulsar/pulsar/v2/helpers/form.html.twig' as form %}
-{% spaceless %}
+{% apply spaceless %}
 
     {% set ruleClass = 'rules__step' %}
 
@@ -143,5 +143,5 @@
             {% endif %}
         </div>
     </fieldset>
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}

--- a/views/pulsar/v2/helpers/util.html.twig
+++ b/views/pulsar/v2/helpers/util.html.twig
@@ -1,23 +1,23 @@
 {% macro addon(value) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if value is not empty %}
     {{- value -}}
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro caret(visible) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if visible is defined and visible != 0 and visible != null %}
         &nbsp;<span class="caret"></span>
     {% endif  %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro class(default, options) %}
-{% spaceless %}
+{% apply spaceless %}
     {% set classes = [] %}
 
     {%
@@ -31,52 +31,52 @@
 
     class="{{ classes|join(' ')|trim }}"
 
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro checked(value) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if value is not empty %}
         checked="{{ value }}"
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro data(attributes) %}
-{% spaceless %}
-    {% for key, value in attributes if value is not empty %}
+{% apply spaceless %}
+    {% for key, value in attributes | filter(value => value is not empty) %}
         {% if key == 'checked' %}
             checked
         {% else %}
             data-{{ key }}="{{ value }}"
         {% endif %}
     {% endfor %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro for(value) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if value is not empty %}
         for="{{ value }}"
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro form(value) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if value is not empty %}
         form="{{ value }}"
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro href(value) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if value is null %}
         {% set href = '#missing-href-attribute' %}
     {% else %}
@@ -84,75 +84,75 @@
     {% endif %}
 
     href="{{ href }}"
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro id(value) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if value is not empty %}
         id="{{ value }}"
     {% endif  %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro label(value) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if value is not empty %}
         label="{{ value }}"
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro multiple(value) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if value is not empty %}
         multiple="{{ value }}"
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro name(value) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if value is not empty %}
         name="{{ value }}"
     {% endif  %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro placeholder(value) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if value is not empty %}
         placeholder="{{ value }}"
     {% endif  %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro required(required) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if required %}
         &nbsp;<span aria-hidden="true" class="required-indicator" data-tippy-content="required">*</span>
     {% endif  %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro type(value) %}
-{% spaceless %}
+{% apply spaceless %}
     {% if value is not empty %}
         type="{{ value }}"
     {% endif  %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 
 {% macro value(value) %}
-{% spaceless %}
+{% apply spaceless %}
     value="{{ value|default }}"
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}


### PR DESCRIPTION
## Summary
Upgrade the `twig/twig` dependency from `^2.0` to `^3.27` to support 
security vulnerability fixes in dependent packages.

## Background
`jadu/quantum-control-centre` has 16 outstanding security vulnerabilities, 
10 of which affect `twig/twig`. The most critical is CVE-2026-46633 
(PHP code injection via `{% use %}` template name, rated critical).

Upgrading `quantum-control-centre` to a patched version of Twig requires 
all dependent packages to support Twig 3, including `jadu/pulsar`.

## Changes
- Updated `twig/twig` constraint from `^2.0` to `^3.27`
- Updated Twig extension classes for Twig 3.x compatibility
- Updated template files for Twig 3.x compatibility
- Updated tests

Closes #1643